### PR TITLE
feat: add context argument to getPaymasterCallData()

### DIFF
--- a/src/paymaster/CandideValidationPaymaster.ts
+++ b/src/paymaster/CandideValidationPaymaster.ts
@@ -68,15 +68,16 @@ export class CandideValidationPaymaster extends Paymaster {
 	async getPaymasterCallData(
 		userOperation: UserOperation,
 		config: string[],
+		context: object = {},
 	): Promise<PmSponsorUserOperationResult | JsonRpcError> {
-		const rpcUrl = config[0];
-		const entrypointAddress = config[1];
+		const rpcUrl = config[0] || this.rpcUrl;
+		const entrypointAddress = config[1] || this.entrypointAddress;
 		const tokenAddress = config[2];
 
 		const jsonRpcResult = await sendJsonRpcRequest(
 			rpcUrl,
 			"pm_sponsorUserOperation",
-			[userOperation, entrypointAddress, { token: tokenAddress }],
+			[userOperation, entrypointAddress, { token: tokenAddress, ...context }],
 		);
 
 		if ("result" in jsonRpcResult) {


### PR DESCRIPTION
Some paymasters require additional context. In order to make this library paymaster-agnostic this PR suggests an additional argument to the `getPaymasterCallData()` function, enabling calls with arbitrary arguments while not breaking the current features and function signatures.

I tested this with Stackup paymaster.