### PR TITLE
fix: export getSafeMessageEip712Data in public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,17 @@
 	"module": "dist/index.m.js",
 	"unpkg": "dist/index.umd.js",
 	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.m.js",
+			"default": "./dist/index.js"
+		},
+		"./dist/account/Safe/safeMessage": {
+			"types": "./dist/abstractionkit.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
 	"scripts": {
 		"build": "rimraf dist && microbundle --tsconfig tsconfig.json --no-sourcemap",
 		"clean": "rimraf dist",

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -125,6 +125,12 @@ export {
     DEFAULT_SECP256R1_PRECOMPILE_ADDRESS
 } from "./constants";
 
-export * from "./account/Safe/safeMessage";
+export {
+	SAFE_MESSAGE_PRIMARY_TYPE,
+	SAFE_MESSAGE_MODULE_TYPE,
+	type SafeMessageTypedDataDomain,
+	type SafeMessageTypedMessageValue,
+	getSafeMessageEip712Data,
+} from "./account/Safe/safeMessage";
 
 export { AbstractionKitError } from "./errors";


### PR DESCRIPTION
## Summary
- Export `getSafeMessageEip712Data` and related types explicitly in the public API instead of using `export *`
- Add `exports` field to package.json to support deep import paths (fixes webpack/Next.js production build failure)
- The function was already bundled but not properly exposed through the type declarations

## Changes
1. `src/abstractionkit.ts`: Changed to explicit named exports for safeMessage module
2. `package.json`: Added exports field to map deep import paths to main bundle