### PR TITLE
fix: expose DEFAULT_DELEGATEE_ADDRESS as static property

### DIFF
--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -697,6 +697,8 @@ export class BaseSimple7702Account extends SmartAccount {
  * {@link UserOperationV8} and sensible defaults for the delegatee address.
  */
 export class Simple7702Account extends BaseSimple7702Account {
+	static readonly DEFAULT_DELEGATEE_ADDRESS = "0xe6Cae83BdE06E4c305530e199D7217f42808555B";
+
 	/**
 	 * @param accountAddress - The EOA address that will be delegated via EIP-7702
 	 * @param overrides - Optional overrides for entrypoint and delegatee addresses
@@ -713,7 +715,7 @@ export class Simple7702Account extends BaseSimple7702Account {
 		super(
             accountAddress,
             overrides.entrypointAddress ?? ENTRYPOINT_V8,
-            overrides.delegateeAddress ?? "0xe6Cae83BdE06E4c305530e199D7217f42808555B"
+            overrides.delegateeAddress ?? Simple7702Account.DEFAULT_DELEGATEE_ADDRESS
         );
 	}
 

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -10,6 +10,8 @@ import { SendUseroperationResponse } from "../SendUseroperationResponse";
  * {@link UserOperationV9} and sensible defaults for the delegatee address.
  */
 export class Simple7702AccountV09 extends BaseSimple7702Account {
+	static readonly DEFAULT_DELEGATEE_ADDRESS = "0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5";
+
 	/**
 	 * @param accountAddress - The EOA address that will be delegated via EIP-7702
 	 * @param overrides - Optional overrides for entrypoint and delegatee addresses
@@ -26,7 +28,7 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 		super(
             accountAddress,
             overrides.entrypointAddress ?? ENTRYPOINT_V9,
-            overrides.delegateeAddress ?? "0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5"
+            overrides.delegateeAddress ?? Simple7702AccountV09.DEFAULT_DELEGATEE_ADDRESS
         );
 	}
 


### PR DESCRIPTION
Extract hardcoded delegatee addresses into static readonly properties on Simple7702Account and Simple7702AccountV09 so they are accessible via the public API.