### PR TITLE
fix: handle fractional percentage multipliers in applyMultiplier

### DIFF
--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -452,7 +452,7 @@ export class CandidePaymaster extends Paymaster {
 		}
 
 		const applyMultiplier = (value: bigint, multiplier?: number): bigint =>
-			value + (value * BigInt(multiplier ?? 0)) / 100n;
+			value + (value * BigInt(Math.round((multiplier ?? 0) * 100))) / 10000n;
 
 		userOp.preVerificationGas = overrides.preVerificationGas
 			?? applyMultiplier(preVerificationGas, overrides.preVerificationGasPercentageMultiplier ?? 5);


### PR DESCRIPTION
- Fix `applyMultiplier` in `CandidePaymaster.ts` to support fractional percentage multipliers
- `BigInt(1.5)` throws a `TypeError` at runtime — this scales the multiplier by 100 before conversion to preserve
fractional precision (e.g., `1.5` correctly applies a 1.5% increase)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in gas limit calculations to provide more accurate transaction fee estimations with refined multiplier rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->