### PR TITLE
Remove isomorphic-unfetch, use native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 		"access": "public",
 		"tag": "latest"
 	},
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"ethers": "^6.13.2"
 	},

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
 		"tag": "latest"
 	},
 	"dependencies": {
-		"ethers": "^6.13.2",
-		"isomorphic-unfetch": "^3.1.0"
+		"ethers": "^6.13.2"
 	},
 	"devDependencies": {
 		"dotenv": "^16.4.5",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import * as fetchImport from "isomorphic-unfetch";
-
 import { id, AbiCoder, keccak256, JsonRpcProvider, solidityPacked, getAddress } from "ethers";
 
 import {
@@ -388,7 +386,6 @@ export async function sendJsonRpcRequest(
     headers: Record<string, string> = { "Content-Type": "application/json" },
     paramsKeyName: string = "params",
 ): Promise<JsonRpcResult> {
-	const fetch = fetchImport.default || fetchImport;
 	const raw = JSON.stringify(
 		{
 			method: method,

--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -1,5 +1,3 @@
-import * as fetchImport from "isomorphic-unfetch";
-
 import { AbiCoder } from "ethers";
 
 import {
@@ -52,7 +50,6 @@ export async function shareTenderlySimulationAndCreateLink(
         'X-Access-Key': tenderlyAccessKey
     };
     
-    const fetch = fetchImport.default || fetchImport;
 	const requestOptions: RequestInit = {
 		method: "POST",
 		headers, 

--- a/test/calibur/calibur7702Account.test.js
+++ b/test/calibur/calibur7702Account.test.js
@@ -1,8 +1,3 @@
-// Mock isomorphic-unfetch: default to real implementation, override in specific tests
-const realFetch = jest.requireActual('isomorphic-unfetch');
-const mockFetch = jest.fn((...args) => realFetch(...args));
-jest.mock('isomorphic-unfetch', () => mockFetch);
-
 const ak = require('../../dist/index.umd');
 const { AbiCoder, keccak256, Wallet } = require('ethers');
 require('dotenv').config();
@@ -885,8 +880,10 @@ describe('Calibur7702Account', () => {
 
     // ─── getDelegatedAddress parsing ─────────────────────────────────────
 
+    const originalFetch = global.fetch;
+
     function mockFetchWithCode(code) {
-        mockFetch.mockImplementationOnce(() =>
+        global.fetch = jest.fn(() =>
             Promise.resolve({
                 json: async () => ({ jsonrpc: '2.0', id: 1, result: code }),
             })
@@ -894,8 +891,7 @@ describe('Calibur7702Account', () => {
     }
 
     afterEach(() => {
-        mockFetch.mockReset();
-        mockFetch.mockImplementation((...args) => realFetch(...args));
+        global.fetch = originalFetch;
     });
 
     test('getDelegatedAddress returns address for valid EIP-7702 delegation code', async () => {


### PR DESCRIPTION
## Summary

- Removes `isomorphic-unfetch` from production dependencies — native `fetch` is available in Node 18+ and all modern browsers
- Eliminates an unmaintained dependency (last commit Jan 2023, last npm release Jan 2023, no security contact)
- Reduces production dependency count from 2 to 1 (only `ethers` remains)

## Changes

- `src/utils.ts`: Remove import and local fetch alias in `sendJsonRpcRequest()`
- `src/utilsTenderly.ts`: Remove import and local fetch alias in `shareTenderlySimulationAndCreateLink()`
- `package.json`: Remove `isomorphic-unfetch` from dependencies
- `test/calibur/calibur7702Account.test.js`: Replace `jest.mock('isomorphic-unfetch')` with `global.fetch` override

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (74/74 — `caliburEncoding.test.js` + `calibur7702Account.test.js`)
- [x] Live bundler example: direct RPC calls (`chainId`, `supportedEntryPoints`)
- [x] Live sponsor-gas example: full UserOp lifecycle — account deployed, NFT minted on Sepolia
- [x] Live passkeys example: WebAuthn + paymaster + NFT minted on Sepolia
- [x] Live batch-transactions example: 2 NFTs minted in single batched UserOp on Sepolia
- [x] Live EIP-7702 Simple example: EOA upgraded + 2 NFTs minted on Sepolia (EntryPoint v0.8)
- [x] Live EIP-7702 Calibur example: `isDelegated` + gas estimation RPC calls succeed (EntryPoint v0.8)
- [x] Live pay-gas-in-erc20 example: token metadata fetch + gas estimation succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `isomorphic-unfetch` from dependencies to reduce external dependency footprint.
  * Updated fetch implementation to rely on globally available fetch instead of a bundled library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->