### PR TITLE
feat: token paymaster option to reset allowance

### DIFF
--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -446,13 +446,13 @@ export class SafeAccount extends SmartAccount {
 			//multisend
 			const decodedCalldata = decodeMultiSendCallData(metaTransaction.data);
 			multiSendCallDataParams =
-				decodedCalldata + encodedApproveMetatransaction.slice(2);
+				encodedApproveMetatransaction + decodedCalldata.slice(2);
 		} else {
 			const encodedCallDataMetaTransaction = encodeMultiSendCallData([
 				metaTransaction,
 			]);
 			multiSendCallDataParams =
-				encodedCallDataMetaTransaction + encodedApproveMetatransaction.slice(2);
+				encodedApproveMetatransaction + encodedCallDataMetaTransaction.slice(2);
 		}
 		const multiSendCallData = createCallData(
 			mutisendSelector,

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -33,6 +33,19 @@ const UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457
 const TOKEN_APPROVE_AMOUNT_MULTIPLIER = 2n;
 
 /**
+ * ERC-20 tokens that require resetting their allowance to 0 before setting a
+ * new approval amount (e.g. USDT on mainnet).
+ * Addresses are stored lowercase for case-insensitive comparison.
+ *
+ * If you encounter a token with this behavior that is not listed here,
+ * please open an issue at https://github.com/candidelabs/abstractionkit/issues
+ * or use the `resetApproval` override as a workaround.
+ */
+const TOKENS_REQUIRING_ALLOWANCE_RESET: string[] = [
+	"0xdac17f958d2ee523a2206206994597c13d831ec7", // USDT (Ethereum mainnet)
+];
+
+/**
  * Client for the Candide Paymaster service.
  * Supports both gas sponsorship (sponsor paymaster) and ERC-20 token payment for gas (token paymaster).
  * Auto-initializes on first use by fetching supported tokens and metadata from the paymaster RPC.
@@ -593,12 +606,24 @@ export class CandidePaymaster extends Paymaster {
 			this.setDummyPaymasterFields(userOperation, epData);
 			// Prepend an infinite approval and re-estimate UserOperation gas limits (a later rational allowance will be calculated and replace the infinite one)
 			const oldCallData = userOperation.callData;
+			const requiresAllowanceReset = overrides?.resetApproval
+				?? TOKENS_REQUIRING_ALLOWANCE_RESET.includes(
+					tokenAddress.toLowerCase(),
+				);
 			let callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
 				userOperation.callData,
 				tokenAddress,
 				epData.paymasterMetadata.address,
 				UINT256_MAX,
 			);
+			if (requiresAllowanceReset) {
+				callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+					callDataWithApprove,
+					tokenAddress,
+					epData.paymasterMetadata.address,
+					0n,
+				);
+			}
 			userOperation.callData = callDataWithApprove;
 
 			await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
@@ -614,6 +639,14 @@ export class CandidePaymaster extends Paymaster {
 				epData.paymasterMetadata.address,
 				approveAmount,
 			);
+			if (requiresAllowanceReset) {
+				callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+					callDataWithApprove,
+					tokenAddress,
+					epData.paymasterMetadata.address,
+					0n,
+				);
+			}
 			userOperation.callData = callDataWithApprove;
 
 			const _overrides = { ...(overrides || {}),

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -53,6 +53,8 @@ export interface PrependTokenPaymasterApproveAccount {
 export interface BasePaymasterUserOperationOverrides {
 	/** set the entrypoint address intead of determining it from the useroperation structure.*/
 	entrypoint?: string;
+	/** When true, prepend an approve(0) call before the actual token approval. Required for tokens like USDT that don't allow changing a non-zero allowance directly. */
+	resetApproval?: boolean;
 }
 
 /**


### PR DESCRIPTION
- Fix token approval order in `SafeAccount.prependTokenPaymasterApproveToCallDataStatic`, the approve call was
  appended after existing transactions instead of prepended.
- Add support for tokens that require resetting allowance to 0 before setting a new value (e.g. USDT on mainnet). A
  built-in `TOKENS_REQUIRING_ALLOWANCE_RESET` list handles known tokens automatically, and a `resetApproval` override in
   `BasePaymasterUserOperationOverrides` allows manual control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added token allowance reset option for ERC-20 token approvals, enabling users to configure approval handling for compatible tokens.

* **Improvements**
  * Optimized paymaster transaction data composition order for enhanced multi-transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->