### PR TITLE
feat: add support for paymaster parallel signing

### DIFF
--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -781,15 +781,21 @@ export class SafeAccount extends SmartAccount {
 					.slice(34);
 			}
 			if (useroperation.paymasterData != null) {
-                const PAYMASTER_SIG_MAGIC = '22e325a297439656';
-                if(
-                    overrides.is_v9 &&
-                    useroperation.paymasterData.endsWith(PAYMASTER_SIG_MAGIC)
-                ){
-                    paymasterAndData += PAYMASTER_SIG_MAGIC;
-                }else{
-				    paymasterAndData += useroperation.paymasterData.slice(2);
-                }
+	      const PAYMASTER_SIG_MAGIC = '22e325a297439656';
+	      if(
+	          overrides.is_v9 &&
+	          useroperation.paymasterData.endsWith(PAYMASTER_SIG_MAGIC)
+	      ){
+	          const sigLenHex = useroperation.paymasterData.slice(
+	            useroperation.paymasterData.length - 16 - 4,
+	            useroperation.paymasterData.length - 16
+	          );
+	          const sigLen = parseInt(sigLenHex, 16);
+	          const prefixEnd = useroperation.paymasterData.length - 16 - 4 - sigLen * 2;
+	          paymasterAndData += useroperation.paymasterData.slice(0, prefixEnd).replaceAll("0x", "") + PAYMASTER_SIG_MAGIC;
+	      }else{
+	        paymasterAndData += useroperation.paymasterData.slice(2);
+	      }
 			}
 		}
 		const messageValue: SafeUserOperationV7TypedMessageValue = {

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1708,10 +1708,10 @@ export class SafeAccount extends SmartAccount {
                     const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
                     if(parallelPaymasterInitValues != null){
                         if(
-                            parallelPaymasterInitValues.paymasterData != "0x22e325a297439656"
+                            !parallelPaymasterInitValues.paymasterData.endsWith("22e325a297439656")
                         ){
                             throw new RangeError(
-                                "Invalid paymasterData override, the only valid value is 0x22e325a297439656."
+                                "Invalid paymasterData override, it must end with the PAYMASTER_SIG_MAGIC '22e325a297439656'."
                             );
                         }
                         if(this.entrypointAddress != ENTRYPOINT_V9){

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -784,7 +784,7 @@ export class SafeAccount extends SmartAccount {
 	      const PAYMASTER_SIG_MAGIC = '22e325a297439656';
 	      if(
 	          overrides.is_v9 &&
-	          useroperation.paymasterData.endsWith(PAYMASTER_SIG_MAGIC)
+	          useroperation.paymasterData.toLowerCase().endsWith(PAYMASTER_SIG_MAGIC)
 	      ){
 	          const sigLenHex = useroperation.paymasterData.slice(
 	            useroperation.paymasterData.length - 16 - 4,

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -332,12 +332,12 @@ export class ExperimentalSafeMultiChainSigAccount extends SafeAccount {
 	): Promise<UserOperationV9> {
 		const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
 		if(
-            parallelPaymasterInitValues != null &&
-            parallelPaymasterInitValues.paymasterData != "0x22e325a297439656"
-        ){
-            throw new RangeError(
-                "Invalid paymasterData override, the only valid value is 0x22e325a297439656."
-            );
+      parallelPaymasterInitValues != null &&
+			!parallelPaymasterInitValues.paymasterData.endsWith("22e325a297439656")
+    ){
+      throw new RangeError(
+          "Invalid paymasterData override, it must end with the PAYMASTER_SIG_MAGIC '22e325a297439656'"
+      );
 		}		
         const [userOperation, factoryAddress, factoryData] =
 			await this.createBaseUserOperationAndFactoryAddressAndFactoryData(

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -333,7 +333,7 @@ export class ExperimentalSafeMultiChainSigAccount extends SafeAccount {
 		const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
 		if(
       parallelPaymasterInitValues != null &&
-			!parallelPaymasterInitValues.paymasterData.endsWith("22e325a297439656")
+			!parallelPaymasterInitValues.paymasterData.toLowerCase().endsWith("22e325a297439656")
     ){
       throw new RangeError(
           "Invalid paymasterData override, it must end with the PAYMASTER_SIG_MAGIC '22e325a297439656'"

--- a/src/paymaster/AllowAllPaymaster.ts
+++ b/src/paymaster/AllowAllPaymaster.ts
@@ -36,7 +36,7 @@ export class ExperimentalAllowAllParallelPaymaster extends Paymaster {
             paymaster: this.address,
             paymasterVerificationGasLimit: 45_000n,
             paymasterPostOpGasLimit: 45_000n,
-            paymasterData:"0x22e325a297439656" // PAYMASTER_SIG_MAGIC
+            paymasterData:"0x010101010101010101010101010101010101010101010101010101010101011c"+"0020"+"22e325a297439656" // DUMMY SIG + PAYMASTER_SIG_LEN + PAYMASTER_SIG_MAGIC
         };
     }
 

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -538,19 +538,24 @@ export class CandidePaymaster extends Paymaster {
 	/**
 	 * Create a gas-sponsored UserOperation (no token payment required).
 	 *
+	 * @param smartAccount - The smart account instance
 	 * @param userOperation - The UserOperation to sponsor
 	 * @param bundlerRpc - Bundler RPC URL for gas estimation
 	 * @param sponsorshipPolicyId - Optional sponsorship policy ID
 	 * @param overrides - Override entrypoint address
+	 * @param context - Optional additional context to pass to the paymaster RPC
 	 * @returns A tuple of [UserOperation, SponsorMetadata | undefined]
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if sponsorship fails
 	 */
 	async createSponsorPaymasterUserOperation<T extends AnyUserOperation>(
+		smartAccount: PrependTokenPaymasterApproveAccount,
 		userOperation: T,
 		bundlerRpc: string,
 		sponsorshipPolicyId?: string,
+		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
+		context = {sponsorshipPolicyId, ...(context || {}) };
 		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(userOperation);
 		await this.ensureInitialized(entrypoint);
 		const epData = this.getEntrypointData(entrypoint);
@@ -559,11 +564,9 @@ export class CandidePaymaster extends Paymaster {
 				`UserOperation for entrypoint ${entrypoint} is not supported`,
 			);
 		}
-		this.setDummyPaymasterFields(userOperation, epData);
-		await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
-		const context: CandidePaymasterContext = {};
-		if (sponsorshipPolicyId && sponsorshipPolicyId.trim().length > 0) {
-			context["sponsorshipPolicyId"] = sponsorshipPolicyId;
+		if (context.signingPhase !== "finalize"){
+			this.setDummyPaymasterFields(userOperation, epData);
+			await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
 		}
 		const _overrides = { ...(overrides || {}),
 			entrypoint: entrypoint,
@@ -584,6 +587,7 @@ export class CandidePaymaster extends Paymaster {
 	 * @param tokenAddress - The ERC-20 token contract address to pay gas with
 	 * @param bundlerRpc - Bundler RPC URL for gas estimation
 	 * @param overrides - Override gas limits and multipliers
+	 * @param context - Optional additional context to pass to the paymaster RPC
 	 * @returns The UserOperation with token approval prepended and paymaster fields set
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if the token is not supported
 	 */
@@ -592,69 +596,72 @@ export class CandidePaymaster extends Paymaster {
 		userOperation: T,
 		tokenAddress: string,
 		bundlerRpc: string,
+		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<SameUserOp<T>> {
 		try {
+			context = { token: tokenAddress, ...(context || {}) };
 			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(userOperation);
 			await this.ensureInitialized(entrypoint);
-			const epData = this.getEntrypointData(entrypoint);
-			if (epData == null) {
-				throw new RangeError(
-					`UserOperation for entrypoint ${entrypoint} is not supported`,
-				);
-			}
-			this.setDummyPaymasterFields(userOperation, epData);
-			// Prepend an infinite approval and re-estimate UserOperation gas limits (a later rational allowance will be calculated and replace the infinite one)
-			const oldCallData = userOperation.callData;
-			const requiresAllowanceReset = overrides?.resetApproval
-				?? TOKENS_REQUIRING_ALLOWANCE_RESET.includes(
-					tokenAddress.toLowerCase(),
-				);
-			let callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
-				userOperation.callData,
-				tokenAddress,
-				epData.paymasterMetadata.address,
-				UINT256_MAX,
-			);
-			if (requiresAllowanceReset) {
-				callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
-					callDataWithApprove,
-					tokenAddress,
+			if (context.signingPhase !== "finalize"){
+				const epData = this.getEntrypointData(entrypoint);
+				if (epData == null) {
+					throw new RangeError(
+						`UserOperation for entrypoint ${entrypoint} is not supported`,
+					);
+				}
+				this.setDummyPaymasterFields(userOperation, epData);
+				// Prepend an infinite approval and re-estimate UserOperation gas limits (a later rational allowance will be calculated and replace the infinite one)
+				const oldCallData = userOperation.callData;
+				const requiresAllowanceReset = overrides?.resetApproval
+					?? TOKENS_REQUIRING_ALLOWANCE_RESET.includes(
+						context.token!.toLowerCase(),
+					);
+				let callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+					userOperation.callData,
+					context.token!,
 					epData.paymasterMetadata.address,
-					0n,
+					UINT256_MAX,
 				);
-			}
-			userOperation.callData = callDataWithApprove;
+				if (requiresAllowanceReset) {
+					callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+						callDataWithApprove,
+						context.token!,
+						epData.paymasterMetadata.address,
+						0n,
+					);
+				}
+				userOperation.callData = callDataWithApprove;
 
-			await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
+				await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
 
-			const maxErc20Cost = await this.calculateUserOperationErc20TokenMaxGasCost(
-				userOperation,
-				tokenAddress,
-			);
-			const approveAmount = maxErc20Cost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
-			callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
-				oldCallData,
-				tokenAddress,
-				epData.paymasterMetadata.address,
-				approveAmount,
-			);
-			if (requiresAllowanceReset) {
+				const maxErc20Cost = await this.calculateUserOperationErc20TokenMaxGasCost(
+					userOperation,
+					context.token!,
+				);
+				const approveAmount = maxErc20Cost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
 				callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
-					callDataWithApprove,
-					tokenAddress,
+					oldCallData,
+					context.token!,
 					epData.paymasterMetadata.address,
-					0n,
+					approveAmount,
 				);
+				if (requiresAllowanceReset) {
+					callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+						callDataWithApprove,
+						context.token!,
+						epData.paymasterMetadata.address,
+						0n,
+					);
+				}
+				userOperation.callData = callDataWithApprove;
 			}
-			userOperation.callData = callDataWithApprove;
-
 			const _overrides = { ...(overrides || {}),
 				entrypoint: entrypoint,
 			};
 			const [resultUserOp] = await this.createPaymasterUserOperation(
 				userOperation,
-				{ token: tokenAddress },
+				context,
 				_overrides,
 			);
 			return resultUserOp;

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -136,14 +136,9 @@ export class CandidePaymaster extends Paymaster {
 		smartAccount: SmartAccountWithEntrypoint,
 		userOperation: AnyUserOperation,
 	): string {
-		// We do these equality checks instead of just returning smartAccount.entrypointAddress
-		// to handle cases where the account may be using a custom entrypoint address
-		// or if the EP address is not set in the account instance
-		const accountEPAddress = smartAccount.entrypointAddress.toString().toLowerCase();
-		if (accountEPAddress == ENTRYPOINT_V6.toLowerCase()) return ENTRYPOINT_V6;
-		if (accountEPAddress == ENTRYPOINT_V7.toLowerCase()) return ENTRYPOINT_V7;
-		if (accountEPAddress == ENTRYPOINT_V8.toLowerCase()) return ENTRYPOINT_V8;
-		if (accountEPAddress == ENTRYPOINT_V9.toLowerCase()) return ENTRYPOINT_V9;
+		if (smartAccount.entrypointAddress != null && smartAccount.entrypointAddress.trim() !== "") {
+			return smartAccount.entrypointAddress;
+		}
 		if ("initCode" in userOperation) return ENTRYPOINT_V6;
 		else if ("eip7702Auth" in userOperation) return ENTRYPOINT_V8;
 		else return ENTRYPOINT_V7;

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -1,9 +1,6 @@
 import { Paymaster } from "./Paymaster";
 import { calculateUserOperationMaxGasCost, sendJsonRpcRequest } from "../utils";
 import {
-	UserOperationV6,
-	UserOperationV7,
-	UserOperationV8,
 	SupportedERC20TokensAndMetadata,
 	SupportedERC20TokensAndMetadataWithExchangeRate,
 	PmUserOperationV8Result,
@@ -19,11 +16,11 @@ import {
 	PrependTokenPaymasterApproveAccount,
 	GasPaymasterUserOperationOverrides,
 	AnyUserOperation,
-	SameUserOp,
+	SameUserOp, SmartAccountWithEntrypoint,
 } from "./types";
 import { Bundler } from "src/Bundler";
 import { AbstractionKitError, ensureError } from "src/errors";
-import { ENTRYPOINT_V8, ENTRYPOINT_V7, ENTRYPOINT_V6 } from "src/constants";
+import {ENTRYPOINT_V8, ENTRYPOINT_V7, ENTRYPOINT_V6, ENTRYPOINT_V9} from "src/constants";
 
 /** Buffer added to verificationGasLimit for paymasterAndData verification overhead */
 const PAYMASTER_V06_VERIFICATION_OVERHEAD = 40000n;
@@ -136,15 +133,20 @@ export class CandidePaymaster extends Paymaster {
 	 * V6 ops have `initCode`, V8 ops have `eip7702Auth`, V7 is the default.
 	 */
 	private resolveEntrypoint(
+		smartAccount: SmartAccountWithEntrypoint,
 		userOperation: AnyUserOperation,
 	): string {
-		if ("initCode" in userOperation) {
-			return ENTRYPOINT_V6;
-		} else if ("eip7702Auth" in userOperation) {
-			return ENTRYPOINT_V8;
-		} else {
-			return ENTRYPOINT_V7;
-		}
+		// We do these equality checks instead of just returning smartAccount.entrypointAddress
+		// to handle cases where the account may be using a custom entrypoint address
+		// or if the EP address is not set in the account instance
+		const accountEPAddress = smartAccount.entrypointAddress.toString().toLowerCase();
+		if (accountEPAddress == ENTRYPOINT_V6.toLowerCase()) return ENTRYPOINT_V6;
+		if (accountEPAddress == ENTRYPOINT_V7.toLowerCase()) return ENTRYPOINT_V7;
+		if (accountEPAddress == ENTRYPOINT_V8.toLowerCase()) return ENTRYPOINT_V8;
+		if (accountEPAddress == ENTRYPOINT_V9.toLowerCase()) return ENTRYPOINT_V9;
+		if ("initCode" in userOperation) return ENTRYPOINT_V6;
+		else if ("eip7702Auth" in userOperation) return ENTRYPOINT_V8;
+		else return ENTRYPOINT_V7;
 	}
 
 	/**
@@ -506,13 +508,14 @@ export class CandidePaymaster extends Paymaster {
 	// ── Core paymaster method (private) ──────────────────────────────
 
 	private async createPaymasterUserOperation<T extends AnyUserOperation>(
+		smartAccount: SmartAccountWithEntrypoint,
 		userOperation: T,
 		context: CandidePaymasterContext = {},
 		overrides: GasPaymasterUserOperationOverrides = {},
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
 		const userOp = { ...userOperation };
 		try {
-			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(userOp);
+			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 			const chainId = await this.getChainId();
 			const jsonRpcResult = await sendJsonRpcRequest(
 				this.rpcUrl,
@@ -548,7 +551,7 @@ export class CandidePaymaster extends Paymaster {
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if sponsorship fails
 	 */
 	async createSponsorPaymasterUserOperation<T extends AnyUserOperation>(
-		smartAccount: PrependTokenPaymasterApproveAccount,
+		smartAccount: SmartAccountWithEntrypoint,
 		userOperation: T,
 		bundlerRpc: string,
 		sponsorshipPolicyId?: string,
@@ -556,7 +559,7 @@ export class CandidePaymaster extends Paymaster {
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
 		context = {sponsorshipPolicyId, ...(context || {}) };
-		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(userOperation);
+		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
 		await this.ensureInitialized(entrypoint);
 		const epData = this.getEntrypointData(entrypoint);
 		if (epData == null) {
@@ -572,6 +575,7 @@ export class CandidePaymaster extends Paymaster {
 			entrypoint: entrypoint,
 		};
 		return await this.createPaymasterUserOperation(
+			smartAccount,
 			userOperation,
 			context,
 			_overrides,
@@ -601,7 +605,7 @@ export class CandidePaymaster extends Paymaster {
 	): Promise<SameUserOp<T>> {
 		try {
 			context = { token: tokenAddress, ...(context || {}) };
-			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(userOperation);
+			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
 			await this.ensureInitialized(entrypoint);
 			if (context.signingPhase !== "finalize"){
 				const epData = this.getEntrypointData(entrypoint);
@@ -636,6 +640,7 @@ export class CandidePaymaster extends Paymaster {
 				await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
 
 				const maxErc20Cost = await this.calculateUserOperationErc20TokenMaxGasCost(
+					smartAccount,
 					userOperation,
 					context.token!,
 				);
@@ -660,6 +665,7 @@ export class CandidePaymaster extends Paymaster {
 				entrypoint: entrypoint,
 			};
 			const [resultUserOp] = await this.createPaymasterUserOperation(
+				smartAccount,
 				userOperation,
 				context,
 				_overrides,
@@ -682,6 +688,7 @@ export class CandidePaymaster extends Paymaster {
 	 * Calculate the maximum ERC-20 token cost for a UserOperation's gas.
 	 * Uses the token's exchange rate from the paymaster to convert from wei.
 	 *
+	 * @param smartAccount - The smart account instance
 	 * @param userOperation - The UserOperation to calculate the cost for
 	 * @param erc20TokenAddress - The ERC-20 token contract address
 	 * @param overrides - Optional entrypoint override
@@ -689,12 +696,13 @@ export class CandidePaymaster extends Paymaster {
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if the token is not supported
 	 */
 	async calculateUserOperationErc20TokenMaxGasCost(
-		userOperation: UserOperationV8 | UserOperationV7 | UserOperationV6,
+		smartAccount: SmartAccountWithEntrypoint,
+		userOperation: AnyUserOperation,
 		erc20TokenAddress: string,
 		overrides: { entrypoint?: string | null } = {},
 	): Promise<bigint> {
 		try {
-			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(userOperation);
+			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
 			await this.ensureInitialized(entrypoint);
 			const exchangeRate = await this.fetchTokenPaymasterExchangeRate(
 				erc20TokenAddress,

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -508,17 +508,16 @@ export class CandidePaymaster extends Paymaster {
 		context: CandidePaymasterContext = {},
 		overrides: GasPaymasterUserOperationOverrides = {},
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
-		const userOp = { ...userOperation };
 		try {
-			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
+			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
 			const chainId = await this.getChainId();
 			const jsonRpcResult = await sendJsonRpcRequest(
 				this.rpcUrl,
 				"pm_getPaymasterData",
-				[userOp, entrypoint, chainId, context],
+				[userOperation, entrypoint, chainId, context],
 			);
-			const sponsorMetadata = this.applyPaymasterResult(userOp, jsonRpcResult);
-			return [userOp as unknown as SameUserOp<T>, sponsorMetadata];
+			const sponsorMetadata = this.applyPaymasterResult(userOperation, jsonRpcResult);
+			return [userOperation as unknown as SameUserOp<T>, sponsorMetadata];
 		} catch (err) {
 			const error = ensureError(err);
 			throw new AbstractionKitError(
@@ -553,8 +552,9 @@ export class CandidePaymaster extends Paymaster {
 		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
+		const userOp = { ...userOperation } as T;
 		context = {sponsorshipPolicyId, ...(context || {}) };
-		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
+		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 		await this.ensureInitialized(entrypoint);
 		const epData = this.getEntrypointData(entrypoint);
 		if (epData == null) {
@@ -563,15 +563,15 @@ export class CandidePaymaster extends Paymaster {
 			);
 		}
 		if (context.signingPhase !== "finalize"){
-			this.setDummyPaymasterFields(userOperation, epData);
-			await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
+			this.setDummyPaymasterFields(userOp, epData);
+			await this.estimateAndApplyGasLimits(userOp, bundlerRpc, entrypoint, overrides ?? {});
 		}
 		const _overrides = { ...(overrides || {}),
 			entrypoint: entrypoint,
 		};
 		return await this.createPaymasterUserOperation(
 			smartAccount,
-			userOperation,
+			userOp,
 			context,
 			_overrides,
 		);
@@ -599,8 +599,9 @@ export class CandidePaymaster extends Paymaster {
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<SameUserOp<T>> {
 		try {
+			const userOp = { ...userOperation } as T;
 			context = { token: tokenAddress, ...(context || {}) };
-			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
+			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 			await this.ensureInitialized(entrypoint);
 			if (context.signingPhase !== "finalize"){
 				const epData = this.getEntrypointData(entrypoint);
@@ -609,15 +610,15 @@ export class CandidePaymaster extends Paymaster {
 						`UserOperation for entrypoint ${entrypoint} is not supported`,
 					);
 				}
-				this.setDummyPaymasterFields(userOperation, epData);
+				this.setDummyPaymasterFields(userOp, epData);
 				// Prepend an infinite approval and re-estimate UserOperation gas limits (a later rational allowance will be calculated and replace the infinite one)
-				const oldCallData = userOperation.callData;
+				const oldCallData = userOp.callData;
 				const requiresAllowanceReset = overrides?.resetApproval
 					?? TOKENS_REQUIRING_ALLOWANCE_RESET.includes(
 						context.token!.toLowerCase(),
 					);
 				let callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
-					userOperation.callData,
+					userOp.callData,
 					context.token!,
 					epData.paymasterMetadata.address,
 					UINT256_MAX,
@@ -630,13 +631,13 @@ export class CandidePaymaster extends Paymaster {
 						0n,
 					);
 				}
-				userOperation.callData = callDataWithApprove;
+				userOp.callData = callDataWithApprove;
 
-				await this.estimateAndApplyGasLimits(userOperation, bundlerRpc, entrypoint, overrides ?? {});
+				await this.estimateAndApplyGasLimits(userOp, bundlerRpc, entrypoint, overrides ?? {});
 
 				const maxErc20Cost = await this.calculateUserOperationErc20TokenMaxGasCost(
 					smartAccount,
-					userOperation,
+					userOp,
 					context.token!,
 				);
 				const approveAmount = maxErc20Cost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
@@ -654,14 +655,14 @@ export class CandidePaymaster extends Paymaster {
 						0n,
 					);
 				}
-				userOperation.callData = callDataWithApprove;
+				userOp.callData = callDataWithApprove;
 			}
 			const _overrides = { ...(overrides || {}),
 				entrypoint: entrypoint,
 			};
 			const [resultUserOp] = await this.createPaymasterUserOperation(
 				smartAccount,
-				userOperation,
+				userOp,
 				context,
 				_overrides,
 			);

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -27,11 +27,16 @@ export interface CandidePaymasterContext {
 	signingPhase?: 'commit' | 'finalize';
 }
 
+export interface SmartAccountWithEntrypoint {
+	/** The EntryPoint contract address this account targets */
+	readonly entrypointAddress: string;
+}
+
 /**
  * Interface for smart accounts that support prepending an ERC-20 approval
  * to their callData so the token paymaster can collect gas fees.
  */
-export interface PrependTokenPaymasterApproveAccount {
+export interface PrependTokenPaymasterApproveAccount extends SmartAccountWithEntrypoint {
 	/**
 	 * Prepends a token approval call to the existing callData.
 	 * @param callData - The original encoded callData

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -23,6 +23,8 @@ export interface CandidePaymasterContext {
 	token?: string;
 	/** Sponsorship policy identifier for the Candide paymaster. */
 	sponsorshipPolicyId?: string;
+	/** Signing phase for parallel signing feature (either 'commit' or 'finalize'). */
+	signingPhase?: 'commit' | 'finalize';
 }
 
 /**

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -17,13 +17,108 @@ export type SameUserOp<T extends AnyUserOperation> =
 /**
  * Context passed to the Candide paymaster RPC when requesting sponsorship
  * or ERC-20 token payment for gas.
+ *
+ * This context is forwarded as the fourth argument to the `pm_getPaymasterData`
+ * JSON-RPC call on the Candide paymaster.
+ *
+ * @example Sponsored (gasless) UserOperation
+ * ```ts
+ * const [userOp, sponsorMeta] = await paymaster.createSponsorPaymasterUserOperation(
+ *   smartAccount, userOp, bundlerRpc,
+ *   "my-sponsorship-policy-id",
+ * );
+ * ```
+ *
+ * @example ERC-20 token gas payment
+ * ```ts
+ * const userOp = await paymaster.createTokenPaymasterUserOperation(
+ *   smartAccount, userOp, USDC_ADDRESS, bundlerRpc,
+ * );
+ * ```
+ *
+ * @example Parallel signing with `signingPhase` (two-step commit/finalize)
+ * ```ts
+ * // ── Step 1: COMMIT ──
+ * // Request initial paymaster fields with dummy signature.
+ * // The paymaster returns gas limits and init paymasterData (ending with
+ * // PAYMASTER_SIG_MAGIC) so owners can sign in parallel without waiting
+ * // for the final paymaster signature.
+ * const [commitOp] = await paymaster.createSponsorPaymasterUserOperation(
+ *   smartAccount, userOp, bundlerRpc,
+ *   sponsorshipPolicyId,
+ *   { signingPhase: "commit" },
+ * );
+ *
+ * // Sign the UserOperation (safe because the UserOp hash is stable —
+ * // the PAYMASTER_SIG_MAGIC boundary ensures the hash stays the same
+ * // whether init or final paymasterData is used).
+ * commitOp.signature = smartAccount.signUserOperation(
+ *   commitOp, [signer], chainId,
+ * );
+ *
+ * // ── Step 2: FINALIZE ──
+ * // Send the already-signed UserOperation back to the paymaster.
+ * // The paymaster replaces the init paymasterData with the final
+ * // paymaster signature. Gas estimation is skipped (already done in commit).
+ * const [finalOp] = await paymaster.createSponsorPaymasterUserOperation(
+ *   smartAccount, commitOp, bundlerRpc,
+ *   sponsorshipPolicyId,
+ *   { signingPhase: "finalize" },
+ * );
+ *
+ * // Send the finalized UserOperation to the bundler.
+ * const response = await smartAccount.sendUserOperation(finalOp, bundlerRpc);
+ * ```
  */
 export interface CandidePaymasterContext {
 	/** ERC-20 token address to use for gas payment. Omit for sponsored (gasless) operations. */
 	token?: string;
 	/** Sponsorship policy identifier for the Candide paymaster. */
 	sponsorshipPolicyId?: string;
-	/** Signing phase for parallel signing feature (either 'commit' or 'finalize'). */
+	/**
+	 * Signing phase for the **parallel signing** feature. Only relevant for
+	 * EntryPoint v0.9 accounts that use `PAYMASTER_SIG_MAGIC`-aware paymasters.
+	 *
+	 * Parallel signing decouples owner signing from the paymaster's final
+	 * signature. This is useful when multiple owners need to co-sign a
+	 * UserOperation (e.g. multi-sig wallets) or when the signing step happens
+	 * on a separate device/service. Without parallel signing, you would need
+	 * the final paymaster signature before owners can sign, creating a
+	 * sequential dependency.
+	 *
+	 * ## How it works
+	 *
+	 * EntryPoint v0.9 introduces the `PAYMASTER_SIG_MAGIC` convention: when
+	 * computing the UserOperation hash, the `paymasterData` is truncated at
+	 * the magic boundary (`22e325a297439656`). This means the hash is
+	 * identical whether the paymasterData contains the init placeholder or
+	 * the final paymaster signature — so owners can safely sign the
+	 * UserOperation before the paymaster has issued its real signature.
+	 *
+	 * ## Two-phase flow
+	 *
+	 * **`"commit"`** — First call. The paymaster:
+	 *   1. Sets dummy paymaster fields for gas estimation.
+	 *   2. Estimates gas limits via the bundler.
+	 *   3. Returns init `paymasterData` ending with `PAYMASTER_SIG_MAGIC`.
+	 *   After this call, the UserOp is ready for owner signing.
+	 *
+	 * **`"finalize"`** — Second call. The paymaster:
+	 *   1. Skips gas estimation (already done in commit).
+	 *   2. Replaces the init `paymasterData` with the real paymaster signature.
+	 *   After this call, the UserOp is ready to be sent to the bundler.
+	 *
+	 * ## When to use
+	 *
+	 * - Multi-owner accounts where owners sign in parallel on different devices.
+	 * - Flows where the signing step is asynchronous (e.g. hardware wallets,
+	 *   approval queues, cross-chain multi-sig via `SafeMultiChainSigAccount`).
+	 * - Any scenario where you need a stable UserOp hash before the paymaster
+	 *   commits its final signature.
+	 *
+	 * If omitted, the default single-step flow is used: gas estimation,
+	 * paymaster signature, and owner signing all happen sequentially.
+	 */
 	signingPhase?: 'commit' | 'finalize';
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -297,7 +297,7 @@ function baseCreatePackedUserOperationV8V9(
 			const PAYMASTER_SIG_MAGIC = '22e325a297439656';
 			if(
 				is_v9 &&
-				useroperation.paymasterData.endsWith(PAYMASTER_SIG_MAGIC)
+				useroperation.paymasterData.toLowerCase().endsWith(PAYMASTER_SIG_MAGIC)
 			){
 				const sigLenHex = useroperation.paymasterData.slice(
 					useroperation.paymasterData.length - 16 - 4,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,17 +219,6 @@ export function createPackedUserOperationV7(
 	return packedUserOperation;
 }
 
-export function paymasterDataKeccakV9(paymasterAndData: string): string{
-    const PAYMASTER_SIG_MAGIC = '22e325a297439656';
-    const parts = paymasterAndData.split(PAYMASTER_SIG_MAGIC);
-    if(parts.length > 1){
-        return keccak256(solidityPacked(
-            ["bytes", "bytes"], [parts[0], "0x" + PAYMASTER_SIG_MAGIC]));
-    }else{
-        return keccak256(paymasterAndData);
-    }
-}
-
 /**
  * ABI-encode and pack a UserOperation for hashing (EntryPoint v0.9 format).
  *
@@ -333,7 +322,7 @@ function baseCreatePackedUserOperationV8V9(
 		accountGasLimits,
 		useroperation.preVerificationGas,
 		gasFees,
-		is_v9?paymasterDataKeccakV9(paymasterAndData):keccak256(paymasterAndData),
+		keccak256(paymasterAndData),
 	];
 
 	const packedUserOperation = abiCoder.encode(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -305,7 +305,21 @@ function baseCreatePackedUserOperationV8V9(
 				.slice(34);
 		}
 		if (useroperation.paymasterData != null) {
-			paymasterAndData += useroperation.paymasterData.slice(2);
+			const PAYMASTER_SIG_MAGIC = '22e325a297439656';
+			if(
+				is_v9 &&
+				useroperation.paymasterData.endsWith(PAYMASTER_SIG_MAGIC)
+			){
+				const sigLenHex = useroperation.paymasterData.slice(
+					useroperation.paymasterData.length - 16 - 4,
+					useroperation.paymasterData.length - 16
+				);
+				const sigLen = parseInt(sigLenHex, 16);
+				const prefixEnd = useroperation.paymasterData.length - 16 - 4 - sigLen * 2;
+				paymasterAndData += useroperation.paymasterData.slice(0, prefixEnd).replaceAll("0x", "") + PAYMASTER_SIG_MAGIC;
+			}else{
+				paymasterAndData += useroperation.paymasterData.slice(2);
+			}
 		}
 	}
 

--- a/test/calibur/caliburPaymaster.test.js
+++ b/test/calibur/caliburPaymaster.test.js
@@ -117,6 +117,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         );
 
         const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+            account,
             userOp,
             bundlerRpc,
         );
@@ -155,6 +156,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         );
 
         const [sponsoredOp2] = await paymaster.createSponsorPaymasterUserOperation(
+            account,
             userOp2,
             bundlerRpc,
         );
@@ -181,6 +183,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         );
 
         const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+            account,
             userOp,
             bundlerRpc,
         );
@@ -212,6 +215,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         );
 
         const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
+            account,
             delegateOp,
             bundlerRpc,
         );
@@ -240,7 +244,9 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
 
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
         const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
-            regOp, bundlerRpc,
+            account,
+            regOp,
+            bundlerRpc,
         );
 
         sponsoredRegOp.signature = account.signUserOperation(sponsoredRegOp, eoa.privateKey, chainId);
@@ -260,7 +266,9 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         );
 
         const [sponsoredPasskeyOp] = await paymaster.createSponsorPaymasterUserOperation(
-            passkeyOp, bundlerRpc,
+            account,
+            passkeyOp,
+            bundlerRpc,
         );
 
         const userOpHash = account.getUserOperationHash(sponsoredPasskeyOp, chainId);
@@ -286,7 +294,9 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             { eip7702Auth: { chainId } },
         );
         const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
-            delegateOp, bundlerRpc,
+            account,
+            delegateOp,
+            bundlerRpc,
         );
         sponsoredDelegateOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
             BigInt(sponsoredDelegateOp.eip7702Auth.chainId),
@@ -309,7 +319,9 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         });
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
         const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
-            regOp, bundlerRpc,
+            account,
+            regOp,
+            bundlerRpc,
         );
         sponsoredRegOp.signature = account.signUserOperation(sponsoredRegOp, eoa.privateKey, chainId);
         await sendAndWait(account, sponsoredRegOp, bundlerRpc);
@@ -320,7 +332,9 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         const revokeTx = ak.Calibur7702Account.createRevokeKeyMetaTransaction(keyHash);
         const revokeOp = await account.createUserOperation([revokeTx], providerRpc, bundlerRpc);
         const [sponsoredRevokeOp] = await paymaster.createSponsorPaymasterUserOperation(
-            revokeOp, bundlerRpc,
+            account,
+            revokeOp,
+            bundlerRpc,
         );
         sponsoredRevokeOp.signature = account.signUserOperation(
             sponsoredRevokeOp, eoa.privateKey, chainId,
@@ -345,6 +359,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         );
 
         const [sponsoredOp, sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+            account,
             userOp,
             bundlerRpc,
         );
@@ -392,7 +407,9 @@ describe('Calibur7702Account Token Paymaster (v0.8 defaults)', () => {
                 { eip7702Auth: { chainId } },
             );
             const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
-                delegateOp, bundlerRpc,
+                account,
+                delegateOp,
+                bundlerRpc,
             );
             sponsoredOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
                 BigInt(sponsoredOp.eip7702Auth.chainId),
@@ -503,6 +520,7 @@ describe('Calibur7702Account Token Paymaster (v0.8 defaults)', () => {
         );
 
         const maxCost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
+            account,
             userOp,
             erc20TokenAddress,
         );

--- a/test/safe/migrateAccount.test.js
+++ b/test/safe/migrateAccount.test.js
@@ -34,7 +34,10 @@ describe('safe account migration', () => {
         )
 
         let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-            testUserOperation, bundlerUrl)
+            accountToMigrate,
+            testUserOperation,
+            bundlerUrl
+        )
         testUserOperation = paymasterUserOperation; 
 
         testUserOperation.signature = accountToMigrate.signUserOperation(
@@ -61,7 +64,11 @@ describe('safe account migration', () => {
         )
         
         const [paymasterUserOperation2, _sponsorMetadata2] = await paymaster.createSponsorPaymasterUserOperation(
-            migrateUserOperation, bundlerUrl)
+            accountToMigrate,
+            migrateUserOperation,
+            bundlerUrl
+        )
+
         migrateUserOperation = paymasterUserOperation2;
 
         migrateUserOperation.signature = accountToMigrate.signUserOperation(
@@ -97,7 +104,10 @@ describe('safe account migration', () => {
         )
         
         const [paymasterUserOperation3, _sponsorMetadata3] = await paymaster.createSponsorPaymasterUserOperation(
-            afterMigrationUserOperation, bundlerUrl)
+            migratedAccount,
+            afterMigrationUserOperation,
+            bundlerUrl
+        )
         afterMigrationUserOperation = paymasterUserOperation3;
 
         afterMigrationUserOperation.signature = migratedAccount.signUserOperation(

--- a/test/simple/delegationLive.test.js
+++ b/test/simple/delegationLive.test.js
@@ -105,7 +105,9 @@ describe('EIP-7702 delegation lifecycle (live)', () => {
 
         // Sponsor gas
         const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
-            userOperation, bundlerUrl
+            smartAccount,
+            userOperation,
+            bundlerUrl
         );
         userOperation = sponsoredOp;
 
@@ -156,7 +158,9 @@ describe('EIP-7702 delegation lifecycle (live)', () => {
 
         // Sponsor gas
         const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
-            userOperation, bundlerUrl
+            smartAccount,
+            userOperation,
+            bundlerUrl
         );
         userOperation = sponsoredOp;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account-driven entrypoint resolution and EntryPoint V9 support for paymaster flows.
  * Signing-phase context added to paymaster operations to support parallel signing stages.

* **Bug Fixes & Improvements**
  * More robust paymaster-data construction and relaxed validation to accept the required V9 suffix.
  * Token-paymaster and sponsorship flows now respect provided account context and signing phase.
  * Improved parallel-paymaster init value generation for allow-all flow.

* **Tests**
  * Updated tests to pass account/context through paymaster API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->