### PR TITLE
refactor: remove any types from src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/dist/**
 **/.env
 *.log
+.worktrees/

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -330,7 +330,7 @@ export class Calibur7702Account extends SmartAccount
 				);
 			}
 
-			const ops: Promise<any>[] = [eip7702AuthNonceOp];
+			const ops: Promise<unknown>[] = [eip7702AuthNonceOp];
 			if (nonceOp != null) ops.push(nonceOp);
 			if (gasPriceOp != null) ops.push(gasPriceOp);
 			if (delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -338,8 +338,8 @@ export class Calibur7702Account extends SmartAccount
 			const values = await Promise.all(ops);
 			let idx = 0;
 			eip7702AuthNonce = BigInt(values[idx++] as string);
-			if (nonceOp != null) nonce = values[idx++];
-			if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+			if (nonceOp != null) nonce = values[idx++] as bigint;
+			if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
 			if (delegationCheckOp != null) {
 				const delegatedTo = values[idx++] as string | null;
 				if (delegatedTo != null &&
@@ -348,7 +348,7 @@ export class Calibur7702Account extends SmartAccount
 				}
 			}
 		} else if (overrides.eip7702Auth != null) {
-			const ops: Promise<any>[] = [];
+			const ops: Promise<unknown>[] = [];
 			if (nonceOp != null) ops.push(nonceOp);
 			if (gasPriceOp != null) ops.push(gasPriceOp);
 			if (delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -356,8 +356,8 @@ export class Calibur7702Account extends SmartAccount
 			if (ops.length > 0) {
 				const values = await Promise.all(ops);
 				let idx = 0;
-				if (nonceOp != null) nonce = values[idx++];
-				if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+				if (nonceOp != null) nonce = values[idx++] as bigint;
+				if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
 				if (delegationCheckOp != null) {
 					const delegatedTo = values[idx++] as string | null;
 					if (delegatedTo != null &&
@@ -1306,7 +1306,7 @@ export class Calibur7702Account extends SmartAccount
 		if (count === 0) return [];
 
 		// Batch all keyAt calls in parallel
-		const keyAtPromises: Promise<any>[] = [];
+		const keyAtPromises: Promise<unknown>[] = [];
 		for (let i = 0; i < count; i++) {
 			const keyAtCallData = KEY_AT_SELECTOR + abiCoder.encode(
 				["uint256"],

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -453,7 +453,7 @@ export class BaseSimple7702Account extends SmartAccount {
             const values = await Promise.all(ops);
             let idx = 0;
             eip7702AuthNonce = BigInt(values[idx++] as string);
-            if(nonceOp != null) nonce = values[idx++] as bigint | null;
+            if(nonceOp != null) nonce = values[idx++] as bigint;
             if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
             if(delegationCheckOp != null){
                 const delegatedTo = values[idx++] as string|null;
@@ -472,7 +472,7 @@ export class BaseSimple7702Account extends SmartAccount {
             if(ops.length > 0){
                 const values = await Promise.all(ops);
                 let idx = 0;
-                if(nonceOp != null) nonce = values[idx++] as bigint | null;
+                if(nonceOp != null) nonce = values[idx++] as bigint;
                 if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
                 if(delegationCheckOp != null){
                     const delegatedTo = values[idx++] as string|null;

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -445,7 +445,7 @@ export class BaseSimple7702Account extends SmartAccount {
             }
 
             // Build array of all parallel operations
-            const ops:Promise<any>[] = [eip7702AuthNonceOp];
+            const ops: Promise<unknown>[] = [eip7702AuthNonceOp];
             if(nonceOp != null) ops.push(nonceOp);
             if(gasPriceOp != null) ops.push(gasPriceOp);
             if(delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -453,8 +453,8 @@ export class BaseSimple7702Account extends SmartAccount {
             const values = await Promise.all(ops);
             let idx = 0;
             eip7702AuthNonce = BigInt(values[idx++] as string);
-            if(nonceOp != null) nonce = values[idx++];
-            if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+            if(nonceOp != null) nonce = values[idx++] as bigint | null;
+            if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
             if(delegationCheckOp != null){
                 const delegatedTo = values[idx++] as string|null;
                 if(delegatedTo != null &&
@@ -464,7 +464,7 @@ export class BaseSimple7702Account extends SmartAccount {
             }
         }else if(overrides.eip7702Auth != null){
             // eip7702AuthNonce was provided, but still need delegation check + other ops
-            const ops:Promise<any>[] = [];
+            const ops: Promise<unknown>[] = [];
             if(nonceOp != null) ops.push(nonceOp);
             if(gasPriceOp != null) ops.push(gasPriceOp);
             if(delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -472,8 +472,8 @@ export class BaseSimple7702Account extends SmartAccount {
             if(ops.length > 0){
                 const values = await Promise.all(ops);
                 let idx = 0;
-                if(nonceOp != null) nonce = values[idx++];
-                if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+                if(nonceOp != null) nonce = values[idx++] as bigint | null;
+                if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
                 if(delegationCheckOp != null){
                     const delegatedTo = values[idx++] as string|null;
                     if(delegatedTo != null &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,8 +108,8 @@ export type ChainIdResult = string;
 export type SupportedEntryPointsResult = string[];
 
 export type SingleTransactionTenderlySimulationResult = {
-    transaction: any
-    simulation: any
+    transaction: unknown;
+    simulation: { id: string } & Record<string, unknown>;
 }
 
 export type TenderlySimulationResult = SingleTransactionTenderlySimulationResult[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export type ChainIdResult = string;
 export type SupportedEntryPointsResult = string[];
 
 export type SingleTransactionTenderlySimulationResult = {
-    transaction: unknown;
+    transaction: Record<string, unknown>;
     simulation: { id: string } & Record<string, unknown>;
 }
 

--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -12,6 +12,7 @@ import {
 	AbstractionKitError
 } from "./errors";
 import { sendJsonRpcRequest, createUserOperationHash } from "./utils";
+import { Authorization7702Hex } from "./utils7702";
 
 /**
  * State override mapping for Tenderly simulations.
@@ -312,19 +313,19 @@ export interface BaseUserOperationToSimulate {
 	/** The encoded call data to execute on the account. */
 	callData: string;
 	/** The account nonce. */
-	nonce: any;
+	nonce: bigint;
 	/** The gas limit for the main execution call. */
-	callGasLimit: any;
+	callGasLimit: bigint;
 	/** The gas limit for the verification step. */
-	verificationGasLimit: any;
+	verificationGasLimit: bigint;
 	/** The gas overhead to compensate the bundler. */
-	preVerificationGas: any;
+	preVerificationGas: bigint;
 	/** The maximum fee per gas (EIP-1559). */
-	maxFeePerGas: any;
+	maxFeePerGas: bigint;
 	/** The maximum priority fee per gas (EIP-1559). */
-	maxPriorityFeePerGas: any;
+	maxPriorityFeePerGas: bigint;
 	/** The UserOperation signature. */
-	signature: any;
+	signature: string;
 }
 
 /**
@@ -335,7 +336,7 @@ export interface UserOperationV6ToSimulate extends BaseUserOperationToSimulate {
 	/** The concatenated factory address and factory data, or null if already deployed. */
 	initCode: string | null;
 	/** The concatenated paymaster address and paymaster-specific data. */
-	paymasterAndData: any;
+	paymasterAndData: string;
 }
 
 /**
@@ -348,13 +349,13 @@ export interface UserOperationV7ToSimulate extends BaseUserOperationToSimulate {
 	/** The factory-specific initialization data, or null if already deployed. */
 	factoryData: string | null;
 	/** The paymaster contract address. */
-	paymaster: any;
+	paymaster: string | null;
 	/** The gas limit for paymaster verification. */
-	paymasterVerificationGasLimit: any;
+	paymasterVerificationGasLimit: bigint | null;
 	/** The gas limit for paymaster postOp execution. */
-	paymasterPostOpGasLimit: any;
+	paymasterPostOpGasLimit: bigint | null;
 	/** The paymaster-specific data. */
-	paymasterData: any;
+	paymasterData: string | null;
 }
 
 /**
@@ -368,15 +369,15 @@ export interface UserOperationV8ToSimulate extends BaseUserOperationToSimulate {
 	/** The factory-specific initialization data, or null if already deployed. */
 	factoryData: string | null;
 	/** The paymaster contract address. */
-	paymaster: any;
+	paymaster: string | null;
 	/** The gas limit for paymaster verification. */
-	paymasterVerificationGasLimit: any;
+	paymasterVerificationGasLimit: bigint | null;
 	/** The gas limit for paymaster postOp execution. */
-	paymasterPostOpGasLimit: any;
+	paymasterPostOpGasLimit: bigint | null;
 	/** The paymaster-specific data. */
-	paymasterData: any;
+	paymasterData: string | null;
 	/** The EIP-7702 delegation authorization data. */
-    eip7702Auth: any;
+	eip7702Auth: Authorization7702Hex | null;
 }
 
 /**
@@ -421,7 +422,7 @@ export async function simulateUserOperationCallDataWithTenderlyAndCreateShareLin
         blockNumber,
         stateOverrides
     );
-    const simulationIds = simulation.map(s => s.simulation.id) as string[];
+    const simulationIds = simulation.map(s => s.simulation.id);
     await Promise.all(simulationIds.map(simulationId =>
         shareTenderlySimulationAndCreateLink(
             tenderlyAccountSlug,
@@ -643,7 +644,7 @@ export async function simulateSenderCallDataWithTenderlyAndCreateShareLink(
         blockNumber,
         stateOverrides
     );
-    const simulationIds = simulation.map(s => s.simulation.id) as string[];
+    const simulationIds = simulation.map(s => s.simulation.id);
     await Promise.all(simulationIds.map(simulationId =>
         shareTenderlySimulationAndCreateLink(
             tenderlyAccountSlug,


### PR DESCRIPTION
## Summary

Replaces every real `any` type annotation in `src/` with a precise type (or `unknown` where the value is genuinely heterogeneous), without changing runtime behavior or breaking the public API.

16 real `any` types removed across 4 files. 5 remaining `any` hits in `src/` are all English prose inside JSDoc or inline comments (deliberately left as-is).

## What changed

- **`src/types.ts`** — `SingleTransactionTenderlySimulationResult.transaction` and `.simulation` tightened from `any` to `Record<string, unknown>` and `{ id: string } & Record<string, unknown>`. The only consumer reads `simulation.id`, which is now typed.
- **`src/utilsTenderly.ts`** — the four `*ToSimulate` interfaces (`BaseUserOperationToSimulate`, `UserOperationV6/V7/V8ToSimulate`) now use `bigint` for gas/fee/nonce fields, `string | null` for paymaster byte fields, and `Authorization7702Hex | null` for `eip7702Auth`, mirroring the canonical `UserOperationV6/V7/V8` types. Two now-redundant `as string[]` casts on `.map(s => s.simulation.id)` chains removed.
- **`src/account/simple/Simple7702Account.ts`** — two `Promise<any>[]` in `createUserOperation` replaced with `Promise<unknown>[]`, with focused read-site casts (`as bigint`, `as [bigint, bigint]`) that match the underlying promise return types.
- **`src/account/Calibur/Calibur7702Account.ts`** — three `Promise<any>[]` (two in `createUserOperation`, one in `getKeys`) replaced with `Promise<unknown>[]`. The `getKeys` site already has a runtime `typeof keyResult !== \"string\"` guard, so no additional casts were needed there.

## Notable correctness improvement

`UserOperationV8ToSimulate.eip7702Auth: Authorization7702Hex | null` now rules out accidentally passing the bigint-valued `Authorization7702` type at a hex-string concatenation site in `utilsTenderly.ts`, which the old `any` silently allowed.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm run build\` passes (CJS, ESM, IIFE)
- [x] \`abstractionkit-examples\` typechecks cleanly when linked against this branch (0 errors, matches pre-refactor baseline)
- [x] \`npx jest test/calibur/caliburEncoding.test.js test/calibur/calibur7702Account.test.js\` — 80/80 pass
- [ ] Integration tests requiring funded EOA + bundler (not run locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced TypeScript type safety across the codebase by replacing generic types with more precise types, including stricter typing for numeric values, strings, and structured objects. These changes improve code reliability and provide better type checking during development.

* **Chores**
  * Updated version control configuration to exclude additional directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->