### PR TITLE
docs: tighten README for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,101 +16,64 @@ AbstractionKit is agnostic of:
 
 
 ## Features
-### Safe Accounts
-- Built on ERC-4337 account abstraction
-- Passkeys Authentication for secure, passwordless access
-- Social Recovery to regain access easily
-- Multisig Support
-- Allowance Management for controlled spending limits
 
-### Gas Abstraction with Paymasters
-- Full Gas Sponsorship for a seamless user experience
-- Support for ERC-20 Tokens as gas payment options
-
-### Bundler Support
-- Compatibility with standard ERC-4337 Bundler Methods
-
-### UserOperation Utilities
-- A complete toolkit to construct, sign, and send UserOperations, enabling smooth integration
+- **Safe Accounts** with passkey authentication, social recovery, multisig, and allowance management
+- **EIP-7702** support via `Calibur7702Account` and `Simple7702Account`
+- **Gas abstraction** with sponsored UserOperations and ERC-20 gas payment via `CandidePaymaster`
+- **Multichain signatures** via `SafeMultiChainSigAccountV1` (sign once, replay across chains)
+- **Bundler client** compatible with standard ERC-4337 methods
+- **EntryPoint v0.6, v0.7, v0.8, and v0.9** support with a version-safe account/UserOp mapping
 
 ## Docs
 
-For full detailed documentation visit our [docs page](https://docs.candide.dev/wallet/abstractionkit/introduction). 
+For full detailed documentation visit our [docs page](https://docs.candide.dev/wallet/abstractionkit/introduction).
 
 ## Installation
+
+Requires Node.js 18 or later.
 
 ```bash
 npm install abstractionkit
 ```
 
+### Upgrading to v0.3.0
+
+v0.3.0 is a major release. Two API changes are likely to break existing paymaster code:
+
+- `CandidePaymaster.createSponsorPaymasterUserOperation(...)` now takes `smartAccount` as the **first** argument: `(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId?, overrides?)`.
+- `CandidePaymasterContext` is no longer a separate argument. Pass it via `overrides.context` on `GasPaymasterUserOperationOverrides`.
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full list of new features, renames, type export changes, and fixes.
+
 ## Quickstart
 
-### Which version to use?
+### Which account class to use?
 
-| Class | EntryPoint | When to use |
-|---|---|---|
-| `SafeAccountV0_3_0` | v0.7 | Recommended for new projects |
-| `SafeAccountV0_2_0` | v0.6 | Legacy support |
+| Class | EntryPoint | Account Type | When to use |
+|---|---|---|---|
+| `SafeAccountV0_3_0` | EP v0.7 | Safe (counterfactual) | Recommended for most new projects |
+| `SafeAccountV1_5_0_M_0_3_0` | EP v0.7 | Safe v1.5.0 (counterfactual) | Safe v1.5.0 with EIP-7951 / Daimo P256 verifier for WebAuthn |
+| `SafeAccountV0_2_0` | EP v0.6 | Safe (counterfactual) | Legacy support for EntryPoint v0.6 |
+| `SafeMultiChainSigAccountV1` | EP v0.9 | Safe multichain | Sign once, replay across chains. |
+| `Calibur7702Account` | EP v0.8 | EIP-7702 (Uniswap Calibur) | Upgrade an EOA in place. Supports EOA, P256, and WebAuthn keys |
+| `Simple7702Account` | EP v0.8 | EIP-7702 (minimal) | Minimal reference EIP-7702 account |
+| `Simple7702AccountV09` | EP v0.9 | EIP-7702 (minimal, parallel paymaster) | EntryPoint v0.9 with parallel paymaster signing |
 
-### Safe Account
+### Endpoints
 
-AbstractionKit features the Safe Account. It uses the original Safe Singleton and adds ERC-4337 functionality using a fallback handler module. The contracts have been developed by the Safe Team. It has been audited by Ackee Blockchain. To learn more about the contracts and audits, visit [safe-global/safe-modules](https://github.com/safe-global/safe-modules/tree/main/modules/4337).
-
-
-```typescript
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
-
-const ownerPublicAddress = "0xBdbc5FBC9cA8C3F514D073eC3de840Ac84FC6D31";
-const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress]);
-
-```
-Then you can consume account methods:
-```typescript
-const safeAddress = smartAccount.accountAddress;
-```
-
-### Bundler
-
-Initialize a Bundler with a bundler RPC url. Get an API key from the [dashboard](https://dashboard.candide.dev), or use the public endpoint (no key required).
-```typescript
-import { Bundler } from "abstractionkit";
-
-// Authenticated (get YOUR_API_KEY from https://dashboard.candide.dev)
-const bundlerRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
-
-// Or public (no key required)
-// const bundlerRpc = "https://api.candide.dev/public/v3/11155111";
-
-const bundler = new Bundler(bundlerRpc);
-```
-Then you can consume Bundler methods:
+Candide hosts both bundler and paymaster under the same base URL. Get an API key from the [dashboard](https://dashboard.candide.dev), or use the public endpoint (rate-limited, no key required).
 
 ```typescript
-const entrypointAddresses = await bundler.supportedEntryPoints();
-```
-
-### Paymaster
-Initialize a Candide Paymaster with your RPC url. Get an API key from the [dashboard](https://dashboard.candide.dev).
-```typescript
-import { CandidePaymaster } from "abstractionkit";
-
 // Authenticated
-const paymasterRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
+const rpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
 
 // Or public (no key required)
-// const paymasterRpc = "https://api.candide.dev/public/v3/11155111";
-
-const paymaster = new CandidePaymaster(paymasterRpc);
-```
-Then you can consume Paymaster methods:
-
-```typescript
-const supportedERC20TokensAndPaymasterMetadata = await paymaster.fetchSupportedERC20TokensAndPaymasterMetadata();
+// const rpc = "https://api.candide.dev/public/v3/11155111";
 ```
 
 ## Recipes
 
-Copy-paste patterns for common tasks. Examples use `SafeAccountV0_3_0` (EntryPoint v0.7). For EntryPoint v0.6, replace with `SafeAccountV0_2_0`.
+Copy paste patterns for common tasks. Examples use `SafeAccountV0_3_0` (EntryPoint v0.7). For EntryPoint v0.6, replace with `SafeAccountV0_2_0`.
 
 ### Send ETH from a new Safe account
 
@@ -120,7 +83,7 @@ import { SafeAccountV0_3_0 } from "abstractionkit";
 const ownerPublicAddress = "0xOwner";
 const ownerPrivateKey = "0xPrivateKey";
 const nodeRpc = "https://rpc.example.com";
-const bundlerRpc = "https://bundler.example.com";
+const bundlerRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
 const chainId = 11155111n; // Sepolia
 
 // Initialize new account (deploys on first UserOp)
@@ -169,7 +132,7 @@ const userOp = await smartAccount.createUserOperation(
 ```typescript
 import { SafeAccountV0_3_0, CandidePaymaster } from "abstractionkit";
 
-const paymaster = new CandidePaymaster("https://paymaster.example.com/rpc");
+const paymaster = new CandidePaymaster("https://api.candide.dev/api/v3/11155111/YOUR_API_KEY");
 
 // Create the UserOp first (without paymaster)
 const userOp = await smartAccount.createUserOperation(
@@ -178,10 +141,14 @@ const userOp = await smartAccount.createUserOperation(
   bundlerRpc,
 );
 
-// Sponsor it — sets paymaster fields and re-estimates gas
+// Sponsor it. Sets paymaster fields and re-estimates gas.
+// Note: as of v0.3.0, smartAccount is the first argument.
 const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+  smartAccount,
   userOp,
   bundlerRpc,
+  sponsorshipPolicyId,
+  // overrides (optional, includes context for parallel signing)
 );
 
 // Sign and send as usual
@@ -194,7 +161,7 @@ const response = await smartAccount.sendUserOperation(sponsoredOp, bundlerRpc);
 ```typescript
 import { SafeAccountV0_3_0, CandidePaymaster } from "abstractionkit";
 
-const paymaster = new CandidePaymaster("https://paymaster.example.com/rpc");
+const paymaster = new CandidePaymaster("https://api.candide.dev/api/v3/11155111/YOUR_API_KEY");
 const gasTokenAddress = "0xERC20TokenAddress"; // must be supported by paymaster
 
 const userOp = await smartAccount.createUserOperation(
@@ -203,16 +170,40 @@ const userOp = await smartAccount.createUserOperation(
   bundlerRpc,
 );
 
-// Automatically prepends token approval + sets paymaster fields
+// Automatically prepends token approval + sets paymaster fields.
+// For tokens like USDT that require resetting allowance to 0 first, pass
+// { resetApproval: true } in the overrides.
 const tokenOp = await paymaster.createTokenPaymasterUserOperation(
   smartAccount,
   userOp,
   gasTokenAddress,
   bundlerRpc,
+  // overrides (optional)
 );
 
 tokenOp.signature = smartAccount.signUserOperation(tokenOp, [ownerPrivateKey], chainId);
 const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
+```
+
+### Pass paymaster context (sponsorship policy, parallel signing)
+
+As of v0.3.0, `CandidePaymasterContext` is passed via the `overrides.context` field on `GasPaymasterUserOperationOverrides`. Previously it was a separate top level argument.
+
+```typescript
+const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+  smartAccount,
+  userOp,
+  bundlerRpc,
+  sponsorshipPolicyId,
+  {
+    context: {
+      // For EntryPoint v0.9 parallel signing flows:
+      // signingPhase: "commit" | "finalize",
+    },
+    // gas overrides also live here:
+    callGasLimitPercentageMultiplier: 110,
+  },
+);
 ```
 
 ### Batch multiple transactions
@@ -220,7 +211,7 @@ const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
 ```typescript
 import { SafeAccountV0_3_0, MetaTransaction } from "abstractionkit";
 
-// Pass an array of MetaTransactions — automatically encoded via MultiSend
+// Pass an array of MetaTransactions. Automatically encoded via MultiSend.
 const transactions: MetaTransaction[] = [
   { to: "0xRecipientA", value: 1000000000000000n, data: "0x" },
   { to: "0xRecipientB", value: 2000000000000000n, data: "0x" },
@@ -246,6 +237,98 @@ const smartAccount = new SafeAccountV0_3_0("0xYourDeployedSafeAddress");
 const newAccount = SafeAccountV0_3_0.initializeNewAccount(["0xOwnerAddress"]);
 // newAccount.accountAddress is the counterfactual address
 // First UserOp will deploy it automatically
+```
+
+### Calibur 7702: delegate an EOA and send a transfer
+
+`Calibur7702Account` is Uniswap's EIP-7702 smart account. It upgrades a regular EOA in place so the same address becomes a programmable smart account on EntryPoint v0.8.
+
+```typescript
+import {
+  Calibur7702Account,
+  createAndSignEip7702DelegationAuthorization,
+} from "abstractionkit";
+
+const eoaAddress = "0xYourEOA";
+const privateKey = "0xYourPrivateKey";
+const nodeRpc = "https://rpc.example.com";
+const bundlerRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
+const chainId = 11155111n;
+
+// The EOA address becomes the smart account address after delegation.
+const account = new Calibur7702Account(eoaAddress);
+
+// Create UserOp with EIP-7702 delegation (only required the first time).
+const userOp = await account.createUserOperation(
+  [{ to: "0xRecipient", value: 1000000000000000n, data: "0x" }],
+  nodeRpc,
+  bundlerRpc,
+  { eip7702Auth: { chainId } },
+);
+
+// Sign the delegation authorization.
+userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+  BigInt(userOp.eip7702Auth.chainId),
+  userOp.eip7702Auth.address,
+  BigInt(userOp.eip7702Auth.nonce),
+  privateKey,
+);
+
+// Sign and send.
+userOp.signature = account.signUserOperation(userOp, privateKey, chainId);
+const response = await account.sendUserOperation(userOp, bundlerRpc);
+const receipt = await response.included();
+```
+
+After the first UserOp deploys the delegation, subsequent UserOps no longer need `eip7702Auth`. Use `getDelegatedAddress(eoaAddress, nodeRpc)` to check delegation status.
+
+### Calibur 7702: register a WebAuthn passkey
+
+```typescript
+import { Calibur7702Account } from "abstractionkit";
+
+// Build a P256 key from the WebAuthn public key coordinates.
+const webAuthnKey = Calibur7702Account.createWebAuthnP256Key(pubKeyX, pubKeyY);
+const keyHash = Calibur7702Account.getKeyHash(webAuthnKey);
+
+// Register with a 1-year expiration.
+const registerTxs = Calibur7702Account.createRegisterKeyMetaTransactions(
+  webAuthnKey,
+  { expiration: Math.floor(Date.now() / 1000) + 86400 * 365 },
+);
+
+const userOp = await account.createUserOperation(registerTxs, nodeRpc, bundlerRpc);
+userOp.signature = account.signUserOperation(userOp, privateKey, chainId);
+const response = await account.sendUserOperation(userOp, bundlerRpc);
+```
+
+### Calibur 7702: sign a UserOp with a registered passkey
+
+```typescript
+import { Calibur7702Account, createUserOperationHash } from "abstractionkit";
+
+// Use a WebAuthn dummy signature for accurate gas estimation.
+const dummySig = Calibur7702Account.createDummyWebAuthnSignature(keyHash);
+
+const userOp = await account.createUserOperation(
+  [{ to: "0xRecipient", value: 0n, data: "0x" }],
+  nodeRpc,
+  bundlerRpc,
+  { dummySignature: dummySig },
+);
+
+// Compute the hash, sign with the passkey off-chain, then format the signature.
+const userOpHash = createUserOperationHash(userOp, entryPointAddress, chainId);
+userOp.signature = account.formatWebAuthnSignature(keyHash, {
+  authenticatorData,
+  clientDataJSON,
+  challengeIndex,
+  typeIndex,
+  r,
+  s, // P256 signature components
+});
+
+const response = await account.sendUserOperation(userOp, bundlerRpc);
 ```
 
 ### Common error codes and solutions
@@ -286,3 +369,5 @@ MIT
 
 * <a href='https://eips.ethereum.org/EIPS/eip-4337'>EIP-4337: Account Abstraction via Entry Point Contract specification </a>
 * <a href='https://safe.global/'>Safe Accounts, Modules, and SGP</a>
+* <a href='https://github.com/Uniswap/calibur'>Uniswap Calibur Account</a>
+


### PR DESCRIPTION
Restructures the README for both human developers and AI coding agents, using v0.3.0 as the target version.

## What changed

**Features section trimmed.** Replaced four marketing-y subsections with six concrete bullets that name actual classes (`Calibur7702Account`, `SafeMultiChainSigAccountV1`, `CandidePaymaster`, etc.) so an AI agent scanning the README immediately sees what's available.

**v0.3.0 breaking changes callout.** A compact `Upgrading to v0.3.0` section lives after Installation and lists only the two paymaster API changes most likely to break existing code, with a link to `CHANGELOG.md` for the rest. Previously the release notes were a 35-line block before Installation that delayed "how do I use this" discovery.

**Expanded account class table.** The `Which account class to use?` table now covers `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0`, `SafeAccountV0_2_0`, `SafeMultiChainSigAccountV1`, `Calibur7702Account`, `Simple7702Account`, and `Simple7702AccountV09` with EntryPoint version, account type, and when-to-use guidance.

**Quickstart redundancy removed.** Dropped the Safe Account / Bundler / Paymaster subsections that showed trivial init snippets duplicated in the Recipes. Replaced with a compact `Endpoints` subsection showing the `api.candide.dev` URL pattern once.

**New Recipes.**
- `Sponsor gas with CandidePaymaster` updated to reflect the new `(smartAccount, userOp, bundlerRpc, ...)` signature.
- New `Pass paymaster context (sponsorship policy, parallel signing)` showing the new `overrides.context` shape.
- Three Calibur 7702 recipes: delegate + send transfer, register a WebAuthn passkey, sign with a registered passkey.

**Misc.**
- Fixed the placeholder `https://bundler.example.com` URL in the Send ETH recipe to use the real `api.candide.dev` pattern, consistent with all other recipes.
- Added `Requires Node.js 18 or later` to Installation (v0.3.0 made this a hard requirement).

## Numbers

- Before: 450 lines
- After: 374 lines

Follow-up: a separate PR will revisit the `CHANGELOG.md` 0.3.0 section to make it a proper 0.2.30 → 0.3.0 migration guide rather than covering just recent commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature list to include EIP-7702 accounts, multichain signatures, and EntryPoint v0.6–v0.9 support
  * Added v0.3.0 upgrade guide with breaking changes
  * Updated Node.js requirement to version 18+
  * Enhanced quickstart guide with improved account selection table
  * Added new paymaster context and Calibur recipe examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->