### PR TITLE
feat(safe): add per-op overrides to formatSignaturesToUseroperationsSignatures

### DIFF
--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -633,6 +633,8 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 					{
 						...defaultOverrides,
 						...userOperationsToSign[0].overrides,
+						validAfter: userOperationsToSign[0].validAfter,
+						validUntil: userOperationsToSign[0].validUntil,
 						isMultiChainSignature: true,
 					},
 				),

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -12,6 +12,7 @@ import {
     SignerSignaturePair,
     WebAuthnSignatureOverrides,
     WebauthnPublicKey,
+    UserOperationToSignWithOverrides,
 } from "./types";
 
 import { UserOperationV9, MetaTransaction, OnChainIdentifierParamsType } from "../../types";
@@ -603,14 +604,13 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * @returns signature
 	 */
 	public static formatSignaturesToUseroperationsSignatures(
-		userOperationsToSign: UserOperationToSign[],
+		userOperationsToSign: UserOperationToSignWithOverrides[],
 		signerSignaturePairs: SignerSignaturePair[],
-		overrides: WebAuthnSignatureOverrides = {},
 	): string[] {
 		if (userOperationsToSign.length < 1) {
 			throw new RangeError("There should be at least one userOperationsToSign");
 		}
-		const resolvedOverrides: WebAuthnSignatureOverrides = {
+		const defaultOverrides: WebAuthnSignatureOverrides = {
 			eip7212WebAuthnPrecompileVerifier:
 				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_PRECOMPILE,
 			eip7212WebAuthnContractVerifier:
@@ -625,50 +625,55 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 				SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
 			webAuthnSharedSigner:
 				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SHARED_SIGNER,
-			...overrides,
 		};
-        if (userOperationsToSign.length === 1) {
-            return [
-                SafeAccount.formatSignaturesToUseroperationSignature(
-                    signerSignaturePairs,
-                    {
-                        ...resolvedOverrides,
-                        isMultiChainSignature: true,
-                    },
-                ),
-            ];
-        }
-        const userOperationsHashes: string[] = [];
-        userOperationsToSign.forEach(
-            (userOperationsToSign, _index) => {
-                const userOperationHash = SafeAccount.getUserOperationEip712Hash_V9(
-                    userOperationsToSign.userOperation,
-                    userOperationsToSign.chainId,
-                    {
-                        validAfter: userOperationsToSign.validAfter,
-                        validUntil: userOperationsToSign.validUntil,
-                        safe4337ModuleAddress: resolvedOverrides.safe4337ModuleAddress,
-                    },
-                );
-                userOperationsHashes.push(userOperationHash);
-        });
-        const [_root, proofs] = generateMerkleProofs(userOperationsHashes);
-        const userOpSignatures: string[] = [];
-        userOperationsToSign.forEach(
-            (_userOperationsToSign, index) => {
-                userOpSignatures.push(
-                    SafeAccount.formatSignaturesToUseroperationSignature(
-                        signerSignaturePairs,
-                        {
-                            ...resolvedOverrides,
-                            isMultiChainSignature:true,
-                            multiChainMerkleProof: proofs[index],
-                        },
-                    )
-                );
-        });
-        return userOpSignatures;
-    }
+		if (userOperationsToSign.length === 1) {
+			return [
+				SafeAccount.formatSignaturesToUseroperationSignature(
+					signerSignaturePairs,
+					{
+						...defaultOverrides,
+						...userOperationsToSign[0].overrides,
+						isMultiChainSignature: true,
+					},
+				),
+			];
+		}
+		const userOperationsHashes: string[] = [];
+		userOperationsToSign.forEach(
+			(userOperationToSign, _index) => {
+				const userOperationHash = SafeAccount.getUserOperationEip712Hash_V9(
+					userOperationToSign.userOperation,
+					userOperationToSign.chainId,
+					{
+						validAfter: userOperationToSign.validAfter,
+						validUntil: userOperationToSign.validUntil,
+						safe4337ModuleAddress:
+							userOperationToSign.overrides?.safe4337ModuleAddress ??
+							defaultOverrides.safe4337ModuleAddress,
+					},
+				);
+				userOperationsHashes.push(userOperationHash);
+			},
+		);
+		const [_root, proofs] = generateMerkleProofs(userOperationsHashes);
+		const userOpSignatures: string[] = [];
+		userOperationsToSign.forEach(
+			(userOperationToSign, index) => {
+				userOpSignatures.push(
+					SafeAccount.formatSignaturesToUseroperationSignature(
+						signerSignaturePairs,
+						{
+							...defaultOverrides,
+							...userOperationToSign.overrides,
+							isMultiChainSignature: true,
+							multiChainMerkleProof: proofs[index],
+						},
+					),
+				);
+			},
+		);
+		return userOpSignatures;
+	}
 
 	public static createWebAuthnSignerVerifierAddress(
 		x: bigint,

--- a/src/account/Safe/types.ts
+++ b/src/account/Safe/types.ts
@@ -300,6 +300,20 @@ export interface UserOperationToSign {
     validUntil?: bigint;
 }
 
+/** Extends UserOperationToSign with per-operation WebAuthn/module overrides. */
+export interface UserOperationToSignWithOverrides extends UserOperationToSign {
+	overrides?: {
+		isInit?: boolean;
+		webAuthnSharedSigner?: string;
+		eip7212WebAuthnPrecompileVerifier?: string;
+		eip7212WebAuthnContractVerifier?: string;
+		webAuthnSignerFactory?: string;
+		webAuthnSignerSingleton?: string;
+		webAuthnSignerProxyCreationCode?: string;
+		safe4337ModuleAddress?: string;
+	};
+}
+
 /** EIP-712 domain for multi-chain signature Merkle tree root. */
 export interface MultiChainSignatureMerkleTreeRootTypedDataDomain {
 	verifyingContract: string;


### PR DESCRIPTION
Replace the global overrides parameter with per-operation overrides embedded in the new UserOperationToSignWithOverrides type, ensuring protocol-critical fields (isMultiChainSignature, multiChainMerkleProof) cannot be clobbered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved multi-chain signature handling with support for per-operation configuration overrides
  * Enables granular customization of WebAuthn signer and module settings for individual operations in multi-chain signing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->