### PR TITLE
feat(paymaster): add generic ERC-7677 paymaster class

### DIFF
--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -124,6 +124,20 @@ export class Bundler {
 				preVerificationGas: BigInt(res.preVerificationGas),
 				verificationGasLimit: BigInt(res.verificationGasLimit),
 			};
+			// EntryPoint v0.7+ bundlers include paymaster gas fields when a
+			// paymaster is attached to the UserOperation. Forward them so
+			// paymaster pipelines (e.g. ERC-7677) don't need to reach past
+			// this wrapper and call eth_estimateUserOperationGas directly.
+			if (res.paymasterVerificationGasLimit != null) {
+				gasEstimationResult.paymasterVerificationGasLimit = BigInt(
+					res.paymasterVerificationGasLimit,
+				);
+			}
+			if (res.paymasterPostOpGasLimit != null) {
+				gasEstimationResult.paymasterPostOpGasLimit = BigInt(
+					res.paymasterPostOpGasLimit,
+				);
+			}
 
 			return gasEstimationResult;
 		} catch (err) {

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -124,10 +124,12 @@ export class Bundler {
 				preVerificationGas: BigInt(res.preVerificationGas),
 				verificationGasLimit: BigInt(res.verificationGasLimit),
 			};
-			// EntryPoint v0.7+ bundlers include paymaster gas fields when a
-			// paymaster is attached to the UserOperation. Forward them so
-			// paymaster pipelines (e.g. ERC-7677) don't need to reach past
-			// this wrapper and call eth_estimateUserOperationGas directly.
+			// `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit`
+			// are standard ERC-4337 UserOperation fields but NOT part of the
+			// bundler-spec `GasInfo`. Some bundlers return them as a
+			// non-standard extension when a paymaster is attached; forwarded
+			// here for compatibility. Guarded with `!= null` so spec-compliant
+			// bundlers still work.
 			if (res.paymasterVerificationGasLimit != null) {
 				gasEstimationResult.paymasterVerificationGasLimit = BigInt(
 					res.paymasterVerificationGasLimit,

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -44,6 +44,11 @@ export type {
 	Erc7677PaymasterFields,
 	Erc7677StubDataResult,
 } from "./paymaster/Erc7677Paymaster";
+export type {
+	Erc7677Provider,
+	Erc7677PaymasterConstructorOptions,
+	GasPaymasterUserOperationOverrides,
+} from "./paymaster/types";
 export { ExperimentalAllowAllParallelPaymaster } from "./paymaster/AllowAllPaymaster";
 
 export { 

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -38,6 +38,12 @@ export { SafeAccountFactory } from "./factory/SafeAccountFactory";
 export { Bundler } from "./Bundler";
 
 export { CandidePaymaster } from "./paymaster/CandidePaymaster";
+export { Erc7677Paymaster } from "./paymaster/Erc7677Paymaster";
+export type {
+	Erc7677Context,
+	Erc7677PaymasterFields,
+	Erc7677StubDataResult,
+} from "./paymaster/Erc7677Paymaster";
 export { ExperimentalAllowAllParallelPaymaster } from "./paymaster/AllowAllPaymaster";
 
 export { 

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -462,12 +462,24 @@ export class Erc7677Paymaster extends Paymaster {
 				);
 			}
 			const bundler = new Bundler(bundlerRpc);
-			const priorCallGasLimit = userOp.callGasLimit;
-			const priorVerificationGasLimit = userOp.verificationGasLimit;
-			const priorPreVerificationGas = userOp.preVerificationGas;
 			userOp.callGasLimit = 0n;
 			userOp.verificationGasLimit = 0n;
 			userOp.preVerificationGas = 0n;
+			// Some bundlers reject estimation when fees are set and the sender
+			// has insufficient balance to pay them. Zero them during the
+			// estimate and restore after — same pattern as CandidePaymaster.
+			//
+			// Pimlico is an exception: estimating with maxFeePerGas = 0 makes
+			// its paymaster postOp divide by the fee and revert with
+			// "AA50 postOp reverted: divide by zero". Skip the zeroing for
+			// Pimlico and pass the user-supplied fees through unchanged.
+			const skipFeeZeroing = this.provider === "pimlico";
+			const inputMaxFeePerGas = userOp.maxFeePerGas;
+			const inputMaxPriorityFeePerGas = userOp.maxPriorityFeePerGas;
+			if (!skipFeeZeroing) {
+				userOp.maxFeePerGas = 0n;
+				userOp.maxPriorityFeePerGas = 0n;
+			}
 
 			const estimation = await bundler.estimateUserOperationGas(
 				userOp,
@@ -475,20 +487,19 @@ export class Erc7677Paymaster extends Paymaster {
 				overrides.state_override_set as StateOverrideSet | undefined,
 			);
 
+			if (!skipFeeZeroing) {
+				userOp.maxFeePerGas = inputMaxFeePerGas;
+				userOp.maxPriorityFeePerGas = inputMaxPriorityFeePerGas;
+			}
+
 			if (estimation.preVerificationGas > preVerificationGas) {
 				preVerificationGas = estimation.preVerificationGas;
-			} else {
-				userOp.preVerificationGas = priorPreVerificationGas;
 			}
 			if (estimation.verificationGasLimit > verificationGasLimit) {
 				verificationGasLimit = estimation.verificationGasLimit;
-			} else {
-				userOp.verificationGasLimit = priorVerificationGasLimit;
 			}
 			if (estimation.callGasLimit > callGasLimit) {
 				callGasLimit = estimation.callGasLimit;
-			} else {
-				userOp.callGasLimit = priorCallGasLimit;
 			}
 
 			// Overwrite paymaster gas fields with bundler-reported values when
@@ -550,8 +561,10 @@ export class Erc7677Paymaster extends Paymaster {
 				overrides.callGasLimitPercentageMultiplier ?? 10,
 			);
 
-		if (entrypoint === ENTRYPOINT_V6) {
+		if (entrypoint.toLowerCase() === ENTRYPOINT_V6.toLowerCase()) {
 			// Align with CandidePaymaster: add paymaster verification overhead for v0.6.
+			// Lowercase compare — overrides.entrypoint is arbitrary user input
+			// and ENTRYPOINT_V6 is checksummed.
 			userOp.verificationGasLimit += 40_000n;
 		}
 		// entrypoint v9 has no special handling here; kept for future use.
@@ -695,7 +708,7 @@ export class Erc7677Paymaster extends Paymaster {
 	 * Route to the correct provider-specific token quote fetcher.
 	 * Returns `null` when no provider is configured.
 	 */
-	public async fetchProviderTokenQuote(
+	private async fetchProviderTokenQuote(
 		tokenAddress: string,
 		entrypoint: string,
 		chainIdHex: string,

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -1,0 +1,451 @@
+import { Paymaster } from "./Paymaster";
+import { Bundler } from "../Bundler";
+import { sendJsonRpcRequest } from "../utils";
+import { AbstractionKitError, ensureError } from "../errors";
+import {
+	ENTRYPOINT_V6,
+	ENTRYPOINT_V7,
+	ENTRYPOINT_V8,
+	ENTRYPOINT_V9,
+} from "../constants";
+import type { StateOverrideSet } from "../types";
+import {
+	AnyUserOperation,
+	SameUserOp,
+	SmartAccountWithEntrypoint,
+	GasPaymasterUserOperationOverrides,
+} from "./types";
+
+/**
+ * Opaque context object forwarded to the paymaster RPC as the fourth argument
+ * of `pm_getPaymasterStubData` / `pm_getPaymasterData`.
+ *
+ * The shape is provider-specific: Pimlico uses `{ token }` for token paymaster
+ * and `{ sponsorshipPolicyId }` for sponsored operations; Alchemy, Biconomy,
+ * and others have their own conventions. Refer to the paymaster provider's
+ * documentation for the exact fields.
+ */
+export type Erc7677Context = Record<string, unknown>;
+
+/**
+ * Paymaster gas/data fields returned by `pm_getPaymasterStubData` and
+ * `pm_getPaymasterData` for EntryPoint v0.7+ UserOperations.
+ */
+export interface Erc7677PaymasterFields {
+	paymaster?: string;
+	paymasterData?: string;
+	paymasterVerificationGasLimit?: bigint | string;
+	paymasterPostOpGasLimit?: bigint | string;
+	/** Present on v0.6 responses; mutually exclusive with the split fields above. */
+	paymasterAndData?: string;
+}
+
+/**
+ * Response from `pm_getPaymasterStubData`. Includes `isFinal` when the paymaster
+ * signs immediately and does not require a follow-up `pm_getPaymasterData` call.
+ */
+export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
+	/** When true, skip pm_getPaymasterData and use these fields as the final signature. */
+	isFinal?: boolean;
+	[key: string]: unknown;
+}
+
+/**
+ * Generic ERC-7677 paymaster client.
+ *
+ * Speaks the [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) JSON-RPC
+ * protocol: `pm_getPaymasterStubData` for gas-estimation stubs and
+ * `pm_getPaymasterData` for the final signed paymaster fields. Works with any
+ * paymaster provider that implements the standard (Pimlico, Alchemy, Biconomy,
+ * etc.).
+ *
+ * For Candide-hosted paymasters, prefer {@link CandidePaymaster}, which uses
+ * cached `dummyPaymasterAndData` metadata to skip the stub round-trip and
+ * supports parallel signing phases.
+ *
+ * ## Flow
+ *
+ * {@link Erc7677Paymaster.createPaymasterUserOperation} runs the full pipeline:
+ *
+ * 1. `pm_getPaymasterStubData(userOp, entrypoint, chainId, context)` — stub
+ *    paymaster fields for gas estimation.
+ * 2. Apply stub fields to the UserOperation.
+ * 3. `eth_estimateUserOperationGas` via the bundler, reading back the bundler's
+ *    paymaster gas limits (v0.7+).
+ * 4. Apply gas limits to the UserOperation.
+ * 5. If the stub response includes `isFinal: true`, skip to step 7.
+ * 6. `pm_getPaymasterData(userOp, entrypoint, chainId, context)` — final
+ *    paymaster signature.
+ * 7. Return the UserOperation with paymaster fields populated, ready to sign.
+ *
+ * Owner signing is intentionally out of scope — call the smart account's
+ * `signUserOperation` (or your external signer) after this method returns.
+ *
+ * ## Token paymaster flows
+ *
+ * For ERC-20 gas payment, the consumer is responsible for:
+ *   - Prepending the `approve(paymasterAddress, amount)` call to their
+ *     UserOperation's callData *before* passing it to this class.
+ *   - Determining the approval amount (typically via a provider-specific
+ *     token-quotes endpoint such as Pimlico's `pimlico_getTokenQuotes`).
+ *   - Resetting non-zero allowances first when required by the token
+ *     (e.g. USDT on Ethereum mainnet).
+ *
+ * @example Sponsored UserOperation (Pimlico)
+ * ```ts
+ * const paymaster = new Erc7677Paymaster(pimlicoUrl);
+ * const [sponsoredOp] = await paymaster.createPaymasterUserOperation(
+ *   smartAccount,
+ *   userOp,
+ *   bundlerRpc,
+ *   { sponsorshipPolicyId: "sp_melted_jackpot" },
+ * );
+ * sponsoredOp.signature = smartAccount.signUserOperation(sponsoredOp, [pk], chainId);
+ * await new Bundler(bundlerRpc).sendUserOperation(sponsoredOp, smartAccount.entrypointAddress);
+ * ```
+ *
+ * @example Token paymaster (Pimlico, USDT)
+ * ```ts
+ * // Consumer prepends approve() to callData and passes the token context.
+ * userOp.callData = smartAccount.prependTokenPaymasterApproveToCallData(
+ *   userOp.callData, usdtAddress, paymasterAddress, approveAmount,
+ * );
+ * const [tokenOp] = await paymaster.createPaymasterUserOperation(
+ *   smartAccount,
+ *   userOp,
+ *   bundlerRpc,
+ *   { token: usdtAddress },
+ * );
+ * ```
+ */
+export class Erc7677Paymaster extends Paymaster {
+	/** The paymaster JSON-RPC endpoint URL */
+	readonly rpcUrl: string;
+	/** Cached chain ID (hex string). Passed via constructor or resolved from the bundler at first use. */
+	private chainId: string | null;
+
+	/**
+	 * @param rpcUrl - Paymaster JSON-RPC endpoint. Can be the same URL as the
+	 *   bundler when the provider bundles both (Pimlico, Alchemy); can also be
+	 *   a separate paymaster-only endpoint.
+	 * @param options.chainId - Optional hex-encoded chain id (e.g. `"0x1"`).
+	 *   When provided, avoids a lookup at first use. Otherwise, resolved from
+	 *   the bundler via `eth_chainId` on the first call.
+	 */
+	constructor(rpcUrl: string, options: { chainId?: string } = {}) {
+		super();
+		this.rpcUrl = rpcUrl;
+		this.chainId = options.chainId ?? null;
+	}
+
+	/**
+	 * Resolve the chain id, querying the bundler if not provided at construction.
+	 */
+	private async getChainId(bundlerRpc: string): Promise<string> {
+		if (this.chainId != null) return this.chainId;
+		const id = await new Bundler(bundlerRpc).chainId();
+		this.chainId = id;
+		return id;
+	}
+
+	/**
+	 * Determine the EntryPoint address from the UserOperation shape.
+	 * V6 ops have `initCode`, V8+ ops have `eip7702Auth`, V7 is the default.
+	 */
+	private resolveEntrypoint(
+		smartAccount: SmartAccountWithEntrypoint,
+		userOperation: AnyUserOperation,
+	): string {
+		if (
+			smartAccount.entrypointAddress != null &&
+			smartAccount.entrypointAddress.trim() !== ""
+		) {
+			return smartAccount.entrypointAddress;
+		}
+		if ("initCode" in userOperation) return ENTRYPOINT_V6;
+		if ("eip7702Auth" in userOperation) return ENTRYPOINT_V8;
+		return ENTRYPOINT_V7;
+	}
+
+	/**
+	 * Low-level ERC-7677 `pm_getPaymasterStubData` call.
+	 * Returns dummy paymaster fields intended for gas estimation.
+	 *
+	 * Most consumers should prefer {@link createPaymasterUserOperation}, which
+	 * runs the full stub → estimate → final pipeline. Use this directly if you
+	 * need to drive the flow manually.
+	 */
+	async getPaymasterStubData(
+		userOperation: AnyUserOperation,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context = {},
+	): Promise<Erc7677StubDataResult> {
+		try {
+			const result = await sendJsonRpcRequest(
+				this.rpcUrl,
+				"pm_getPaymasterStubData",
+				[userOperation, entrypoint, chainIdHex, context],
+			);
+			return result as Erc7677StubDataResult;
+		} catch (err) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"pm_getPaymasterStubData failed",
+				{ cause: ensureError(err) },
+			);
+		}
+	}
+
+	/**
+	 * Low-level ERC-7677 `pm_getPaymasterData` call.
+	 * Returns the final signed paymaster fields.
+	 */
+	async getPaymasterData(
+		userOperation: AnyUserOperation,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context = {},
+	): Promise<Erc7677PaymasterFields> {
+		try {
+			const result = await sendJsonRpcRequest(
+				this.rpcUrl,
+				"pm_getPaymasterData",
+				[userOperation, entrypoint, chainIdHex, context],
+			);
+			return result as Erc7677PaymasterFields;
+		} catch (err) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"pm_getPaymasterData failed",
+				{ cause: ensureError(err) },
+			);
+		}
+	}
+
+	/**
+	 * Runs the full ERC-7677 pipeline and returns a UserOperation with paymaster
+	 * fields populated. The caller is responsible for signing and sending.
+	 *
+	 * @param smartAccount - Provides the target EntryPoint; not mutated.
+	 * @param userOperation - Starting UserOperation. Not mutated — a shallow copy is returned.
+	 * @param bundlerRpc - Bundler URL used for gas estimation and, if
+	 *   `options.chainId` was not provided to the constructor, chain-id lookup.
+	 * @param context - Provider-specific paymaster context
+	 *   (e.g. `{ sponsorshipPolicyId }` or `{ token }`).
+	 * @param overrides - Gas estimation overrides and state-override set.
+	 *
+	 * @returns The UserOperation with paymaster + gas fields populated.
+	 */
+	async createPaymasterUserOperation<T extends AnyUserOperation>(
+		smartAccount: SmartAccountWithEntrypoint,
+		userOperation: T,
+		bundlerRpc: string,
+		context: Erc7677Context = {},
+		overrides: GasPaymasterUserOperationOverrides = {},
+	): Promise<SameUserOp<T>> {
+		try {
+			const userOp = { ...userOperation } as T;
+			const entrypoint =
+				overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
+			const chainIdHex = await this.getChainId(bundlerRpc);
+
+			// Step 1 — stub paymaster data for gas estimation.
+			const stub = await this.getPaymasterStubData(
+				userOp,
+				entrypoint,
+				chainIdHex,
+				context,
+			);
+			this.applyPaymasterFields(userOp, stub);
+
+			// Step 2 — gas estimation with the stub paymaster applied. When a
+			// paymaster is attached, v0.7+ bundlers return paymaster gas limits
+			// alongside the execution limits; they supersede the stub's
+			// placeholder values (Pimlico returns paymasterPostOpGasLimit: 0x1).
+			await this.estimateAndApplyGasLimits(
+				userOp,
+				bundlerRpc,
+				entrypoint,
+				overrides,
+			);
+
+			// Step 3 — if the stub was already final, we're done.
+			if (stub.isFinal === true) {
+				return userOp as unknown as SameUserOp<T>;
+			}
+
+			// Step 4 — final paymaster data (signature over the fully-populated userOp).
+			const final = await this.getPaymasterData(
+				userOp,
+				entrypoint,
+				chainIdHex,
+				context,
+			);
+			this.applyPaymasterFields(userOp, final);
+
+			return userOp as unknown as SameUserOp<T>;
+		} catch (err) {
+			const error = ensureError(err);
+			if (error instanceof AbstractionKitError) throw error;
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"createPaymasterUserOperation failed",
+				{ cause: error },
+			);
+		}
+	}
+
+	/**
+	 * Merge paymaster fields into a UserOperation. Handles both v0.6
+	 * (`paymasterAndData`) and v0.7+ split fields.
+	 */
+	private applyPaymasterFields(
+		userOp: AnyUserOperation,
+		fields: Erc7677PaymasterFields,
+	): void {
+		if ("initCode" in userOp) {
+			if (fields.paymasterAndData != null) {
+				userOp.paymasterAndData = fields.paymasterAndData;
+			}
+			return;
+		}
+		if (fields.paymaster != null) userOp.paymaster = fields.paymaster;
+		if (fields.paymasterData != null) userOp.paymasterData = fields.paymasterData;
+		if (fields.paymasterVerificationGasLimit != null) {
+			userOp.paymasterVerificationGasLimit = BigInt(
+				fields.paymasterVerificationGasLimit,
+			);
+		}
+		if (fields.paymasterPostOpGasLimit != null) {
+			userOp.paymasterPostOpGasLimit = BigInt(fields.paymasterPostOpGasLimit);
+		}
+	}
+
+	/**
+	 * Estimate gas limits via the bundler and apply them (with multipliers).
+	 * Reads paymaster gas fields back from the bundler when present — Pimlico's
+	 * `pm_getPaymasterStubData` returns `paymasterPostOpGasLimit: 0x1` as a
+	 * placeholder; the bundler's estimate has the real value.
+	 *
+	 * Mirrors CandidePaymaster.estimateAndApplyGasLimits default multipliers
+	 * (5%/10%/10% on preVerification/verification/call) for consistent UX.
+	 */
+	private async estimateAndApplyGasLimits(
+		userOp: AnyUserOperation,
+		bundlerRpc: string,
+		entrypoint: string,
+		overrides: GasPaymasterUserOperationOverrides,
+	): Promise<void> {
+		let preVerificationGas = userOp.preVerificationGas;
+		let verificationGasLimit = userOp.verificationGasLimit;
+		let callGasLimit = userOp.callGasLimit;
+
+		if (
+			overrides.preVerificationGas == null ||
+			overrides.verificationGasLimit == null ||
+			overrides.callGasLimit == null
+		) {
+			if (bundlerRpc == null) {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"bundlerRpc can't be null if preVerificationGas, verificationGasLimit and callGasLimit are not overridden",
+				);
+			}
+			const bundler = new Bundler(bundlerRpc);
+			const priorCallGasLimit = userOp.callGasLimit;
+			const priorVerificationGasLimit = userOp.verificationGasLimit;
+			const priorPreVerificationGas = userOp.preVerificationGas;
+			userOp.callGasLimit = 0n;
+			userOp.verificationGasLimit = 0n;
+			userOp.preVerificationGas = 0n;
+
+			const estimation = await bundler.estimateUserOperationGas(
+				userOp,
+				entrypoint,
+				overrides.state_override_set as StateOverrideSet | undefined,
+			);
+
+			if (estimation.preVerificationGas > preVerificationGas) {
+				preVerificationGas = estimation.preVerificationGas;
+			} else {
+				userOp.preVerificationGas = priorPreVerificationGas;
+			}
+			if (estimation.verificationGasLimit > verificationGasLimit) {
+				verificationGasLimit = estimation.verificationGasLimit;
+			} else {
+				userOp.verificationGasLimit = priorVerificationGasLimit;
+			}
+			if (estimation.callGasLimit > callGasLimit) {
+				callGasLimit = estimation.callGasLimit;
+			} else {
+				userOp.callGasLimit = priorCallGasLimit;
+			}
+
+			// Overwrite paymaster gas fields with bundler-reported values when
+			// available. Stub responses often leave these as placeholders.
+			if (
+				"paymaster" in userOp &&
+				estimation.paymasterVerificationGasLimit != null
+			) {
+				userOp.paymasterVerificationGasLimit =
+					estimation.paymasterVerificationGasLimit;
+			}
+			if (
+				"paymaster" in userOp &&
+				estimation.paymasterPostOpGasLimit != null
+			) {
+				userOp.paymasterPostOpGasLimit = estimation.paymasterPostOpGasLimit;
+			}
+		}
+
+		if (
+			typeof overrides.preVerificationGas === "bigint" &&
+			overrides.preVerificationGas < 0n
+		) {
+			throw new RangeError("preVerificationGas override can't be negative");
+		}
+		if (
+			typeof overrides.verificationGasLimit === "bigint" &&
+			overrides.verificationGasLimit < 0n
+		) {
+			throw new RangeError("verificationGasLimit override can't be negative");
+		}
+		if (
+			typeof overrides.callGasLimit === "bigint" &&
+			overrides.callGasLimit < 0n
+		) {
+			throw new RangeError("callGasLimit override can't be negative");
+		}
+
+		const applyMultiplier = (value: bigint, multiplier?: number): bigint =>
+			value +
+			(value * BigInt(Math.round((multiplier ?? 0) * 100))) / 10000n;
+
+		userOp.preVerificationGas =
+			overrides.preVerificationGas ??
+			applyMultiplier(
+				preVerificationGas,
+				overrides.preVerificationGasPercentageMultiplier ?? 5,
+			);
+		userOp.verificationGasLimit =
+			overrides.verificationGasLimit ??
+			applyMultiplier(
+				verificationGasLimit,
+				overrides.verificationGasLimitPercentageMultiplier ?? 10,
+			);
+		userOp.callGasLimit =
+			overrides.callGasLimit ??
+			applyMultiplier(
+				callGasLimit,
+				overrides.callGasLimitPercentageMultiplier ?? 10,
+			);
+
+		if (entrypoint === ENTRYPOINT_V6) {
+			// Align with CandidePaymaster: add paymaster verification overhead for v0.6.
+			userOp.verificationGasLimit += 40_000n;
+		}
+		// entrypoint v9 has no special handling here; kept for future use.
+		void ENTRYPOINT_V9;
+	}
+}

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -866,12 +866,11 @@ export class Erc7677Paymaster extends Paymaster {
 		}
 		userOp.callData = callDataWithApprove;
 
-		// Step 7 — if the stub was already final, we're done.
-		if (stub.isFinal === true) {
-			return userOp as unknown as SameUserOp<T>;
-		}
-
-		// Step 8 — final paymaster data (signature over the fully-populated userOp).
+		// Step 7 — final paymaster data (signature over the fully-populated
+		// userOp). The token flow always fetches fresh paymaster data: the
+		// stub's `isFinal` cannot be honored here because callData was mutated
+		// after the stub was generated, so any stub signature is over a
+		// different UserOp hash than the one we're about to return.
 		const final = await this.getPaymasterData(
 			userOp,
 			entrypoint,

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -763,7 +763,21 @@ export class Erc7677Paymaster extends Paymaster {
 		} else if (context.exchangeRate != null) {
 			// Case B: no provider, but exchangeRate in context.
 			// paymasterAddress is resolved from the stub response below.
-			exchangeRate = BigInt(context.exchangeRate as string | bigint);
+			try {
+				exchangeRate = BigInt(context.exchangeRate as string | bigint);
+			} catch (err) {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					`context.exchangeRate could not be parsed as a bigint: ${String(context.exchangeRate)}`,
+					{ cause: ensureError(err) },
+				);
+			}
+			if (exchangeRate <= 0n) {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					`context.exchangeRate must be > 0, got ${exchangeRate}`,
+				);
+			}
 		} else {
 			// Case C: no provider, no exchangeRate — fall through to regular flow.
 			return this.sponsoredFlow(

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -1,6 +1,6 @@
 import { Paymaster } from "./Paymaster";
 import { Bundler } from "../Bundler";
-import { sendJsonRpcRequest } from "../utils";
+import { calculateUserOperationMaxGasCost, sendJsonRpcRequest } from "../utils";
 import { AbstractionKitError, ensureError } from "../errors";
 import {
 	ENTRYPOINT_V6,
@@ -13,10 +13,23 @@ import {
 	AnyUserOperation,
 	SameUserOp,
 	SmartAccountWithEntrypoint,
+	PrependTokenPaymasterApproveAccount,
 	GasPaymasterUserOperationOverrides,
 	Erc7677Provider,
 	Erc7677PaymasterConstructorOptions,
 } from "./types";
+
+/** Max value for uint256 */
+const UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457584007913129639935n;
+/** Multiplier for token approve amount to cover paymasterAndData cost variance */
+const TOKEN_APPROVE_AMOUNT_MULTIPLIER = 2n;
+/**
+ * ERC-20 tokens that require resetting their allowance to 0 before setting a
+ * new approval amount (e.g. USDT on mainnet).
+ */
+const TOKENS_REQUIRING_ALLOWANCE_RESET: string[] = [
+	"0xdac17f958d2ee523a2206206994597c13d831ec7", // USDT (Ethereum mainnet)
+];
 
 /**
  * Opaque context object forwarded to the paymaster RPC as the fourth argument
@@ -86,18 +99,23 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  *
  * ## Token paymaster flows
  *
- * For ERC-20 gas payment, the consumer is responsible for:
- *   - Prepending the `approve(paymasterAddress, amount)` call to their
- *     UserOperation's callData *before* passing it to this class.
- *   - Determining the approval amount (typically via a provider-specific
- *     token-quotes endpoint such as Pimlico's `pimlico_getTokenQuotes`).
- *   - Resetting non-zero allowances first when required by the token
- *     (e.g. USDT on Ethereum mainnet).
+ * When `context.token` is set and the smart account implements
+ * `prependTokenPaymasterApproveToCallData`, the class automatically runs the
+ * token paymaster pipeline:
  *
- * @example Sponsored UserOperation (Pimlico)
+ * - **Provider detected** (Candide, Pimlico): fetches exchange rate and
+ *   paymaster address via provider-specific RPC, then handles approval
+ *   prepending, gas estimation, and final paymaster data automatically.
+ * - **No provider, `context.exchangeRate` set**: uses the provided rate;
+ *   paymaster address comes from `pm_getPaymasterStubData`.
+ * - **No provider, no `exchangeRate`**: falls through to the regular
+ *   sponsored flow — the developer is responsible for prepending the
+ *   approval and calculating the amount.
+ *
+ * @example Sponsored UserOperation (Candide)
  * ```ts
- * const paymaster = new Erc7677Paymaster(pimlicoUrl);
- * const [sponsoredOp] = await paymaster.createPaymasterUserOperation(
+ * const paymaster = new Erc7677Paymaster(candideUrl);
+ * const sponsoredOp = await paymaster.createPaymasterUserOperation(
  *   smartAccount,
  *   userOp,
  *   bundlerRpc,
@@ -107,17 +125,25 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * await new Bundler(bundlerRpc).sendUserOperation(sponsoredOp, smartAccount.entrypointAddress);
  * ```
  *
- * @example Token paymaster (Pimlico, USDT)
+ * @example Token paymaster (Candide — automatic, provider auto-detected)
  * ```ts
- * // Consumer prepends approve() to callData and passes the token context.
- * userOp.callData = smartAccount.prependTokenPaymasterApproveToCallData(
- *   userOp.callData, usdtAddress, paymasterAddress, approveAmount,
- * );
- * const [tokenOp] = await paymaster.createPaymasterUserOperation(
+ * const paymaster = new Erc7677Paymaster(candideUrl);
+ * const tokenOp = await paymaster.createPaymasterUserOperation(
  *   smartAccount,
  *   userOp,
  *   bundlerRpc,
  *   { token: usdtAddress },
+ * );
+ * ```
+ *
+ * @example Token paymaster (unknown provider, exchangeRate supplied)
+ * ```ts
+ * const paymaster = new Erc7677Paymaster(customUrl);
+ * const tokenOp = await paymaster.createPaymasterUserOperation(
+ *   smartAccount,
+ *   userOp,
+ *   bundlerRpc,
+ *   { token: usdtAddress, exchangeRate: "1000000000000000000" },
  * );
  * ```
  */
@@ -306,41 +332,32 @@ export class Erc7677Paymaster extends Paymaster {
 				overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 			const chainIdHex = await this.getChainId(bundlerRpc);
 
-			// Step 1 — stub paymaster data for gas estimation.
-			const stub = await this.getPaymasterStubData(
-				userOp,
-				entrypoint,
-				chainIdHex,
-				context,
-			);
-			this.applyPaymasterFields(userOp, stub);
+			// Token paymaster flow: triggered when context.token is set
+			if (
+				context.token != null &&
+				typeof context.token === "string"
+			) {
+				return this.tokenPaymasterFlow(
+					smartAccount as unknown as PrependTokenPaymasterApproveAccount,
+					userOp,
+					context.token as string,
+					bundlerRpc,
+					entrypoint,
+					chainIdHex,
+					context,
+					overrides,
+				);
+			}
 
-			// Step 2 — gas estimation with the stub paymaster applied. When a
-			// paymaster is attached, v0.7+ bundlers return paymaster gas limits
-			// alongside the execution limits; they supersede the stub's
-			// placeholder values (some providers return paymasterPostOpGasLimit: 0x1).
-			await this.estimateAndApplyGasLimits(
+			// Delegate to the sponsored flow (stub → estimate → final).
+			return this.sponsoredFlow(
 				userOp,
 				bundlerRpc,
 				entrypoint,
-				overrides,
-			);
-
-			// Step 3 — if the stub was already final, we're done.
-			if (stub.isFinal === true) {
-				return userOp as unknown as SameUserOp<T>;
-			}
-
-			// Step 4 — final paymaster data (signature over the fully-populated userOp).
-			const final = await this.getPaymasterData(
-				userOp,
-				entrypoint,
 				chainIdHex,
 				context,
+				overrides,
 			);
-			this.applyPaymasterFields(userOp, final);
-
-			return userOp as unknown as SameUserOp<T>;
 		} catch (err) {
 			const error = ensureError(err);
 			if (error instanceof AbstractionKitError) throw error;
@@ -503,5 +520,284 @@ export class Erc7677Paymaster extends Paymaster {
 		}
 		// entrypoint v9 has no special handling here; kept for future use.
 		void ENTRYPOINT_V9;
+	}
+
+	// ── Provider-specific exchange-rate helpers ──────────────────────────
+
+	/**
+	 * Fetch token exchange rate and paymaster address via Pimlico's
+	 * `pimlico_getTokenQuotes` RPC.
+	 */
+	private async fetchPimlicoTokenQuote(
+		tokenAddress: string,
+		entrypoint: string,
+		chainIdHex: string,
+	): Promise<{ exchangeRate: bigint; paymasterAddress: string }> {
+		const result = await sendJsonRpcRequest(
+			this.rpcUrl,
+			"pimlico_getTokenQuotes",
+			[{ tokens: [tokenAddress] }, entrypoint, chainIdHex],
+		) as { quotes?: Array<{ paymaster: string; token: string; exchangeRate: string }> };
+
+		const quotes = result?.quotes;
+		if (!Array.isArray(quotes) || quotes.length === 0) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`pimlico_getTokenQuotes returned no quotes for token ${tokenAddress}`,
+			);
+		}
+		const quote = quotes.find(
+			(q) => q.token.toLowerCase() === tokenAddress.toLowerCase(),
+		);
+		if (quote == null) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`pimlico_getTokenQuotes did not include token ${tokenAddress}`,
+			);
+		}
+		return {
+			exchangeRate: BigInt(quote.exchangeRate),
+			paymasterAddress: quote.paymaster,
+		};
+	}
+
+	/**
+	 * Fetch token exchange rate and paymaster address via Candide's
+	 * `pm_supportedERC20Tokens` RPC.
+	 */
+	private async fetchCandideTokenQuote(
+		tokenAddress: string,
+		entrypoint: string,
+	): Promise<{ exchangeRate: bigint; paymasterAddress: string }> {
+		const result = await sendJsonRpcRequest(
+			this.rpcUrl,
+			"pm_supportedERC20Tokens",
+			[entrypoint],
+		) as unknown as {
+			tokens: Array<{ address: string; exchangeRate: string }>;
+			paymasterMetadata: { address: string };
+		};
+
+		const token = result.tokens?.find(
+			(t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
+		);
+		if (token == null) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`${tokenAddress} token is not supported by the Candide paymaster`,
+			);
+		}
+		return {
+			exchangeRate: BigInt(token.exchangeRate),
+			paymasterAddress: result.paymasterMetadata.address,
+		};
+	}
+
+	/**
+	 * Route to the correct provider-specific token quote fetcher.
+	 * Returns `null` when no provider is configured.
+	 */
+	public async fetchProviderTokenQuote(
+		tokenAddress: string,
+		entrypoint: string,
+		chainIdHex: string,
+	): Promise<{ exchangeRate: bigint; paymasterAddress: string } | null> {
+		switch (this.provider) {
+			case "pimlico":
+				return this.fetchPimlicoTokenQuote(tokenAddress, entrypoint, chainIdHex);
+			case "candide":
+				return this.fetchCandideTokenQuote(tokenAddress, entrypoint);
+			default:
+				return null;
+		}
+	}
+
+	// ── Token paymaster flow ────────────────────────────────────────────
+
+	/**
+	 * Internal token paymaster pipeline. Called from `createPaymasterUserOperation`
+	 * when `context.token` is set and the smart account supports approval prepending.
+	 *
+	 * Three cases:
+	 * - **Provider detected**: exchange rate + paymaster address from provider RPC.
+	 * - **No provider, `context.exchangeRate` set**: uses provided rate, paymaster
+	 *   address from stub.
+	 * - **No provider, no rate**: falls through to the regular sponsored flow
+	 *   (developer already handled approval).
+	 */
+	private async tokenPaymasterFlow<T extends AnyUserOperation>(
+		smartAccount: PrependTokenPaymasterApproveAccount,
+		userOp: T,
+		tokenAddress: string,
+		bundlerRpc: string,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context,
+		overrides: GasPaymasterUserOperationOverrides,
+	): Promise<SameUserOp<T>> {
+		// Step 1 — resolve exchange rate + paymaster address.
+		let exchangeRate: bigint;
+		let paymasterAddress: string | null = null;
+
+		const providerQuote = await this.fetchProviderTokenQuote(
+			tokenAddress,
+			entrypoint,
+			chainIdHex,
+		);
+
+		if (providerQuote != null) {
+			// Case A: provider detected.
+			exchangeRate = providerQuote.exchangeRate;
+			paymasterAddress = providerQuote.paymasterAddress;
+		} else if (context.exchangeRate != null) {
+			// Case B: no provider, but exchangeRate in context.
+			// paymasterAddress is resolved from the stub response below.
+			exchangeRate = BigInt(context.exchangeRate as string | bigint);
+		} else {
+			// Case C: no provider, no exchangeRate — fall through to regular flow.
+			return this.sponsoredFlow(
+				userOp,
+				bundlerRpc,
+				entrypoint,
+				chainIdHex,
+				context,
+				overrides,
+			);
+		}
+
+		// Step 2 — stub paymaster data for gas estimation.
+		const stub = await this.getPaymasterStubData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, stub);
+
+		// For Case B, resolve paymasterAddress from stub or context override.
+		if (paymasterAddress == null) {
+			if (context.paymasterAddress != null) {
+				paymasterAddress = context.paymasterAddress as string;
+			} else if ("initCode" in userOp && stub.paymasterAndData != null) {
+				// v0.6: extract address from first 20 bytes of paymasterAndData.
+				paymasterAddress = "0x" + stub.paymasterAndData.slice(2, 42);
+			} else if (stub.paymaster != null) {
+				paymasterAddress = stub.paymaster;
+			} else {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					"pm_getPaymasterStubData did not return a paymaster address. " +
+					"Pass paymasterAddress in the context or set a provider.",
+				);
+			}
+		}
+
+		// Step 3 — save original callData, prepend approve(paymaster, UINT256_MAX).
+		const originalCallData = userOp.callData;
+		const requiresAllowanceReset = overrides.resetApproval
+			?? TOKENS_REQUIRING_ALLOWANCE_RESET.includes(tokenAddress.toLowerCase());
+
+		let callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+			userOp.callData,
+			tokenAddress,
+			paymasterAddress,
+			UINT256_MAX,
+		);
+		if (requiresAllowanceReset) {
+			callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+				callDataWithApprove,
+				tokenAddress,
+				paymasterAddress,
+				0n,
+			);
+		}
+		userOp.callData = callDataWithApprove;
+
+		// Step 4 — estimate gas limits.
+		await this.estimateAndApplyGasLimits(userOp, bundlerRpc, entrypoint, overrides);
+
+		// Step 5 — calculate real token cost.
+		const maxGasCostWei = calculateUserOperationMaxGasCost(userOp);
+		const tokenCost = (exchangeRate * maxGasCostWei) / (10n ** 18n);
+		const approveAmount = tokenCost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
+
+		// Step 6 — replace dummy approval with calculated amount on original callData.
+		callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+			originalCallData,
+			tokenAddress,
+			paymasterAddress,
+			approveAmount,
+		);
+		if (requiresAllowanceReset) {
+			callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+				callDataWithApprove,
+				tokenAddress,
+				paymasterAddress,
+				0n,
+			);
+		}
+		userOp.callData = callDataWithApprove;
+
+		// Step 7 — if the stub was already final, we're done.
+		if (stub.isFinal === true) {
+			return userOp as unknown as SameUserOp<T>;
+		}
+
+		// Step 8 — final paymaster data (signature over the fully-populated userOp).
+		const final = await this.getPaymasterData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, final);
+
+		return userOp as unknown as SameUserOp<T>;
+	}
+
+	/**
+	 * The regular (non-token) sponsored flow: stub → estimate → final.
+	 * Extracted to allow `tokenPaymasterFlow` to fall through to it for Case C.
+	 */
+	private async sponsoredFlow<T extends AnyUserOperation>(
+		userOp: T,
+		bundlerRpc: string,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context,
+		overrides: GasPaymasterUserOperationOverrides,
+	): Promise<SameUserOp<T>> {
+		// Step 1 — stub paymaster data for gas estimation.
+		const stub = await this.getPaymasterStubData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, stub);
+
+		// Step 2 — gas estimation with the stub paymaster applied.
+		await this.estimateAndApplyGasLimits(
+			userOp,
+			bundlerRpc,
+			entrypoint,
+			overrides,
+		);
+
+		// Step 3 — if the stub was already final, we're done.
+		if (stub.isFinal === true) {
+			return userOp as unknown as SameUserOp<T>;
+		}
+
+		// Step 4 — final paymaster data (signature over the fully-populated userOp).
+		const final = await this.getPaymasterData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, final);
+
+		return userOp as unknown as SameUserOp<T>;
 	}
 }

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -14,16 +14,18 @@ import {
 	SameUserOp,
 	SmartAccountWithEntrypoint,
 	GasPaymasterUserOperationOverrides,
+	Erc7677Provider,
+	Erc7677PaymasterConstructorOptions,
 } from "./types";
 
 /**
  * Opaque context object forwarded to the paymaster RPC as the fourth argument
  * of `pm_getPaymasterStubData` / `pm_getPaymasterData`.
  *
- * The shape is provider-specific: Pimlico uses `{ token }` for token paymaster
- * and `{ sponsorshipPolicyId }` for sponsored operations; Alchemy, Biconomy,
- * and others have their own conventions. Refer to the paymaster provider's
- * documentation for the exact fields.
+ * The shape is provider-specific: Candide uses `{ token }` for token paymaster
+ * and `{ sponsorshipPolicyId }` for sponsored operations; other providers
+ * (Pimlico, Alchemy, Biconomy, …) have their own conventions. Refer to the
+ * paymaster provider's documentation for the exact fields.
  */
 export type Erc7677Context = Record<string, unknown>;
 
@@ -56,12 +58,13 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * Speaks the [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) JSON-RPC
  * protocol: `pm_getPaymasterStubData` for gas-estimation stubs and
  * `pm_getPaymasterData` for the final signed paymaster fields. Works with any
- * paymaster provider that implements the standard (Pimlico, Alchemy, Biconomy,
- * etc.).
+ * paymaster provider that implements the standard (Candide, Pimlico, Alchemy,
+ * Biconomy, …).
  *
- * For Candide-hosted paymasters, prefer {@link CandidePaymaster}, which uses
- * cached `dummyPaymasterAndData` metadata to skip the stub round-trip and
- * supports parallel signing phases.
+ * For Candide-hosted paymasters, {@link CandidePaymaster} is the dedicated
+ * client and offers extra features (parallel signing phases, etc.). This
+ * generic class is provided so consumers retain the freedom to switch
+ * providers without changing the SDK.
  *
  * ## Flow
  *
@@ -123,19 +126,49 @@ export class Erc7677Paymaster extends Paymaster {
 	readonly rpcUrl: string;
 	/** Cached chain ID (hex string). Passed via constructor or resolved from the bundler at first use. */
 	private chainId: string | null;
+	/** Detected or explicitly set paymaster provider. `null` means no provider-specific features. */
+	readonly provider: Erc7677Provider;
+
+	/**
+	 * Detect the paymaster provider from the RPC URL hostname.
+	 * Returns `null` for unknown hosts or malformed URLs.
+	 *
+	 * Hostname-based (not substring) so that proxies or paths containing a
+	 * provider name (e.g. `https://my-proxy.com/pimlico-compat/...`) are not
+	 * misidentified.
+	 */
+	static detectProvider(rpcUrl: string): Erc7677Provider {
+		let host: string;
+		try {
+			host = new URL(rpcUrl).hostname.toLowerCase();
+		} catch {
+			return null;
+		}
+		if (host === "pimlico.io" || host.endsWith(".pimlico.io")) return "pimlico";
+		if (host === "candide.dev" || host.endsWith(".candide.dev")) return "candide";
+		return null;
+	}
 
 	/**
 	 * @param rpcUrl - Paymaster JSON-RPC endpoint. Can be the same URL as the
-	 *   bundler when the provider bundles both (Pimlico, Alchemy); can also be
-	 *   a separate paymaster-only endpoint.
-	 * @param options.chainId - Optional hex-encoded chain id (e.g. `"0x1"`).
-	 *   When provided, avoids a lookup at first use. Otherwise, resolved from
-	 *   the bundler via `eth_chainId` on the first call.
+	 *   bundler when the provider bundles both (Candide, Pimlico, Alchemy);
+	 *   can also be a separate paymaster-only endpoint.
+	 * @param options
+	 * @param options.chainId - Optional chain id as a bigint (e.g. `1n` for
+	 *   mainnet). When provided, avoids a lookup at first use. Otherwise,
+	 *   resolved from the bundler via `eth_chainId` on the first call.
+	 * @param options.provider - Paymaster provider. `"auto"` (default) detects
+	 *   from the RPC URL. Set explicitly to override, or `null` to disable.
 	 */
-	constructor(rpcUrl: string, options: { chainId?: string } = {}) {
+	constructor(rpcUrl: string, options: Erc7677PaymasterConstructorOptions = {}) {
 		super();
 		this.rpcUrl = rpcUrl;
-		this.chainId = options.chainId ?? null;
+		this.chainId = options.chainId != null ? "0x" + options.chainId.toString(16) : null;
+		if (options.provider === undefined || options.provider === "auto") {
+			this.provider = Erc7677Paymaster.detectProvider(rpcUrl);
+		} else {
+			this.provider = options.provider;
+		}
 	}
 
 	/**
@@ -224,6 +257,29 @@ export class Erc7677Paymaster extends Paymaster {
 	}
 
 	/**
+	 * Send an arbitrary JSON-RPC request through the paymaster endpoint.
+	 * Useful for provider-specific methods that fall outside the ERC-7677 spec.
+	 *
+	 * @param method - The JSON-RPC method name
+	 * @param params - The JSON-RPC params array
+	 * @returns The `result` field from the JSON-RPC response
+	 */
+	async sendRPCRequest(
+		method: string,
+		params: unknown[] = [],
+	): Promise<unknown> {
+		try {
+			return await sendJsonRpcRequest(this.rpcUrl, method, params);
+		} catch (err) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`sendRPCRequest(${method}) failed`,
+				{ cause: ensureError(err) },
+			);
+		}
+	}
+
+	/**
 	 * Runs the full ERC-7677 pipeline and returns a UserOperation with paymaster
 	 * fields populated. The caller is responsible for signing and sending.
 	 *
@@ -262,7 +318,7 @@ export class Erc7677Paymaster extends Paymaster {
 			// Step 2 — gas estimation with the stub paymaster applied. When a
 			// paymaster is attached, v0.7+ bundlers return paymaster gas limits
 			// alongside the execution limits; they supersede the stub's
-			// placeholder values (Pimlico returns paymasterPostOpGasLimit: 0x1).
+			// placeholder values (some providers return paymasterPostOpGasLimit: 0x1).
 			await this.estimateAndApplyGasLimits(
 				userOp,
 				bundlerRpc,
@@ -324,9 +380,9 @@ export class Erc7677Paymaster extends Paymaster {
 
 	/**
 	 * Estimate gas limits via the bundler and apply them (with multipliers).
-	 * Reads paymaster gas fields back from the bundler when present — Pimlico's
-	 * `pm_getPaymasterStubData` returns `paymasterPostOpGasLimit: 0x1` as a
-	 * placeholder; the bundler's estimate has the real value.
+	 * Reads paymaster gas fields back from the bundler when present — some
+	 * providers' `pm_getPaymasterStubData` returns `paymasterPostOpGasLimit: 0x1`
+	 * as a placeholder, relying on the bundler's estimate for the real value.
 	 *
 	 * Mirrors CandidePaymaster.estimateAndApplyGasLimits default multipliers
 	 * (5%/10%/10% on preVerification/verification/call) for consistent UX.

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -30,6 +30,13 @@ const TOKEN_APPROVE_AMOUNT_MULTIPLIER = 2n;
 const TOKENS_REQUIRING_ALLOWANCE_RESET: string[] = [
 	"0xdac17f958d2ee523a2206206994597c13d831ec7", // USDT (Ethereum mainnet)
 ];
+/**
+ * Time-to-live for cached Candide `pm_supportedERC20Tokens` responses, applied
+ * only when the fetch is initiated for an exchange-rate lookup. Stub-data
+ * lookups (paymaster address + dummyPaymasterAndData) reuse the cache
+ * indefinitely since those fields are effectively static per EP.
+ */
+const CANDIDE_TOKEN_QUOTE_TTL_MS = 45_000;
 
 /**
  * Opaque context object forwarded to the paymaster RPC as the fourth argument
@@ -147,6 +154,26 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * );
  * ```
  */
+/**
+ * Raw shape of Candide's `pm_supportedERC20Tokens` response.
+ * `dummyPaymasterAndData` is a concatenated hex string for EntryPoint v0.6 and
+ * a structured object for v0.7+.
+ */
+interface CandideSupportedResponse {
+	tokens: Array<{ address: string; exchangeRate: string }>;
+	paymasterMetadata: {
+		address: string;
+		dummyPaymasterAndData:
+			| string
+			| {
+				paymaster: string;
+				paymasterVerificationGasLimit: string;
+				paymasterPostOpGasLimit: string;
+				paymasterData: string;
+			};
+	};
+}
+
 export class Erc7677Paymaster extends Paymaster {
 	/** The paymaster JSON-RPC endpoint URL */
 	readonly rpcUrl: string;
@@ -154,6 +181,15 @@ export class Erc7677Paymaster extends Paymaster {
 	private chainId: string | null;
 	/** Detected or explicitly set paymaster provider. `null` means no provider-specific features. */
 	readonly provider: Erc7677Provider;
+	/**
+	 * Cached Candide `pm_supportedERC20Tokens` response, keyed by lowercase
+	 * entrypoint. Used for both token quotes and stub data to avoid a second
+	 * round-trip (`pm_getPaymasterStubData`) for Candide-hosted paymasters.
+	 *
+	 * The cache is indefinite for stub-data lookups but has a TTL for
+	 * exchange-rate lookups — see {@link CANDIDE_TOKEN_QUOTE_TTL_MS}.
+	 */
+	private candideCache = new Map<string, { data: CandideSupportedResponse; fetchedAt: number }>();
 
 	/**
 	 * Detect the paymaster provider from the RPC URL hostname.
@@ -562,6 +598,37 @@ export class Erc7677Paymaster extends Paymaster {
 	}
 
 	/**
+	 * Fetch (and cache) Candide's `pm_supportedERC20Tokens` response for the
+	 * given entrypoint. The response carries both exchange rates and the
+	 * `dummyPaymasterAndData` used for gas estimation, so one round-trip
+	 * suffices for the entire paymaster flow.
+	 *
+	 * @param options.enforceTTL - When true, re-fetches if the cached entry is
+	 *   older than {@link CANDIDE_TOKEN_QUOTE_TTL_MS}. Set by exchange-rate
+	 *   lookups (where staleness matters). Stub-data lookups leave this false
+	 *   and reuse the cache indefinitely — the paymaster address and
+	 *   `dummyPaymasterAndData` are effectively static per paymaster version.
+	 */
+	private async fetchCandideSupportedTokens(
+		entrypoint: string,
+		options: { enforceTTL?: boolean } = {},
+	): Promise<CandideSupportedResponse> {
+		const key = entrypoint.toLowerCase();
+		const cached = this.candideCache.get(key);
+		const isStale = cached != null
+			&& options.enforceTTL === true
+			&& Date.now() - cached.fetchedAt > CANDIDE_TOKEN_QUOTE_TTL_MS;
+		if (cached != null && !isStale) return cached.data;
+		const result = await sendJsonRpcRequest(
+			this.rpcUrl,
+			"pm_supportedERC20Tokens",
+			[entrypoint],
+		) as unknown as CandideSupportedResponse;
+		this.candideCache.set(key, { data: result, fetchedAt: Date.now() });
+		return result;
+	}
+
+	/**
 	 * Fetch token exchange rate and paymaster address via Candide's
 	 * `pm_supportedERC20Tokens` RPC.
 	 */
@@ -569,14 +636,7 @@ export class Erc7677Paymaster extends Paymaster {
 		tokenAddress: string,
 		entrypoint: string,
 	): Promise<{ exchangeRate: bigint; paymasterAddress: string }> {
-		const result = await sendJsonRpcRequest(
-			this.rpcUrl,
-			"pm_supportedERC20Tokens",
-			[entrypoint],
-		) as unknown as {
-			tokens: Array<{ address: string; exchangeRate: string }>;
-			paymasterMetadata: { address: string };
-		};
+		const result = await this.fetchCandideSupportedTokens(entrypoint, { enforceTTL: true });
 
 		const token = result.tokens?.find(
 			(t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
@@ -591,6 +651,44 @@ export class Erc7677Paymaster extends Paymaster {
 			exchangeRate: BigInt(token.exchangeRate),
 			paymasterAddress: result.paymasterMetadata.address,
 		};
+	}
+
+	/**
+	 * Convert Candide's `dummyPaymasterAndData` metadata into a stub result
+	 * compatible with {@link applyPaymasterFields}. Handles both v0.6
+	 * (concatenated hex string) and v0.7+ (structured) shapes.
+	 */
+	private candideStubFromMetadata(
+		metadata: CandideSupportedResponse["paymasterMetadata"],
+	): Erc7677StubDataResult {
+		const dummy = metadata.dummyPaymasterAndData;
+		if (typeof dummy === "string") {
+			return { paymasterAndData: dummy };
+		}
+		return {
+			paymaster: dummy.paymaster,
+			paymasterData: dummy.paymasterData,
+			paymasterVerificationGasLimit: dummy.paymasterVerificationGasLimit,
+			paymasterPostOpGasLimit: dummy.paymasterPostOpGasLimit,
+		};
+	}
+
+	/**
+	 * Get stub paymaster data. For Candide-hosted paymasters this derives the
+	 * stub from the cached `pm_supportedERC20Tokens` response (no extra
+	 * round-trip). For other providers, falls back to `pm_getPaymasterStubData`.
+	 */
+	private async getStubData(
+		userOperation: AnyUserOperation,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context,
+	): Promise<Erc7677StubDataResult> {
+		if (this.provider === "candide") {
+			const response = await this.fetchCandideSupportedTokens(entrypoint);
+			return this.candideStubFromMetadata(response.paymasterMetadata);
+		}
+		return this.getPaymasterStubData(userOperation, entrypoint, chainIdHex, context);
 	}
 
 	/**
@@ -666,7 +764,10 @@ export class Erc7677Paymaster extends Paymaster {
 		}
 
 		// Step 2 — stub paymaster data for gas estimation.
-		const stub = await this.getPaymasterStubData(
+		// For Candide, this is derived from the cached `pm_supportedERC20Tokens`
+		// response (same RPC call used for the exchange rate above) — no extra
+		// `pm_getPaymasterStubData` round-trip.
+		const stub = await this.getStubData(
 			userOp,
 			entrypoint,
 			chainIdHex,
@@ -768,7 +869,9 @@ export class Erc7677Paymaster extends Paymaster {
 		overrides: GasPaymasterUserOperationOverrides,
 	): Promise<SameUserOp<T>> {
 		// Step 1 — stub paymaster data for gas estimation.
-		const stub = await this.getPaymasterStubData(
+		// Candide-hosted paymasters skip `pm_getPaymasterStubData` and use the
+		// cached `pm_supportedERC20Tokens` response instead.
+		const stub = await this.getStubData(
 			userOp,
 			entrypoint,
 			chainIdHex,

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -44,8 +44,16 @@ const CANDIDE_TOKEN_QUOTE_TTL_MS = 45_000;
  *
  * The shape is provider-specific: Candide uses `{ token }` for token paymaster
  * and `{ sponsorshipPolicyId }` for sponsored operations; other providers
- * (Pimlico, Alchemy, Biconomy, …) have their own conventions. Refer to the
+ * (Pimlico, Alchemy, …) have their own conventions. Refer to the
  * paymaster provider's documentation for the exact fields.
+ *
+ * ## Reserved fields consumed by this class (not forwarded to the RPC)
+ *
+ * - `exchangeRate` - token-to-ETH exchange rate as a bigint or hex/decimal
+ *   string, scaled by 10^18 (i.e. the value of 1 ETH expressed in the token's
+ *   smallest unit). Used to calculate the ERC-20 approval amount when no
+ *   provider is auto-detected. Not needed when `provider` is `"pimlico"` or
+ *   `"candide"`; the class fetches the rate from the provider's RPC.
  */
 export type Erc7677Context = Record<string, unknown>;
 
@@ -78,8 +86,7 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * Speaks the [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) JSON-RPC
  * protocol: `pm_getPaymasterStubData` for gas-estimation stubs and
  * `pm_getPaymasterData` for the final signed paymaster fields. Works with any
- * paymaster provider that implements the standard (Candide, Pimlico, Alchemy,
- * Biconomy, …).
+ * paymaster provider that implements the standard (Candide, Pimlico, Alchemy, …).
  *
  * For Candide-hosted paymasters, {@link CandidePaymaster} is the dedicated
  * client and offers extra features (parallel signing phases, etc.). This
@@ -576,6 +583,10 @@ export class Erc7677Paymaster extends Paymaster {
 	/**
 	 * Fetch token exchange rate and paymaster address via Pimlico's
 	 * `pimlico_getTokenQuotes` RPC.
+	 *
+	 * @returns `exchangeRate` as a bigint scaled by 10^18 (the value of 1 ETH
+	 *   expressed in the token's smallest unit). Used to compute the token
+	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`.
 	 */
 	private async fetchPimlicoTokenQuote(
 		tokenAddress: string,
@@ -644,6 +655,10 @@ export class Erc7677Paymaster extends Paymaster {
 	/**
 	 * Fetch token exchange rate and paymaster address via Candide's
 	 * `pm_supportedERC20Tokens` RPC.
+	 *
+	 * @returns `exchangeRate` as a bigint scaled by 10^18 (the value of 1 ETH
+	 *   expressed in the token's smallest unit). Used to compute the token
+	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`.
 	 */
 	private async fetchCandideTokenQuote(
 		tokenAddress: string,

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -148,6 +148,20 @@ export interface PrependTokenPaymasterApproveAccount extends SmartAccountWithEnt
 	): string;
 }
 
+/** Known paymaster provider identifiers for provider-specific features (token quotes, etc.). */
+export type Erc7677Provider = "pimlico" | "candide" | null;
+
+/** Constructor options for {@link Erc7677Paymaster}. */
+export interface Erc7677PaymasterConstructorOptions {
+	/** Chain id as a bigint (e.g. `1n` for mainnet). Avoids a lookup at first use. */
+	chainId?: bigint;
+	/**
+	 * Paymaster provider. `"auto"` (default) detects from the RPC URL.
+	 * Set explicitly to override detection, or `null` to disable provider features.
+	 */
+	provider?: "auto" | Erc7677Provider;
+}
+
 /**
  * Base overrides for paymaster-assisted UserOperation creation.
  * Allows manually specifying the EntryPoint address instead of auto-detection.

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,10 @@ export type GasEstimationResult = {
 	preVerificationGas: bigint;
 	/** Estimated gas limit for verification step */
 	verificationGasLimit: bigint;
+	/** Paymaster verification gas limit (v0.7+ when a paymaster was attached) */
+	paymasterVerificationGasLimit?: bigint;
+	/** Paymaster post-op gas limit (v0.7+ when a paymaster was attached) */
+	paymasterPostOpGasLimit?: bigint;
 };
 
 /** Result of eth_getUserOperationByHash. Null if not found. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,9 +144,9 @@ export type GasEstimationResult = {
 	preVerificationGas: bigint;
 	/** Estimated gas limit for verification step */
 	verificationGasLimit: bigint;
-	/** Paymaster verification gas limit (v0.7+ when a paymaster was attached) */
+	/** Paymaster verification gas limit. Non-standard bundler extension; see `Bundler.estimateUserOperationGas`. */
 	paymasterVerificationGasLimit?: bigint;
-	/** Paymaster post-op gas limit (v0.7+ when a paymaster was attached) */
+	/** Paymaster post-op gas limit. Non-standard bundler extension; see `Bundler.estimateUserOperationGas`. */
 	paymasterPostOpGasLimit?: bigint;
 };
 

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -820,6 +820,65 @@ describe('Erc7677Paymaster', () => {
     }
   });
 
+  // ── Case B: invalid exchangeRate validation ─────────────────────────
+
+  test('Case B: unparseable exchangeRate throws AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: '0x' + 'aa'.repeat(20), exchangeRate: 'not-a-number' },
+        ),
+      ).rejects.toThrow(/exchangeRate could not be parsed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('Case B: zero exchangeRate throws AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: '0x' + 'aa'.repeat(20), exchangeRate: 0n },
+        ),
+      ).rejects.toThrow(/exchangeRate must be > 0/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('Case B: negative exchangeRate throws AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: '0x' + 'aa'.repeat(20), exchangeRate: '-1' },
+        ),
+      ).rejects.toThrow(/exchangeRate must be > 0/);
+    } finally {
+      await server.close();
+    }
+  });
+
   // ── Token paymaster flow: USDT allowance reset ──────────────────────
 
   test('USDT-like token gets approve(0) prepended', async () => {

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -59,6 +59,7 @@ function v7UserOp(overrides = {}) {
 }
 
 const CHAIN_ID_HEX = '0x1';
+const CHAIN_ID = 1n;
 const ENTRYPOINT_V7 = '0x0000000071727De22E5E9d8BAf0edAc6f37da032';
 
 describe('Erc7677Paymaster', () => {
@@ -86,7 +87,7 @@ describe('Erc7677Paymaster', () => {
     });
 
     try {
-      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
       const smartAccount = { entrypointAddress: ENTRYPOINT_V7 };
       const userOp = v7UserOp();
       const context = { sponsorshipPolicyId: 'sp_test' };
@@ -144,7 +145,7 @@ describe('Erc7677Paymaster', () => {
     });
 
     try {
-      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
       const out = await paymaster.createPaymasterUserOperation(
         { entrypointAddress: ENTRYPOINT_V7 },
         v7UserOp(),
@@ -180,7 +181,7 @@ describe('Erc7677Paymaster', () => {
     });
 
     try {
-      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
       const context = { token: '0xUsdt', custom: { nested: 'value' } };
       await paymaster.createPaymasterUserOperation(
         { entrypointAddress: ENTRYPOINT_V7 },
@@ -197,7 +198,7 @@ describe('Erc7677Paymaster', () => {
   test('paymaster RPC error surfaces as AbstractionKitError', async () => {
     const server = await makeMockRpcServer({});
     try {
-      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
       await expect(
         paymaster.createPaymasterUserOperation(
           { entrypointAddress: ENTRYPOINT_V7 },
@@ -222,6 +223,78 @@ describe('Erc7677Paymaster', () => {
       expect(stub.paymaster).toMatch(/^0xPaymaster/);
       const final = await paymaster.getPaymasterData(userOp, ENTRYPOINT_V7, CHAIN_ID_HEX, {});
       expect(final.paymasterData).toBe('0xfinal');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Provider detection ──────────────────────────────────────────────
+
+  test('auto-detects pimlico provider from URL', () => {
+    const paymaster = new Erc7677Paymaster('https://api.pimlico.io/v2/sepolia/rpc?apikey=test');
+    expect(paymaster.provider).toBe('pimlico');
+  });
+
+  test('auto-detects candide provider from URL', () => {
+    const paymaster = new Erc7677Paymaster('https://api.candide.dev/paymaster/v3/sepolia/xxx');
+    expect(paymaster.provider).toBe('candide');
+  });
+
+  test('auto-detects null for unknown URL', () => {
+    const paymaster = new Erc7677Paymaster('https://custom-rpc.example.com');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('auto-detect ignores provider name in path (proxy false-positive)', () => {
+    const paymaster = new Erc7677Paymaster('https://my-proxy.com/pimlico-compat/rpc');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('auto-detect ignores provider name in hostname suffix without dot delimiter', () => {
+    // evilpimlico.io ends with "pimlico.io" but is not a pimlico subdomain.
+    const paymaster = new Erc7677Paymaster('https://evilpimlico.io/rpc');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('auto-detect handles malformed URL by returning null', () => {
+    const paymaster = new Erc7677Paymaster('not-a-valid-url');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('explicit provider overrides auto-detection', () => {
+    const paymaster = new Erc7677Paymaster('https://api.pimlico.io/v2/sepolia/rpc', { provider: null });
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('explicit provider on non-matching URL', () => {
+    const paymaster = new Erc7677Paymaster('https://custom-proxy.example.com', { provider: 'pimlico' });
+    expect(paymaster.provider).toBe('pimlico');
+  });
+
+  // ── sendRPCRequest ──────────────────────────────────────────────────
+
+  test('sendRPCRequest forwards method and params', async () => {
+    const server = await makeMockRpcServer({
+      custom_method: (params) => ({ echo: params }),
+    });
+    try {
+      const paymaster = new Erc7677Paymaster(server.url);
+      const result = await paymaster.sendRPCRequest('custom_method', ['arg1', 'arg2']);
+      expect(result).toEqual({ echo: ['arg1', 'arg2'] });
+      expect(server.calls[0].method).toBe('custom_method');
+      expect(server.calls[0].params).toEqual(['arg1', 'arg2']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('sendRPCRequest wraps errors as AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url);
+      await expect(
+        paymaster.sendRPCRequest('nonexistent_method'),
+      ).rejects.toThrow(/sendRPCRequest\(nonexistent_method\) failed/);
     } finally {
       await server.close();
     }

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -73,10 +73,11 @@ function makeTokenAccount(entrypoint) {
     calls,
     prependTokenPaymasterApproveToCallData(callData, tokenAddress, paymasterAddress, approveAmount) {
       calls.push({ callData, tokenAddress, paymasterAddress, approveAmount });
-      // Simple simulation: prefix a marker so we can verify the call happened.
-      // In the real code this would re-encode MultiSend calldata.
+      // Simulate the real prepend semantics: the approve call comes BEFORE
+      // the original callData in execution order (Safe MultiSend / Calibur
+      // BatchedCall / Simple executeBatch all prepend).
       const marker = `approve(${paymasterAddress},${approveAmount.toString(16)})`;
-      return `${callData}::${marker}`;
+      return `${marker}::${callData}`;
     },
   };
 }

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -820,6 +820,53 @@ describe('Erc7677Paymaster', () => {
     }
   });
 
+  // ── Token flow ignores stub.isFinal (callData mutates after stub) ──
+
+  test('token flow still calls pm_getPaymasterData even when stub.isFinal is true', async () => {
+    const PAYMASTER_ADDR = '0x' + 'ee'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'ff'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+        isFinal: true, // would be unsafe to honor — callData mutates after stub
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' },
+      );
+
+      // pm_getPaymasterData was called even though the stub claimed isFinal:
+      // the token flow mutates callData, so the stub's signature would be
+      // invalid against the final UserOp hash.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toContain('pm_getPaymasterData');
+      expect(out.paymasterData).toBe('0xfinal');
+    } finally {
+      await server.close();
+    }
+  });
+
   // ── Case B: invalid exchangeRate validation ─────────────────────────
 
   test('Case B: unparseable exchangeRate throws AbstractionKitError', async () => {

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -62,6 +62,25 @@ const CHAIN_ID_HEX = '0x1';
 const CHAIN_ID = 1n;
 const ENTRYPOINT_V7 = '0x0000000071727De22E5E9d8BAf0edAc6f37da032';
 
+/**
+ * Minimal smart account that implements prependTokenPaymasterApproveToCallData.
+ * Tracks calls for assertion purposes.
+ */
+function makeTokenAccount(entrypoint) {
+  const calls = [];
+  return {
+    entrypointAddress: entrypoint,
+    calls,
+    prependTokenPaymasterApproveToCallData(callData, tokenAddress, paymasterAddress, approveAmount) {
+      calls.push({ callData, tokenAddress, paymasterAddress, approveAmount });
+      // Simple simulation: prefix a marker so we can verify the call happened.
+      // In the real code this would re-encode MultiSend calldata.
+      const marker = `approve(${paymasterAddress},${approveAmount.toString(16)})`;
+      return `${callData}::${marker}`;
+    },
+  };
+}
+
 describe('Erc7677Paymaster', () => {
   test('createPaymasterUserOperation runs stub → estimate → final', async () => {
     const server = await makeMockRpcServer({
@@ -295,6 +314,393 @@ describe('Erc7677Paymaster', () => {
       await expect(
         paymaster.sendRPCRequest('nonexistent_method'),
       ).rejects.toThrow(/sendRPCRequest\(nonexistent_method\) failed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case A (Pimlico provider) ─────────────────
+
+  test('Case A: pimlico provider runs full token flow', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20);
+    const EXCHANGE_RATE = '0xde0b6b3a7640000'; // 1e18
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: EXCHANGE_RATE,
+          postOpGas: '0x1000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0x1',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+        paymasterVerificationGasLimit: '0x9999',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinaltoken',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Call order: pimlico_getTokenQuotes → stub → estimate → final.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pimlico_getTokenQuotes',
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // Final paymaster data applied.
+      expect(out.paymasterData).toBe('0xfinaltoken');
+
+      // prependTokenPaymasterApproveToCallData was called (first with MAX, then with calculated).
+      expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
+
+      // Input not mutated.
+      expect(userOp.paymasterData).toBe(null);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case A (Candide provider) ─────────────────
+
+  test('Case A: candide provider runs full token flow', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: { address: PAYMASTER_ADDR },
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalcandide',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Call order: pm_supportedERC20Tokens → stub → estimate → final.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_supportedERC20Tokens',
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      expect(out.paymasterData).toBe('0xfinalcandide');
+      expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case B (exchangeRate in context) ──────────
+
+  test('Case B: no provider, exchangeRate in context runs token flow', async () => {
+    const PAYMASTER_ADDR = '0x' + 'ee'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'ff'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalrate',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' },
+      );
+
+      // No provider-specific RPC call.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // Paymaster address from stub was used in approve calls.
+      expect(smartAccount.calls[0].paymasterAddress).toBe(PAYMASTER_ADDR);
+      expect(out.paymasterData).toBe('0xfinalrate');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case C (fallthrough) ──────────────────────
+
+  test('Case C: no provider, no exchangeRate falls through to sponsored flow', async () => {
+    const PAYMASTER_ADDR = '0x' + '11'.repeat(20);
+    const TOKEN_ADDR = '0x' + '22'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalsponsored',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const originalCallData = '0xoriginal';
+      const userOp = v7UserOp({ callData: originalCallData });
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR }, // no exchangeRate
+      );
+
+      // Regular sponsored flow — no provider RPC, no prependTokenPaymasterApproveToCallData calls.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // prependTokenPaymasterApproveToCallData was NOT called.
+      expect(smartAccount.calls.length).toBe(0);
+
+      // context.token was forwarded to paymaster RPCs.
+      expect(server.calls[0].params[3]).toEqual({ token: TOKEN_ADDR });
+      expect(out.paymasterData).toBe('0xfinalsponsored');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: USDT allowance reset ──────────────────────
+
+  test('USDT-like token gets approve(0) prepended', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    // Mainnet USDT address (in the TOKENS_REQUIRING_ALLOWANCE_RESET list)
+    const USDT_ADDR = '0xdac17f958d2ee523a2206206994597c13d831ec7';
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: USDT_ADDR,
+          exchangeRate: '0xde0b6b3a7640000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalusdt',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: USDT_ADDR },
+      );
+
+      // Should have approve(0) calls (for reset) in addition to approve(MAX) and approve(calculated).
+      const zeroApproveCalls = smartAccount.calls.filter((c) => c.approveAmount === 0n);
+      expect(zeroApproveCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: resetApproval override ────────────────────
+
+  test('resetApproval override forces approve(0) for non-USDT token', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20); // Not USDT
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: '0xde0b6b3a7640000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+        { resetApproval: true },
+      );
+
+      // Should have approve(0) calls even though token is not USDT.
+      const zeroApproveCalls = smartAccount.calls.filter((c) => c.approveAmount === 0n);
+      expect(zeroApproveCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: input not mutated ─────────────────────────
+
+  test('token flow does not mutate the input UserOperation', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: '0xde0b6b3a7640000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+      const originalCallData = userOp.callData;
+      const originalPaymasterData = userOp.paymasterData;
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      expect(userOp.callData).toBe(originalCallData);
+      expect(userOp.paymasterData).toBe(originalPaymasterData);
     } finally {
       await server.close();
     }

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -280,6 +280,48 @@ describe('Erc7677Paymaster', () => {
     expect(paymaster.provider).toBe(null);
   });
 
+  // ── Entrypoint case-sensitivity ─────────────────────────────────────
+
+  test('lowercase v0.6 entrypoint override applies the +40_000n overhead', async () => {
+    // ENTRYPOINT_V6 is checksummed in constants.ts; user input may be lowercase.
+    const ENTRYPOINT_V6_LOWER = '0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789';
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
+      const out = await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+        {},
+        { entrypoint: ENTRYPOINT_V6_LOWER },
+      );
+
+      // verificationGasLimit = (0x2000 + 10%) + 40_000n overhead.
+      const baseVgl = 0x2000n + (0x2000n * 1000n) / 10000n;
+      expect(out.verificationGasLimit).toBe(baseVgl + 40_000n);
+    } finally {
+      await server.close();
+    }
+  });
+
   test('explicit provider overrides auto-detection', () => {
     const paymaster = new Erc7677Paymaster('https://api.pimlico.io/v2/sepolia/rpc', { provider: null });
     expect(paymaster.provider).toBe(null);

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -1,0 +1,229 @@
+const http = require('node:http');
+const { Erc7677Paymaster } = require('../../dist/index.cjs');
+
+jest.setTimeout(30000);
+
+/**
+ * Spin up a local HTTP server that responds to a scripted sequence of
+ * JSON-RPC calls. The paymaster class has no network knowledge beyond the
+ * RPC URL we hand it, so a tiny loopback server is enough to cover the
+ * happy path + every branch of the flow.
+ */
+function makeMockRpcServer(handlers) {
+  const calls = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      const { method, params, id } = JSON.parse(body);
+      calls.push({ method, params });
+      const handler = handlers[method];
+      const payload = handler == null
+        ? { id, jsonrpc: '2.0', error: { code: -32601, message: `no mock for ${method}` } }
+        : { id, jsonrpc: '2.0', result: handler(params) };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        calls,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+function v7UserOp(overrides = {}) {
+  return {
+    sender: '0x' + '1'.repeat(40),
+    nonce: 0n,
+    callData: '0x',
+    callGasLimit: 0n,
+    verificationGasLimit: 0n,
+    preVerificationGas: 0n,
+    maxFeePerGas: 1_000_000_000n,
+    maxPriorityFeePerGas: 100_000_000n,
+    signature: '0x',
+    factory: null,
+    factoryData: null,
+    paymaster: null,
+    paymasterVerificationGasLimit: null,
+    paymasterPostOpGasLimit: null,
+    paymasterData: null,
+    ...overrides,
+  };
+}
+
+const CHAIN_ID_HEX = '0x1';
+const ENTRYPOINT_V7 = '0x0000000071727De22E5E9d8BAf0edAc6f37da032';
+
+describe('Erc7677Paymaster', () => {
+  test('createPaymasterUserOperation runs stub → estimate → final', async () => {
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xabcd',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0x1', // placeholder — bundler returns real
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+        paymasterVerificationGasLimit: '0x9999',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xfinal',
+        paymasterVerificationGasLimit: '0x9999',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const smartAccount = { entrypointAddress: ENTRYPOINT_V7 };
+      const userOp = v7UserOp();
+      const context = { sponsorshipPolicyId: 'sp_test' };
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        context,
+      );
+
+      // Final paymaster fields populated from pm_getPaymasterData.
+      expect(out.paymasterData).toBe('0xfinal');
+      // Bundler gas limits applied (with default 5%/10%/10% multipliers).
+      expect(out.preVerificationGas).toBe(0x3000n + (0x3000n * 500n) / 10000n);
+      expect(out.verificationGasLimit).toBe(0x2000n + (0x2000n * 1000n) / 10000n);
+      expect(out.callGasLimit).toBe(0x1000n + (0x1000n * 1000n) / 10000n);
+      // Paymaster gas fields taken from bundler estimation, not the stub placeholder.
+      expect(out.paymasterPostOpGasLimit).toBe(0xa000n);
+      expect(out.paymasterVerificationGasLimit).toBe(0x9999n);
+
+      // Input was not mutated.
+      expect(userOp.paymasterData).toBe(null);
+
+      // Call order: stub → estimate → final.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // Context forwarded verbatim.
+      expect(server.calls[0].params[3]).toEqual(context);
+      expect(server.calls[2].params[3]).toEqual(context);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('stub with isFinal: true skips pm_getPaymasterData', async () => {
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xonly',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+        isFinal: true,
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const out = await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      expect(out.paymasterData).toBe('0xonly');
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual(['pm_getPaymasterStubData', 'eth_estimateUserOperationGas']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('forwards provider-specific context verbatim', async () => {
+    let stubContext = null;
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: (params) => {
+        stubContext = params[3];
+        return {
+          paymaster: '0xPaymaster'.padEnd(42, '0'),
+          paymasterData: '0x',
+          paymasterVerificationGasLimit: '0x8000',
+          paymasterPostOpGasLimit: '0xa000',
+          isFinal: true,
+        };
+      },
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      const context = { token: '0xUsdt', custom: { nested: 'value' } };
+      await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+        context,
+      );
+      expect(stubContext).toEqual(context);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('paymaster RPC error surfaces as AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID_HEX });
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          { entrypointAddress: ENTRYPOINT_V7 },
+          v7UserOp(),
+          server.url,
+        ),
+      ).rejects.toThrow(/pm_getPaymasterStubData failed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('getPaymasterStubData and getPaymasterData can be called independently', async () => {
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({ paymaster: '0xPaymaster'.padEnd(42, '0') }),
+      pm_getPaymasterData: () => ({ paymaster: '0xPaymaster'.padEnd(42, '0'), paymasterData: '0xfinal' }),
+    });
+    try {
+      const paymaster = new Erc7677Paymaster(server.url);
+      const userOp = v7UserOp();
+      const stub = await paymaster.getPaymasterStubData(userOp, ENTRYPOINT_V7, CHAIN_ID_HEX, {});
+      expect(stub.paymaster).toMatch(/^0xPaymaster/);
+      const final = await paymaster.getPaymasterData(userOp, ENTRYPOINT_V7, CHAIN_ID_HEX, {});
+      expect(final.paymasterData).toBe('0xfinal');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -397,13 +397,15 @@ describe('Erc7677Paymaster', () => {
     const server = await makeMockRpcServer({
       pm_supportedERC20Tokens: () => ({
         tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
-        paymasterMetadata: { address: PAYMASTER_ADDR },
-      }),
-      pm_getPaymasterStubData: () => ({
-        paymaster: PAYMASTER_ADDR,
-        paymasterData: '0xstub',
-        paymasterVerificationGasLimit: '0x8000',
-        paymasterPostOpGasLimit: '0xa000',
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
       }),
       eth_estimateUserOperationGas: () => ({
         callGasLimit: '0x1000',
@@ -428,17 +430,240 @@ describe('Erc7677Paymaster', () => {
         { token: TOKEN_ADDR },
       );
 
-      // Call order: pm_supportedERC20Tokens → stub → estimate → final.
+      // Call order: pm_supportedERC20Tokens → estimate → final.
+      // No pm_getPaymasterStubData — stub data comes from the cached response.
       const methods = server.calls.map((c) => c.method);
       expect(methods).toEqual([
         'pm_supportedERC20Tokens',
-        'pm_getPaymasterStubData',
         'eth_estimateUserOperationGas',
         'pm_getPaymasterData',
       ]);
 
       expect(out.paymasterData).toBe('0xfinalcandide');
       expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Candide sponsored flow: skips pm_getPaymasterStubData ──────────
+
+  test('Candide provider: sponsored flow skips pm_getPaymasterStubData', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalsponsored',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const out = await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      // Call order: pm_supportedERC20Tokens → estimate → final.
+      // Skips pm_getPaymasterStubData by deriving stub from the cached response.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_supportedERC20Tokens',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+      expect(out.paymasterData).toBe('0xfinalsponsored');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Candide TTL: token flow re-fetches after 45s ────────────────────
+
+  test('Candide provider: token flow re-fetches pm_supportedERC20Tokens after TTL', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    jest.useFakeTimers({ doNotFake: ['setTimeout', 'setInterval', 'setImmediate', 'clearTimeout', 'clearInterval', 'clearImmediate', 'nextTick', 'queueMicrotask'] });
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      // 1st token flow call — fetches pm_supportedERC20Tokens.
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Advance time past the 45s TTL.
+      jest.setSystemTime(new Date('2024-01-01T00:00:46Z'));
+
+      // 2nd token flow call — TTL expired, should re-fetch.
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      const supportedCalls = server.calls.filter((c) => c.method === 'pm_supportedERC20Tokens');
+      expect(supportedCalls.length).toBe(2);
+    } finally {
+      jest.useRealTimers();
+      await server.close();
+    }
+  });
+
+  test('Candide provider: sponsored flow uses cache indefinitely (ignores TTL)', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    jest.useFakeTimers({ doNotFake: ['setTimeout', 'setInterval', 'setImmediate', 'clearTimeout', 'clearInterval', 'clearImmediate', 'nextTick', 'queueMicrotask'] });
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+
+      // 1st sponsored call — fetches pm_supportedERC20Tokens for stub data.
+      await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      // Advance time far past TTL.
+      jest.setSystemTime(new Date('2024-01-01T01:00:00Z'));
+
+      // 2nd sponsored call — TTL does NOT apply, reuses cache.
+      await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      const supportedCalls = server.calls.filter((c) => c.method === 'pm_supportedERC20Tokens');
+      expect(supportedCalls.length).toBe(1);
+    } finally {
+      jest.useRealTimers();
+      await server.close();
+    }
+  });
+
+  // ── Candide: single pm_supportedERC20Tokens call for combined flow ──
+
+  test('Candide provider: only one pm_supportedERC20Tokens call (cached)', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Token quote + stub data both come from a SINGLE pm_supportedERC20Tokens call.
+      const supportedCalls = server.calls.filter((c) => c.method === 'pm_supportedERC20Tokens');
+      expect(supportedCalls.length).toBe(1);
     } finally {
       await server.close();
     }


### PR DESCRIPTION
## Summary

Adds `Erc7677Paymaster` — a provider-agnostic client that speaks the [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) JSON-RPC protocol (`pm_getPaymasterStubData` + `pm_getPaymasterData`). Works with any paymaster that implements the standard (Pimlico, Alchemy, Biconomy, …), complementing the existing `CandidePaymaster`.

Also fixes `Bundler.estimateUserOperationGas` to forward `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit` when returned by v0.7+ bundlers. The `Erc7677Paymaster` pipeline needs these: Pimlico's `pm_getPaymasterStubData` returns `paymasterPostOpGasLimit: 0x1` as a placeholder and relies on the bundler's estimate for the real value.

## Why

`CandidePaymaster` is first-class but Pimlico / Alchemy / any ERC-7677 provider required a hand-rolled adapter on the consumer side (~100 LOC of `pm_getPaymasterStubData` + `pm_getPaymasterData` glue). `Erc7677Paymaster` makes that work one line:

```ts
const paymaster = new Erc7677Paymaster(pimlicoUrl);
const sponsoredOp = await paymaster.createPaymasterUserOperation(
  smartAccount, userOp, bundlerRpc,
  { sponsorshipPolicyId: "sp_melted_jackpot" },
);
```

## API

```ts
class Erc7677Paymaster extends Paymaster {
  readonly rpcUrl: string
  constructor(rpcUrl: string, options?: { chainId?: string })

  // Low-level ERC-7677 RPC
  getPaymasterStubData(userOp, entrypoint, chainIdHex, context?)
  getPaymasterData(userOp, entrypoint, chainIdHex, context?)

  // Full pipeline: stub → estimate via bundler → (unless isFinal) getPaymasterData
  createPaymasterUserOperation<T>(
    smartAccount, userOp, bundlerRpc, context?, overrides?
  ): Promise<SameUserOp<T>>
}
```

`context` is passed through verbatim — provider-specific shape (`{ sponsorshipPolicyId }`, `{ token }`, etc.). Token-paymaster approve logic stays with the consumer because approve-amount lookup and USDT-style allowance resets are provider-specific; the class doesn't try to standardize that.

## Scope

- **No `createTokenPaymasterUserOperation` wrapper** in this PR. Token-paymaster flows need a provider-specific quote endpoint (Pimlico's `pimlico_getTokenQuotes`, etc.) and per-token approve semantics. Happy to add one later if a clean abstraction emerges.
- **No `createSponsorPaymasterUserOperation` wrapper** in this PR. It would just be `createPaymasterUserOperation(..., { sponsorshipPolicyId })`. Keeping the surface minimal.

## Compatibility

Strictly additive, no breaking changes:

- `GasEstimationResult` gains two **optional** fields. Existing destructuring unaffected.
- `Bundler.estimateUserOperationGas` same return type. When the bundler returns no paymaster fields, output is bit-for-bit identical to before.
- All existing exports unchanged.

Verified every call site of `bundler.estimateUserOperationGas` in AK (`CandidePaymaster`, `SafeAccount`, `Calibur7702Account`, `Simple7702Account`, `WorldIdPermissionlessPaymaster`) only reads the three original fields. Nothing changes for them.

## Tests

New unit tests (`test/paymaster/erc7677Paymaster.test.js`) cover the happy path and every branch via a local mock JSON-RPC server:

- `createPaymasterUserOperation` runs stub → estimate → final in order
- `isFinal: true` on the stub skips `pm_getPaymasterData`
- Provider-specific context forwarded verbatim
- RPC error surfaces as `AbstractionKitError`
- Low-level `getPaymasterStubData` / `getPaymasterData` usable independently

5/5 pass. Existing tests that don't require network env vars also pass (`calibur7702Account`, `caliburEncoding`). Tests that were env-gated on `main` (`safeAccount`, `simpleEip7702`, `caliburLifecycle`, `caliburPaymasterV9`, etc.) remain env-gated — those failures reproduce on upstream `main` without any of my changes, and are unrelated to this PR. Heads-up: `calibur7702Account.test.js` emits an unhandled async rejection (`AbstractionKitError: getNonce failed`) after its tests complete, which on Node.js 25 can appear to "fail" whichever test file runs next under `--runInBand`. Also pre-existing on `main` — not introduced here.

## End-to-end validation

Validated against live Pimlico and Candide bundlers on Sepolia via Tether's WDK integration (28/28 flows pass):

- **Sponsored** (gasless) — quote + send + receipt
- **Token paymaster** (USDT) — quote + send + receipt + `transfer()` ERC-20 path
- **Native coin** — quote + send + receipt

Tx hashes available on request.

## Test plan

- [x] New unit tests pass
- [x] Existing suites unaffected (parity with `main`)
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Build succeeds (`yarn build`)
- [x] Live Sepolia against Pimlico — all flows pass
- [x] Live Sepolia against Candide — all flows pass (existing `CandidePaymaster` continues working)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ERC-7677 paymaster integration with automatic provider detection for popular paymaster services.
  * Token paymaster flow with automated ERC-20 approval handling, allowance management, and exchange-rate support.
  * Gas estimation enhanced to surface paymaster-specific gas limits and apply paymaster-aware multipliers.

* **Tests**
  * Comprehensive test suite covering paymaster flows, provider behaviors, gas handling, caching, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->