### PR TITLE
feat(paymaster): hoist signingPhase to top-level override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   // After (0.3.0):
   await paymaster.createSponsorPaymasterUserOperation(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId, overrides);
   ```
-  The `overrides` parameter type is also richer: it now accepts a `context?: CandidePaymasterContext` field for passing `sponsorshipPolicyId` and the new parallel-signing `signingPhase` option through overrides.
+  The `overrides` parameter type is also richer: it now accepts a `context?: CandidePaymasterContext` field (forwarded as-is to the paymaster RPC), a top-level `signingPhase?: SigningPhase` for the new parallel-signing flow, and the existing gas limit / multiplier overrides.
 - **`createPaymasterUserOperation` has been removed.** Use `createSponsorPaymasterUserOperation` or `createTokenPaymasterUserOperation` directly.
 - **CandidePaymaster now uses the `pm_getPaymasterData` JSON-RPC method** internally. Paymaster types have been unified and restructured.
 - **`PaymasterInitValues` renamed to `ParallelPaymasterInitValues`.**
@@ -65,7 +65,24 @@ The wildcard re-export `export * from "./account/Safe/safeMessage"` has been rep
 #### Parallel Paymaster Signing (EntryPoint v0.9)
 
 - **`ExperimentalAllowAllParallelPaymaster`**: an experimental paymaster for the parallel-signing flow.
-- **`signingPhase`** added to `CandidePaymasterContext`, with values `"commit"` and `"finalize"`. Enables parallel-signing flows where owner signing and the paymaster's final signature can happen independently, via the `PAYMASTER_SIG_MAGIC` convention on `paymasterData`. Works with EntryPoint v0.9 only.
+- **`signingPhase`** top-level override on `GasPaymasterUserOperationOverrides`, typed with the exported `SigningPhase` constant (`SigningPhase.Commit` / `SigningPhase.Finalize`). Enables parallel-signing flows where owner signing and the paymaster's final signature can happen independently, via the `PAYMASTER_SIG_MAGIC` convention on `paymasterData`. Works with EntryPoint v0.9 only.
+
+  Migration (only affects callers already on the 0.3.0 parallel-signing flow):
+  ```ts
+  // Before
+  await paymaster.createSponsorPaymasterUserOperation(
+    smartAccount, userOp, bundlerRpc, sponsorshipPolicyId,
+    { context: { signingPhase: "commit" as const } },
+  );
+
+  // After
+  import { SigningPhase } from "abstractionkit";
+  await paymaster.createSponsorPaymasterUserOperation(
+    smartAccount, userOp, bundlerRpc, sponsorshipPolicyId,
+    { signingPhase: SigningPhase.Commit },
+  );
+  ```
+  `signingPhase` is no longer a field on `CandidePaymasterContext`. String literals (`"commit"` / `"finalize"`) still type-check against `SigningPhase`, so the constant is recommended but not required.
 - `CandidePaymaster` supports both v0.9 parallel flows and the existing sequential flow.
 
 #### Safe Accounts

--- a/README.md
+++ b/README.md
@@ -189,17 +189,19 @@ const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
 
 As of v0.3.0, `CandidePaymasterContext` is passed via the `overrides.context` field on `GasPaymasterUserOperationOverrides`. Previously it was a separate top level argument.
 
+The parallel-signing `signingPhase` is a top-level override, not a context field. Use the exported `SigningPhase` constant to avoid `as const` and get autocomplete.
+
 ```typescript
+import { SigningPhase } from "abstractionkit";
+
 const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
   smartAccount,
   userOp,
   bundlerRpc,
   sponsorshipPolicyId,
   {
-    context: {
-      // For EntryPoint v0.9 parallel signing flows:
-      // signingPhase: "commit" | "finalize",
-    },
+    // EntryPoint v0.9 parallel signing:
+    signingPhase: SigningPhase.Commit, // or SigningPhase.Finalize
     // gas overrides also live here:
     callGasLimitPercentageMultiplier: 110,
   },

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -104,6 +104,7 @@ export type {
 	AnyUserOperation,
 	SameUserOp,
 } from "./paymaster/types";
+export { SigningPhase } from "./paymaster/types";
 
 export { Operation, GasOption, PolygonChain } from "./types";
 export type {

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -16,8 +16,19 @@ import {
 	PrependTokenPaymasterApproveAccount,
 	GasPaymasterUserOperationOverrides,
 	AnyUserOperation,
-	SameUserOp, SmartAccountWithEntrypoint,
+	SameUserOp,
+	SigningPhase,
+	SmartAccountWithEntrypoint,
 } from "./types";
+
+/**
+ * Wire-level context payload sent to the paymaster JSON-RPC. Extends the
+ * public {@link CandidePaymasterContext} with the hoisted `signingPhase` so
+ * callers can set it at the top level of overrides.
+ */
+type WirePaymasterContext = CandidePaymasterContext & {
+	signingPhase?: SigningPhase;
+};
 import { Bundler } from "src/Bundler";
 import { AbstractionKitError, ensureError } from "src/errors";
 import {ENTRYPOINT_V8, ENTRYPOINT_V7, ENTRYPOINT_V6, ENTRYPOINT_V9} from "src/constants";
@@ -502,10 +513,26 @@ export class CandidePaymaster extends Paymaster {
 
 	// ── Core paymaster method (private) ──────────────────────────────
 
+	/**
+	 * Merge a public {@link CandidePaymasterContext} with the hoisted
+	 * `signingPhase` into the wire-level payload forwarded to the paymaster
+	 * JSON-RPC. When `signingPhase` is undefined the field is omitted so the
+	 * default single-step flow is preserved on the wire.
+	 */
+	private buildWireContext(
+		context: CandidePaymasterContext,
+		signingPhase: SigningPhase | undefined,
+	): WirePaymasterContext {
+		if (signingPhase === undefined) {
+			return context;
+		}
+		return { ...context, signingPhase };
+	}
+
 	private async createPaymasterUserOperation<T extends AnyUserOperation>(
 		smartAccount: SmartAccountWithEntrypoint,
 		userOperation: T,
-		context: CandidePaymasterContext = {},
+		context: WirePaymasterContext = {},
 		overrides: GasPaymasterUserOperationOverrides = {},
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
 		try {
@@ -551,7 +578,11 @@ export class CandidePaymaster extends Paymaster {
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
 		const userOp = { ...userOperation } as T;
-		const context: CandidePaymasterContext = {sponsorshipPolicyId, ...(overrides?.context || {}) };
+		const signingPhase = overrides?.signingPhase;
+		const context = this.buildWireContext(
+			{sponsorshipPolicyId, ...(overrides?.context || {})},
+			signingPhase,
+		);
 		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 		await this.ensureInitialized(entrypoint);
 		const epData = this.getEntrypointData(entrypoint);
@@ -560,7 +591,7 @@ export class CandidePaymaster extends Paymaster {
 				`UserOperation for entrypoint ${entrypoint} is not supported`,
 			);
 		}
-		if (context.signingPhase !== "finalize"){
+		if (signingPhase !== "finalize"){
 			this.setDummyPaymasterFields(userOp, epData);
 			await this.estimateAndApplyGasLimits(userOp, bundlerRpc, entrypoint, overrides ?? {});
 		}
@@ -596,10 +627,14 @@ export class CandidePaymaster extends Paymaster {
 	): Promise<SameUserOp<T>> {
 		try {
 			const userOp = { ...userOperation } as T;
-			const context: CandidePaymasterContext = { token: tokenAddress, ...(overrides?.context || {}) };
+			const signingPhase = overrides?.signingPhase;
+			const context = this.buildWireContext(
+				{ token: tokenAddress, ...(overrides?.context || {}) },
+				signingPhase,
+			);
 			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 			await this.ensureInitialized(entrypoint);
-			if (context.signingPhase !== "finalize"){
+			if (signingPhase !== "finalize"){
 				const epData = this.getEntrypointData(entrypoint);
 				if (epData == null) {
 					throw new RangeError(

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -15,11 +15,28 @@ export type SameUserOp<T extends AnyUserOperation> =
 	UserOperationV6;
 
 /**
+ * Signing phase for the **parallel signing** feature. Only relevant for
+ * EntryPoint v0.9 accounts that use `PAYMASTER_SIG_MAGIC`-aware paymasters.
+ *
+ * Use the {@link SigningPhase} constant for call sites (e.g. `SigningPhase.Commit`)
+ * so TypeScript narrows the literal without needing `as const`.
+ */
+export const SigningPhase = {
+	Commit: 'commit',
+	Finalize: 'finalize',
+} as const;
+
+export type SigningPhase = typeof SigningPhase[keyof typeof SigningPhase];
+
+/**
  * Context passed to the Candide paymaster RPC when requesting sponsorship
  * or ERC-20 token payment for gas.
  *
  * This context is forwarded as the fourth argument to the `pm_getPaymasterData`
- * JSON-RPC call on the Candide paymaster.
+ * JSON-RPC call on the Candide paymaster. It carries `token` and
+ * `sponsorshipPolicyId`. The parallel-signing `signingPhase` is hoisted to
+ * the top-level {@link GasPaymasterUserOperationOverrides.signingPhase} field
+ * and injected into this context internally before the RPC call.
  *
  * @example Sponsored (gasless) UserOperation
  * ```ts
@@ -35,91 +52,12 @@ export type SameUserOp<T extends AnyUserOperation> =
  *   smartAccount, userOp, USDC_ADDRESS, bundlerRpc,
  * );
  * ```
- *
- * @example Parallel signing with `signingPhase` (two-step commit/finalize)
- * ```ts
- * // ── Step 1: COMMIT ──
- * // Request initial paymaster fields with dummy signature.
- * // The paymaster returns gas limits and init paymasterData (ending with
- * // PAYMASTER_SIG_MAGIC) so owners can sign in parallel without waiting
- * // for the final paymaster signature.
- * const [commitOp] = await paymaster.createSponsorPaymasterUserOperation(
- *   smartAccount, userOp, bundlerRpc,
- *   sponsorshipPolicyId,
- *   { signingPhase: "commit" },
- * );
- *
- * // Sign the UserOperation (safe because the UserOp hash is stable —
- * // the PAYMASTER_SIG_MAGIC boundary ensures the hash stays the same
- * // whether init or final paymasterData is used).
- * commitOp.signature = smartAccount.signUserOperation(
- *   commitOp, [signer], chainId,
- * );
- *
- * // ── Step 2: FINALIZE ──
- * // Send the already-signed UserOperation back to the paymaster.
- * // The paymaster replaces the init paymasterData with the final
- * // paymaster signature. Gas estimation is skipped (already done in commit).
- * const [finalOp] = await paymaster.createSponsorPaymasterUserOperation(
- *   smartAccount, commitOp, bundlerRpc,
- *   sponsorshipPolicyId,
- *   { signingPhase: "finalize" },
- * );
- *
- * // Send the finalized UserOperation to the bundler.
- * const response = await smartAccount.sendUserOperation(finalOp, bundlerRpc);
- * ```
  */
 export interface CandidePaymasterContext {
 	/** ERC-20 token address to use for gas payment. Omit for sponsored (gasless) operations. */
 	token?: string;
 	/** Sponsorship policy identifier for the Candide paymaster. */
 	sponsorshipPolicyId?: string;
-	/**
-	 * Signing phase for the **parallel signing** feature. Only relevant for
-	 * EntryPoint v0.9 accounts that use `PAYMASTER_SIG_MAGIC`-aware paymasters.
-	 *
-	 * Parallel signing decouples owner signing from the paymaster's final
-	 * signature. This is useful when multiple owners need to co-sign a
-	 * UserOperation (e.g. multi-sig wallets) or when the signing step happens
-	 * on a separate device/service. Without parallel signing, you would need
-	 * the final paymaster signature before owners can sign, creating a
-	 * sequential dependency.
-	 *
-	 * ## How it works
-	 *
-	 * EntryPoint v0.9 introduces the `PAYMASTER_SIG_MAGIC` convention: when
-	 * computing the UserOperation hash, the `paymasterData` is truncated at
-	 * the magic boundary (`22e325a297439656`). This means the hash is
-	 * identical whether the paymasterData contains the init placeholder or
-	 * the final paymaster signature — so owners can safely sign the
-	 * UserOperation before the paymaster has issued its real signature.
-	 *
-	 * ## Two-phase flow
-	 *
-	 * **`"commit"`** — First call. The paymaster:
-	 *   1. Sets dummy paymaster fields for gas estimation.
-	 *   2. Estimates gas limits via the bundler.
-	 *   3. Returns init `paymasterData` ending with `PAYMASTER_SIG_MAGIC`.
-	 *   After this call, the UserOp is ready for owner signing.
-	 *
-	 * **`"finalize"`** — Second call. The paymaster:
-	 *   1. Skips gas estimation (already done in commit).
-	 *   2. Replaces the init `paymasterData` with the real paymaster signature.
-	 *   After this call, the UserOp is ready to be sent to the bundler.
-	 *
-	 * ## When to use
-	 *
-	 * - Multi-owner accounts where owners sign in parallel on different devices.
-	 * - Flows where the signing step is asynchronous (e.g. hardware wallets,
-	 *   approval queues, cross-chain multi-sig via `SafeMultiChainSigAccount`).
-	 * - Any scenario where you need a stable UserOp hash before the paymaster
-	 *   commits its final signature.
-	 *
-	 * If omitted, the default single-step flow is used: gas estimation,
-	 * paymaster signature, and owner signing all happen sequentially.
-	 */
-	signingPhase?: 'commit' | 'finalize';
 }
 
 export interface SmartAccountWithEntrypoint {
@@ -182,4 +120,74 @@ export interface GasPaymasterUserOperationOverrides extends BasePaymasterUserOpe
 	state_override_set?: StateOverrideSet;
 
 	context?: CandidePaymasterContext;
+
+	/**
+	 * Signing phase for the **parallel signing** feature. Only relevant for
+	 * EntryPoint v0.9 accounts that use `PAYMASTER_SIG_MAGIC`-aware paymasters.
+	 *
+	 * Parallel signing decouples owner signing from the paymaster's final
+	 * signature. This is useful when multiple owners need to co-sign a
+	 * UserOperation (e.g. multi-sig wallets) or when the signing step happens
+	 * on a separate device/service. Without parallel signing, you would need
+	 * the final paymaster signature before owners can sign, creating a
+	 * sequential dependency.
+	 *
+	 * ## How it works
+	 *
+	 * EntryPoint v0.9 introduces the `PAYMASTER_SIG_MAGIC` convention: when
+	 * computing the UserOperation hash, the `paymasterData` is truncated at
+	 * the magic boundary (`22e325a297439656`). The hash is identical whether
+	 * the paymasterData contains the init placeholder or the final paymaster
+	 * signature, so owners can safely sign the UserOperation before the
+	 * paymaster has issued its real signature.
+	 *
+	 * ## Two-phase flow
+	 *
+	 * **`SigningPhase.Commit`** (first call). The paymaster:
+	 *   1. Sets dummy paymaster fields for gas estimation.
+	 *   2. Estimates gas limits via the bundler.
+	 *   3. Returns init `paymasterData` ending with `PAYMASTER_SIG_MAGIC`.
+	 *   After this call, the UserOp is ready for owner signing.
+	 *
+	 * **`SigningPhase.Finalize`** (second call). The paymaster:
+	 *   1. Skips gas estimation (already done in commit).
+	 *   2. Replaces the init `paymasterData` with the real paymaster signature.
+	 *   After this call, the UserOp is ready to be sent to the bundler.
+	 *
+	 * ## When to use
+	 *
+	 * - Multi-owner accounts where owners sign in parallel on different devices.
+	 * - Flows where the signing step is asynchronous (e.g. hardware wallets,
+	 *   approval queues, cross-chain multi-sig via `SafeMultiChainSigAccount`).
+	 * - Any scenario where you need a stable UserOp hash before the paymaster
+	 *   commits its final signature.
+	 *
+	 * If omitted, the default single-step flow is used: gas estimation,
+	 * paymaster signature, and owner signing all happen sequentially.
+	 *
+	 * @example
+	 * ```ts
+	 * import { SigningPhase } from "abstractionkit";
+	 *
+	 * // Step 1: commit. Returns a UserOp with stable hash and init paymasterData.
+	 * const [commitOp] = await paymaster.createSponsorPaymasterUserOperation(
+	 *   smartAccount, userOp, bundlerRpc,
+	 *   sponsorshipPolicyId,
+	 *   { signingPhase: SigningPhase.Commit },
+	 * );
+	 *
+	 * // Owners sign in parallel. The hash is stable across commit/finalize.
+	 * commitOp.signature = smartAccount.signUserOperation(commitOp, [signer], chainId);
+	 *
+	 * // Step 2: finalize. The paymaster replaces the init data with its real signature.
+	 * const [finalOp] = await paymaster.createSponsorPaymasterUserOperation(
+	 *   smartAccount, commitOp, bundlerRpc,
+	 *   sponsorshipPolicyId,
+	 *   { signingPhase: SigningPhase.Finalize },
+	 * );
+	 *
+	 * await smartAccount.sendUserOperation(finalOp, bundlerRpc);
+	 * ```
+	 */
+	signingPhase?: SigningPhase;
 }


### PR DESCRIPTION
## Summary

- Lift `signingPhase` out of `CandidePaymasterContext` onto `GasPaymasterUserOperationOverrides` as a first-class override.
- Export a typed `SigningPhase` constant / union so call sites read `{ signingPhase: SigningPhase.Commit }` instead of `{ context: { signingPhase: "commit" as const } }` (no `as const`, works with autocomplete, one canonical pattern).
- Paymaster JSON-RPC wire format is unchanged: a private `buildWireContext` helper merges the hoisted phase into the forwarded context.

## Why

The 0.3.0 shape (`overrides.context.signingPhase`) had three pain points: it required `as const` at call sites, was nested two levels deep, and made the commit/finalize lifecycle hard to discover. Hoisting to a top-level override with a typed constant fixes all three without adding new method variants, and keeps the lifecycle visible in code.

## Breaking change (scoped)

Breaking for callers on the 0.3.0 parallel-signing flow only. `signingPhase` is no longer a field on `CandidePaymasterContext`; values buried inside `overrides.context` are ignored. The default single-step flow (no `signingPhase`) is unchanged end-to-end. Migration snippet added inline to the 0.3.0 CHANGELOG section. Version bump and release CHANGELOG entry will happen on the release PR into \`main\`.

## Test plan

- [x] \`npm run build\` green; generated \`dist/index.d.mts\` shows \`SigningPhase\` exported as const + union and \`signingPhase\` on \`GasPaymasterUserOperationOverrides\` (not on \`CandidePaymasterContext\`)
- [ ] Manual smoke test of the commit/finalize flow against a v0.9 paymaster
- [ ] Verify existing non-parallel sponsor and token paymaster calls still work unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `SigningPhase` constants (`Commit`, `Finalize`) for parallel paymaster signing.

* **Bug Fixes / Improvements**
  * Restructured parallel signing API: `signingPhase` is now a top-level field in `GasPaymasterUserOperationOverrides` instead of nested in context, providing a cleaner and more intuitive interface.

* **Documentation**
  * Updated examples and changelog to reflect the new API structure for parallel signing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->