### PR TITLE
Release 0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/dist/**
 **/.env
 *.log
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.1
+
+### New Features
+
+- **`Erc7677Paymaster`**: provider-agnostic [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) paymaster client. Works with any compliant provider (Candide, Pimlico, Alchemy, ...). Auto-detects Candide/Pimlico from the URL and runs the full stub, estimate, and final pipeline in one call. Passing `{ token }` in context triggers the ERC-20 gas flow automatically.
+- `Bundler.estimateUserOperationGas` now forwards `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit` when returned by the bundler.
+
+### Breaking Changes
+
+- **`SafeMultiChainSigAccountV1.formatSignaturesToUseroperationsSignatures`**: the third `overrides` argument has been removed. Overrides are now per-operation via a new optional `overrides` field on each `UserOperationToSignWithOverrides` element of the first argument. Migration: `ops.map(op => ({ ...op, overrides: {...} }))` and drop the third argument.
+
+### Other
+
+- Minor type tightening across Calibur, Simple7702, and Tenderly helpers.
+
 ## 0.3.0
 
 **This is a major release. The canonical upgrade path is from 0.2.30 (previous stable) to 0.3.0 (current stable).** Versions 0.2.31 through 0.2.41 were experimental pre-releases and are not on the `latest` dist-tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,112 +2,133 @@
 
 ## 0.3.0
 
+**This is a major release. The canonical upgrade path is from 0.2.30 (previous stable) to 0.3.0 (current stable).** Versions 0.2.31 through 0.2.41 were experimental pre-releases and are not on the `latest` dist-tag.
+
 ### Breaking Changes
 
 #### Build & Runtime
 
-- **Node.js >= 18 required** — native `fetch` is now used; `isomorphic-unfetch` has been removed as a dependency.
-- **Build system switched from microbundle to tsdown** — dist output paths have changed:
-  - `dist/index.js` → `dist/index.cjs`
-  - `dist/index.m.js` → `dist/index.mjs`
-  - `dist/index.umd.js` → `dist/index.iife.js`
-  - `dist/index.d.ts` → `dist/index.d.cts`
-  - Proper `exports` map added to `package.json` for ESM/CJS resolution.
+- **Node.js >= 18 required.** Native `fetch` is now used; `isomorphic-unfetch` has been removed as a dependency.
+- **Build system switched from microbundle to tsdown.** Dist output paths have changed. If you import from a subpath, update your references:
+  - `dist/index.js` -> `dist/index.cjs`
+  - `dist/index.m.js` -> `dist/index.mjs`
+  - `dist/index.umd.js` -> `dist/index.iife.js`
+  - `dist/index.d.ts` -> `dist/index.d.cts`
+  - A proper `exports` map has been added to `package.json` for ESM/CJS resolution, so normal `import { X } from "abstractionkit"` consumers are unaffected.
 
-#### API Changes
+#### Paymaster API
 
-- **`signUserOperation` now only accepts a private key.** Use the new `signUserOperationWithSigner` method for external/custom signers.
-- **`createPaymasterUserOperation` removed.** Use `CandidePaymaster` methods directly.
-- **CandidePaymaster migrated to `pm_getPaymasterData` RPC** — paymaster types have been unified and restructured.
+- **`CandidePaymaster.createSponsorPaymasterUserOperation(...)` signature changed.** The method now takes `smartAccount` as the **first** argument. Migration:
+  ```ts
+  // Before (0.2.30):
+  await paymaster.createSponsorPaymasterUserOperation(userOp, bundlerRpc, sponsorshipPolicyId, overrides);
+
+  // After (0.3.0):
+  await paymaster.createSponsorPaymasterUserOperation(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId, overrides);
+  ```
+  The `overrides` parameter type is also richer: it now accepts a `context?: CandidePaymasterContext` field for passing `sponsorshipPolicyId` and the new parallel-signing `signingPhase` option through overrides.
+- **`createPaymasterUserOperation` has been removed.** Use `createSponsorPaymasterUserOperation` or `createTokenPaymasterUserOperation` directly.
+- **CandidePaymaster now uses the `pm_getPaymasterData` JSON-RPC method** internally. Paymaster types have been unified and restructured.
 - **`PaymasterInitValues` renamed to `ParallelPaymasterInitValues`.**
 
-#### Renames
+#### TypeScript Export Changes (`isolatedModules` compatibility)
 
-| Before | After |
-|--------|-------|
-| `ExperimentalSafeMultiChainSigAccount` | `SafeMultiChainSigAccountV1` |
-| `ExperimentalAllowAllPaymaster` | `ExperimentalAllowAllParallelPaymaster` |
-| `EIP712_MULTI_SAFE_OPERATIONS_TYPE` | `EIP712_MULTI_CHAIN_OPERATIONS_TYPE` |
-| `listKeys` (Calibur) | `getKeys` |
-
-#### TypeScript Export Changes
-
-Several interfaces and types are now exported as `export type` instead of `export` for `isolatedModules` compatibility. This is only breaking if you re-export them with `export { X } from "abstractionkit"` — change to `export type { X }`:
+Many interfaces and types are now exported with `export type` instead of `export`. This is only breaking if you re-export them yourself with `export { X } from "abstractionkit"`, in which case change to `export type { X }`. Affected identifiers include:
 
 - `RecoveryRequest`, `RecoverySignaturePair`, `RecoveryRequestTypedDataDomain`, `RecoveryRequestTypedMessageValue`
 - `Allowance`
 - `DepositInfo`
 - `Authorization7702Hex`, `Authorization7702`
 - `CandidePaymasterContext`, `PrependTokenPaymasterApproveAccount`
-- `UserOperationV6`, `UserOperationV7`, `UserOperationV8`, `AbiInputValue`, `JsonRpcParam`, `JsonRpcResponse`, `MetaTransaction`, `StateOverrideSet`, etc.
+- `UserOperationV6`, `UserOperationV7`, `UserOperationV8`, `UserOperationV9`, `AbiInputValue`, `JsonRpcParam`, `JsonRpcResponse`, `MetaTransaction`, `StateOverrideSet`, and other non-runtime types from `./types`
+- `CreateUserOperationV6Overrides`, `CreateUserOperationV7Overrides`, `CreateUserOperationV9Overrides`, `ECDSAPublicAddress`, `InitCodeOverrides`, `SafeUserOperationTypedDataDomain`, `WebauthnPublicKey`, `WebauthnSignatureData`, `SignerSignaturePair`, `Signer`
 - `SafeMessageTypedDataDomain`, `SafeMessageTypedMessageValue`
-- `SafeUserOperationTypedDataDomain`, `WebauthnPublicKey`, `WebauthnSignatureData`, `SignerSignaturePair`, `Signer`, etc.
 
-The wildcard re-export `export * from "./account/Safe/safeMessage"` has been replaced with explicit named exports.
+The wildcard re-export `export * from "./account/Safe/safeMessage"` has been replaced with explicit named exports (`SAFE_MESSAGE_PRIMARY_TYPE`, `SAFE_MESSAGE_MODULE_TYPE`, `getSafeMessageEip712Data`).
 
 ### New Features
 
-#### EIP-7702 Support
+#### New Account Classes
 
-- **`Simple7702Account`** — EIP-7702 account for EntryPoint v0.8.
-- **`Simple7702AccountV09`** — EIP-7702 account for EntryPoint v0.9, with parallel paymaster support.
-- **`Calibur7702Account`** — full-featured EIP-7702 account with WebAuthn/passkey support, key management, delegation auto-checking, and delegation revocation.
-- **`getDelegatedAddress`** utility for checking EIP-7702 delegation status.
-- **EIP-7702 delegation helpers** on `BaseSimple7702Account` (create, sign, and revoke delegation authorizations).
-- **Tenderly simulation support** for EntryPoint v0.9.
+- **`Calibur7702Account`**: full-featured EIP-7702 smart account for EntryPoint v0.8, ported from Uniswap's Calibur. Supports secp256k1, P256, and WebAuthn P256 keys with per-key permissions and expirations. Includes key management (register, revoke, update settings via self-calls), automatic EIP-7702 delegation authoring and checking, and delegation revocation. Also exports `CaliburKeyType` and the `CaliburKey`, `CaliburKeySettings`, `CaliburKeySettingsResult`, `WebAuthnSignatureData`, `CaliburCreateUserOperationOverrides`, `CaliburSignatureOverrides`, and `SignerFunction` types.
+- **`Simple7702AccountV09`**: minimal EIP-7702 account targeting EntryPoint v0.9, with parallel paymaster signing support.
+- **`SafeMultiChainSigAccountV1`**: audited multi-chain signature account. Sign once, replay across chains via a merkle-proof structure. Promoted from experimental.
+- **`SafeAccountV1_5_0_M_0_3_0`**: Safe contract v1.5.0 support with EIP-7951 and the Daimo P256 verifier for WebAuthn.
+
+#### EntryPoint v0.8 and v0.9 Support
+
+- `UserOperationV9` type and `CreateUserOperationV9Overrides` added.
+- `ENTRYPOINT_V6`, `ENTRYPOINT_V7`, `ENTRYPOINT_V8`, `ENTRYPOINT_V9` address constants exported.
+- Bundler, CandidePaymaster, and Tenderly simulation helpers updated to handle all four EntryPoint versions.
+- Entrypoint version resolution has been centralized in `CandidePaymaster`: a new private `resolveEntrypoint` helper reads the target entrypoint from the smart account instance at the top of each public method, replacing the per-method `UserOperation vX.YZ is not supported` checks from 0.2.30. The guard itself is not new, but unsupported-version errors are now surfaced earlier and more consistently.
+
+#### Parallel Paymaster Signing (EntryPoint v0.9)
+
+- **`ExperimentalAllowAllParallelPaymaster`**: an experimental paymaster for the parallel-signing flow.
+- **`signingPhase`** added to `CandidePaymasterContext`, with values `"commit"` and `"finalize"`. Enables parallel-signing flows where owner signing and the paymaster's final signature can happen independently, via the `PAYMASTER_SIG_MAGIC` convention on `paymasterData`. Works with EntryPoint v0.9 only.
+- `CandidePaymaster` supports both v0.9 parallel flows and the existing sequential flow.
 
 #### Safe Accounts
 
-- **`SafeAccountV1_5_0_M_0_3_0`** — Safe contract v1.5.0 support with EIP-7951 and Daimo P256 verifier for WebAuthn.
-- **`SafeMultiChainSigAccountV1`** — multi-chain signature account (audited, promoted from experimental).
-- `createChangeThresholdMetaTransaction`, `createApproveHashMetaTransaction`, and `getThreshold` methods.
-- Auto-prepend `approve(0)` for ERC-20 tokens that require allowance reset before setting a new approval.
+- **`createChangeThresholdMetaTransaction`**, **`createApproveHashMetaTransaction`**, and **`getThreshold`** added to `SafeAccount`. Makes multi-sig threshold management and offchain approval flows first-class.
+- **Auto-prepend `approve(0)`** before setting a new ERC-20 allowance for tokens like USDT that disallow changing a non-zero allowance directly. Opt in via `{ resetApproval: true }` on the token paymaster overrides.
+- **`MerkleTree`** helper utilities added for multi-chain operations.
 
-#### EntryPoint v0.9
+#### AllowanceModule v1.0.0
 
-- `UserOperationV9` type added.
-- Version-entrypoint compatibility guard — mismatched UserOperation versions are now caught early.
-- Entrypoint version is now resolved from the account instance.
+- Allowance module updated to v1.0.0. The legacy address is exported as **`ALLOWANCE_MODULE_V0_1_0_ADDRESS`** for migration purposes.
 
-#### Paymaster
+#### Calibur Singleton Addresses
 
-- **`CandidePaymaster` now supports EntryPoint v0.9 and parallel signing flows.**
-- **`ExperimentalAllowAllParallelPaymaster`** for parallel paymaster data flows.
-- **Signing phases** added to the context object, with support in paymaster flows.
-- Parallel paymaster support for `Simple7702AccountV09`.
+- **`CALIBUR_UNISWAP_V1_0_0_SINGLETON_ADDRESS`** and **`CALIBUR_CANDIDE_V0_1_0_SINGLETON_ADDRESS`** exported as constants.
 
-#### Utilities
+#### EIP-7702 Delegation Helpers
 
-- `MerkleTree` helper functions for multi-chain operations.
-- EIP-2098 compact signature support in `parseRawSignature`.
-- `EIP712_SAFE_OPERATION_PRIMARY_TYPE` and `EIP712_MULTI_CHAIN_OPERATIONS_PRIMARY_TYPE` constants.
-- Entrypoint address constants: `ENTRYPOINT_V6`, `ENTRYPOINT_V7`, `ENTRYPOINT_V8`, `ENTRYPOINT_V9`.
-- `CALIBUR_UNISWAP_V1_0_0_SINGLETON_ADDRESS` and `CALIBUR_CANDIDE_V0_1_0_SINGLETON_ADDRESS` constants.
-- Legacy `ALLOWANCE_MODULE_V0_1_0_ADDRESS` constant for migration.
+- **`getDelegatedAddress(eoaAddress, nodeRpc)`** utility for checking the current EIP-7702 delegation target of an EOA.
+- **Calibur delegation and key revocation**: `Calibur7702Account.createRevokeKeyMetaTransaction` and `createRevokeAllKeysMetaTransactions` for revoking individual or all registered keys, plus `createRevokeDelegationRawTransaction` for revoking the EIP-7702 delegation itself. Complements automatic delegation checking during UserOperation creation.
+
+#### Utilities and Constants
+
+- **EIP-2098** compact signature support in `parseRawSignature`.
+- **`EIP712_SAFE_OPERATION_PRIMARY_TYPE`** and **`EIP712_MULTI_CHAIN_OPERATIONS_PRIMARY_TYPE`** constants added alongside the existing EIP-712 type constants.
+- **`EIP712_MULTI_CHAIN_OPERATIONS_TYPE`** (previously `EIP712_MULTI_SAFE_OPERATIONS_TYPE`, renamed).
+- New paymaster-type exports: **`AnyUserOperation`**, **`SameUserOp`**.
+
+#### Tenderly
+
+- Tenderly simulation helpers updated to support EntryPoint v0.9 and `IAccountExecute.executeUserOp` callData rewriting.
+
+### Renames
+
+| Before | After |
+|--------|-------|
+| `ExperimentalSafeMultiChainSigAccount` | `SafeMultiChainSigAccountV1` |
+| `ExperimentalAllowAllPaymaster` | `ExperimentalAllowAllParallelPaymaster` |
+| `EIP712_MULTI_SAFE_OPERATIONS_TYPE` | `EIP712_MULTI_CHAIN_OPERATIONS_TYPE` |
+| `PaymasterInitValues` | `ParallelPaymasterInitValues` |
+| `listKeys` (Calibur) | `getKeys` |
+
+These renames only apply to code built on intermediate experimental versions (0.2.31 through 0.2.41). Code on 0.2.30 does not reference these identifiers.
 
 ### Bug Fixes
 
-- Fix object mutation via aliasing in `SafeAccountV1_5_0_M_0_3_0` and `CandidePaymaster`.
-- Fix object mutation, infinite recursion, and missing module address in multi-chain leaf hashes.
-- Fix BigInt gas scaling, merkle proof forwarding, entrypoint dispatch, and missing override fields.
-- Fix `CHAIN_ID` BigInt crash.
-- Fix gas overrides calculations.
-- Fix `formatSignaturesToUseroperationsSignatures` overrides and single-op case handling.
-- Fix `paymasterAndData` packing and signing when `PAYMASTER_SIG_MAGIC` is appended (v0.9).
-- Fix fractional percentage multipliers in `applyMultiplier`.
-- Fix normalize `paymasterMetadata` hex fields in `fetchSupportedERC20TokensAndPaymasterMetadata`.
-- Fix multi-chain sig account singleton forwarding, hash overrides, and type safety.
-- Fix constructor forwarding, timeout tracking, and unhandled promises.
-- Fix reverse proof order to match onchain verification order.
-- Fix WebAuthn passkeys v0.2.1 compatibility for custom contract addresses.
-- Fix token approval prepended before existing calls in SafeAccount multisend.
-- Fix `IAccountExecute.executeUserOp` callData rewriting for Tenderly simulation.
-- Fix multi-chain defaults in `formatSignaturesToUseroperationsSignatures`.
+Fixes listed here apply to APIs that already existed at 0.2.30. Bugs that were fixed within new-in-0.3.0 features during their pre-release development are not listed separately; those features are shipped in their final form as part of the "New Features" section.
+
+- **Gas estimation**: fixed gas overrides calculations, BigInt gas scaling, and handling of fractional percentage multipliers in `applyMultiplier`.
+- **SafeAccount multisend**: fixed a bug where token paymaster approvals were prepended after existing calls instead of before them.
+- **WebAuthn passkeys**: fixed compatibility with the v0.2.1 shared-signer contracts when using custom contract addresses.
+- **EIP-7702 utilities**: fixed `CHAIN_ID` BigInt crash in signing helpers and exposed `DEFAULT_DELEGATEE_ADDRESS` as a static property.
+- **Safe v0.3.0 account**: fixed `safeAccountSingleton` forwarding and added missing `webAuthnSignerProxyCreationCode` handling.
+- **CandidePaymaster**: fixed `paymasterMetadata` hex-field normalization in `fetchSupportedERC20TokensAndPaymasterMetadata`; fixed several instances of in-place mutation via aliasing on the user-passed UserOperation.
+- **Constructor forwarding and lifecycle**: fixed unhandled promises, timeout tracking, and constructor argument forwarding across pre-existing classes.
+- **Miscellaneous**: typo fixes in error messages, removal of unused imports and dead guards, unused `safeV06PrevModuleAddress` removed, chainId validation tightened in pre-existing helpers.
 
 ### Internal
 
-- Build system migrated from microbundle to tsdown.
-- Removed `isomorphic-unfetch` and `rimraf` dependencies.
+- Build system migrated from microbundle to tsdown. Output paths updated (see Breaking Changes).
+- `Simple7702Account` refactored into a `BaseSimple7702Account` pattern to enable the new `Simple7702AccountV09` subclass. No user-facing API changes on `Simple7702Account` itself.
+- Removed `isomorphic-unfetch` and `rimraf` dependencies; `rimraf` replaced with a cross-platform inline Node script.
 - Added CI workflow (`.github/workflows/ci.yml`) using yarn.
 - Added `SECURITY.md` with vulnerability reporting policy.
 - Added `prepare` script for GitHub-based installs.
+- Extensive JSDoc coverage added across public methods and types.

--- a/README.md
+++ b/README.md
@@ -16,101 +16,64 @@ AbstractionKit is agnostic of:
 
 
 ## Features
-### Safe Accounts
-- Built on ERC-4337 account abstraction
-- Passkeys Authentication for secure, passwordless access
-- Social Recovery to regain access easily
-- Multisig Support
-- Allowance Management for controlled spending limits
 
-### Gas Abstraction with Paymasters
-- Full Gas Sponsorship for a seamless user experience
-- Support for ERC-20 Tokens as gas payment options
-
-### Bundler Support
-- Compatibility with standard ERC-4337 Bundler Methods
-
-### UserOperation Utilities
-- A complete toolkit to construct, sign, and send UserOperations, enabling smooth integration
+- **Safe Accounts** with passkey authentication, social recovery, multisig, and allowance management
+- **EIP-7702** support via `Calibur7702Account` and `Simple7702Account`
+- **Gas abstraction** with sponsored UserOperations and ERC-20 gas payment via `CandidePaymaster`
+- **Multichain signatures** via `SafeMultiChainSigAccountV1` (sign once, replay across chains)
+- **Bundler client** compatible with standard ERC-4337 methods
+- **EntryPoint v0.6, v0.7, v0.8, and v0.9** support with a version-safe account/UserOp mapping
 
 ## Docs
 
-For full detailed documentation visit our [docs page](https://docs.candide.dev/wallet/abstractionkit/introduction). 
+For full detailed documentation visit our [docs page](https://docs.candide.dev/wallet/abstractionkit/introduction).
 
 ## Installation
+
+Requires Node.js 18 or later.
 
 ```bash
 npm install abstractionkit
 ```
 
+### Upgrading to v0.3.0
+
+v0.3.0 is a major release. Two API changes are likely to break existing paymaster code:
+
+- `CandidePaymaster.createSponsorPaymasterUserOperation(...)` now takes `smartAccount` as the **first** argument: `(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId?, overrides?)`.
+- `CandidePaymasterContext` is no longer a separate argument. Pass it via `overrides.context` on `GasPaymasterUserOperationOverrides`.
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full list of new features, renames, type export changes, and fixes.
+
 ## Quickstart
 
-### Which version to use?
+### Which account class to use?
 
-| Class | EntryPoint | When to use |
-|---|---|---|
-| `SafeAccountV0_3_0` | v0.7 | Recommended for new projects |
-| `SafeAccountV0_2_0` | v0.6 | Legacy support |
+| Class | EntryPoint | Account Type | When to use |
+|---|---|---|---|
+| `SafeAccountV0_3_0` | EP v0.7 | Safe (counterfactual) | Recommended for most new projects |
+| `SafeAccountV1_5_0_M_0_3_0` | EP v0.7 | Safe v1.5.0 (counterfactual) | Safe v1.5.0 with EIP-7951 / Daimo P256 verifier for WebAuthn |
+| `SafeAccountV0_2_0` | EP v0.6 | Safe (counterfactual) | Legacy support for EntryPoint v0.6 |
+| `SafeMultiChainSigAccountV1` | EP v0.9 | Safe multichain | Sign once, replay across chains. |
+| `Calibur7702Account` | EP v0.8 | EIP-7702 (Uniswap Calibur) | Upgrade an EOA in place. Supports EOA, P256, and WebAuthn keys |
+| `Simple7702Account` | EP v0.8 | EIP-7702 (minimal) | Minimal reference EIP-7702 account |
+| `Simple7702AccountV09` | EP v0.9 | EIP-7702 (minimal, parallel paymaster) | EntryPoint v0.9 with parallel paymaster signing |
 
-### Safe Account
+### Endpoints
 
-AbstractionKit features the Safe Account. It uses the original Safe Singleton and adds ERC-4337 functionality using a fallback handler module. The contracts have been developed by the Safe Team. It has been audited by Ackee Blockchain. To learn more about the contracts and audits, visit [safe-global/safe-modules](https://github.com/safe-global/safe-modules/tree/main/modules/4337).
-
-
-```typescript
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
-
-const ownerPublicAddress = "0xBdbc5FBC9cA8C3F514D073eC3de840Ac84FC6D31";
-const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress]);
-
-```
-Then you can consume account methods:
-```typescript
-const safeAddress = smartAccount.accountAddress;
-```
-
-### Bundler
-
-Initialize a Bundler with a bundler RPC url. Get an API key from the [dashboard](https://dashboard.candide.dev), or use the public endpoint (no key required).
-```typescript
-import { Bundler } from "abstractionkit";
-
-// Authenticated (get YOUR_API_KEY from https://dashboard.candide.dev)
-const bundlerRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
-
-// Or public (no key required)
-// const bundlerRpc = "https://api.candide.dev/public/v3/11155111";
-
-const bundler = new Bundler(bundlerRpc);
-```
-Then you can consume Bundler methods:
+Candide hosts both bundler and paymaster under the same base URL. Get an API key from the [dashboard](https://dashboard.candide.dev), or use the public endpoint (rate-limited, no key required).
 
 ```typescript
-const entrypointAddresses = await bundler.supportedEntryPoints();
-```
-
-### Paymaster
-Initialize a Candide Paymaster with your RPC url. Get an API key from the [dashboard](https://dashboard.candide.dev).
-```typescript
-import { CandidePaymaster } from "abstractionkit";
-
 // Authenticated
-const paymasterRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
+const rpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
 
 // Or public (no key required)
-// const paymasterRpc = "https://api.candide.dev/public/v3/11155111";
-
-const paymaster = new CandidePaymaster(paymasterRpc);
-```
-Then you can consume Paymaster methods:
-
-```typescript
-const supportedERC20TokensAndPaymasterMetadata = await paymaster.fetchSupportedERC20TokensAndPaymasterMetadata();
+// const rpc = "https://api.candide.dev/public/v3/11155111";
 ```
 
 ## Recipes
 
-Copy-paste patterns for common tasks. Examples use `SafeAccountV0_3_0` (EntryPoint v0.7). For EntryPoint v0.6, replace with `SafeAccountV0_2_0`.
+Copy paste patterns for common tasks. Examples use `SafeAccountV0_3_0` (EntryPoint v0.7). For EntryPoint v0.6, replace with `SafeAccountV0_2_0`.
 
 ### Send ETH from a new Safe account
 
@@ -120,7 +83,7 @@ import { SafeAccountV0_3_0 } from "abstractionkit";
 const ownerPublicAddress = "0xOwner";
 const ownerPrivateKey = "0xPrivateKey";
 const nodeRpc = "https://rpc.example.com";
-const bundlerRpc = "https://bundler.example.com";
+const bundlerRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
 const chainId = 11155111n; // Sepolia
 
 // Initialize new account (deploys on first UserOp)
@@ -169,7 +132,7 @@ const userOp = await smartAccount.createUserOperation(
 ```typescript
 import { SafeAccountV0_3_0, CandidePaymaster } from "abstractionkit";
 
-const paymaster = new CandidePaymaster("https://paymaster.example.com/rpc");
+const paymaster = new CandidePaymaster("https://api.candide.dev/api/v3/11155111/YOUR_API_KEY");
 
 // Create the UserOp first (without paymaster)
 const userOp = await smartAccount.createUserOperation(
@@ -178,10 +141,14 @@ const userOp = await smartAccount.createUserOperation(
   bundlerRpc,
 );
 
-// Sponsor it — sets paymaster fields and re-estimates gas
+// Sponsor it. Sets paymaster fields and re-estimates gas.
+// Note: as of v0.3.0, smartAccount is the first argument.
 const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+  smartAccount,
   userOp,
   bundlerRpc,
+  sponsorshipPolicyId,
+  // overrides (optional, includes context for parallel signing)
 );
 
 // Sign and send as usual
@@ -194,7 +161,7 @@ const response = await smartAccount.sendUserOperation(sponsoredOp, bundlerRpc);
 ```typescript
 import { SafeAccountV0_3_0, CandidePaymaster } from "abstractionkit";
 
-const paymaster = new CandidePaymaster("https://paymaster.example.com/rpc");
+const paymaster = new CandidePaymaster("https://api.candide.dev/api/v3/11155111/YOUR_API_KEY");
 const gasTokenAddress = "0xERC20TokenAddress"; // must be supported by paymaster
 
 const userOp = await smartAccount.createUserOperation(
@@ -203,16 +170,40 @@ const userOp = await smartAccount.createUserOperation(
   bundlerRpc,
 );
 
-// Automatically prepends token approval + sets paymaster fields
+// Automatically prepends token approval + sets paymaster fields.
+// For tokens like USDT that require resetting allowance to 0 first, pass
+// { resetApproval: true } in the overrides.
 const tokenOp = await paymaster.createTokenPaymasterUserOperation(
   smartAccount,
   userOp,
   gasTokenAddress,
   bundlerRpc,
+  // overrides (optional)
 );
 
 tokenOp.signature = smartAccount.signUserOperation(tokenOp, [ownerPrivateKey], chainId);
 const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
+```
+
+### Pass paymaster context (sponsorship policy, parallel signing)
+
+As of v0.3.0, `CandidePaymasterContext` is passed via the `overrides.context` field on `GasPaymasterUserOperationOverrides`. Previously it was a separate top level argument.
+
+```typescript
+const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+  smartAccount,
+  userOp,
+  bundlerRpc,
+  sponsorshipPolicyId,
+  {
+    context: {
+      // For EntryPoint v0.9 parallel signing flows:
+      // signingPhase: "commit" | "finalize",
+    },
+    // gas overrides also live here:
+    callGasLimitPercentageMultiplier: 110,
+  },
+);
 ```
 
 ### Batch multiple transactions
@@ -220,7 +211,7 @@ const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
 ```typescript
 import { SafeAccountV0_3_0, MetaTransaction } from "abstractionkit";
 
-// Pass an array of MetaTransactions — automatically encoded via MultiSend
+// Pass an array of MetaTransactions. Automatically encoded via MultiSend.
 const transactions: MetaTransaction[] = [
   { to: "0xRecipientA", value: 1000000000000000n, data: "0x" },
   { to: "0xRecipientB", value: 2000000000000000n, data: "0x" },
@@ -246,6 +237,98 @@ const smartAccount = new SafeAccountV0_3_0("0xYourDeployedSafeAddress");
 const newAccount = SafeAccountV0_3_0.initializeNewAccount(["0xOwnerAddress"]);
 // newAccount.accountAddress is the counterfactual address
 // First UserOp will deploy it automatically
+```
+
+### Calibur 7702: delegate an EOA and send a transfer
+
+`Calibur7702Account` is Uniswap's EIP-7702 smart account. It upgrades a regular EOA in place so the same address becomes a programmable smart account on EntryPoint v0.8.
+
+```typescript
+import {
+  Calibur7702Account,
+  createAndSignEip7702DelegationAuthorization,
+} from "abstractionkit";
+
+const eoaAddress = "0xYourEOA";
+const privateKey = "0xYourPrivateKey";
+const nodeRpc = "https://rpc.example.com";
+const bundlerRpc = "https://api.candide.dev/api/v3/11155111/YOUR_API_KEY";
+const chainId = 11155111n;
+
+// The EOA address becomes the smart account address after delegation.
+const account = new Calibur7702Account(eoaAddress);
+
+// Create UserOp with EIP-7702 delegation (only required the first time).
+const userOp = await account.createUserOperation(
+  [{ to: "0xRecipient", value: 1000000000000000n, data: "0x" }],
+  nodeRpc,
+  bundlerRpc,
+  { eip7702Auth: { chainId } },
+);
+
+// Sign the delegation authorization.
+userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+  BigInt(userOp.eip7702Auth.chainId),
+  userOp.eip7702Auth.address,
+  BigInt(userOp.eip7702Auth.nonce),
+  privateKey,
+);
+
+// Sign and send.
+userOp.signature = account.signUserOperation(userOp, privateKey, chainId);
+const response = await account.sendUserOperation(userOp, bundlerRpc);
+const receipt = await response.included();
+```
+
+After the first UserOp deploys the delegation, subsequent UserOps no longer need `eip7702Auth`. Use `getDelegatedAddress(eoaAddress, nodeRpc)` to check delegation status.
+
+### Calibur 7702: register a WebAuthn passkey
+
+```typescript
+import { Calibur7702Account } from "abstractionkit";
+
+// Build a P256 key from the WebAuthn public key coordinates.
+const webAuthnKey = Calibur7702Account.createWebAuthnP256Key(pubKeyX, pubKeyY);
+const keyHash = Calibur7702Account.getKeyHash(webAuthnKey);
+
+// Register with a 1-year expiration.
+const registerTxs = Calibur7702Account.createRegisterKeyMetaTransactions(
+  webAuthnKey,
+  { expiration: Math.floor(Date.now() / 1000) + 86400 * 365 },
+);
+
+const userOp = await account.createUserOperation(registerTxs, nodeRpc, bundlerRpc);
+userOp.signature = account.signUserOperation(userOp, privateKey, chainId);
+const response = await account.sendUserOperation(userOp, bundlerRpc);
+```
+
+### Calibur 7702: sign a UserOp with a registered passkey
+
+```typescript
+import { Calibur7702Account, createUserOperationHash } from "abstractionkit";
+
+// Use a WebAuthn dummy signature for accurate gas estimation.
+const dummySig = Calibur7702Account.createDummyWebAuthnSignature(keyHash);
+
+const userOp = await account.createUserOperation(
+  [{ to: "0xRecipient", value: 0n, data: "0x" }],
+  nodeRpc,
+  bundlerRpc,
+  { dummySignature: dummySig },
+);
+
+// Compute the hash, sign with the passkey off-chain, then format the signature.
+const userOpHash = createUserOperationHash(userOp, entryPointAddress, chainId);
+userOp.signature = account.formatWebAuthnSignature(keyHash, {
+  authenticatorData,
+  clientDataJSON,
+  challengeIndex,
+  typeIndex,
+  r,
+  s, // P256 signature components
+});
+
+const response = await account.sendUserOperation(userOp, bundlerRpc);
 ```
 
 ### Common error codes and solutions
@@ -286,3 +369,5 @@ MIT
 
 * <a href='https://eips.ethereum.org/EIPS/eip-4337'>EIP-4337: Account Abstraction via Entry Point Contract specification </a>
 * <a href='https://safe.global/'>Safe Accounts, Modules, and SGP</a>
+* <a href='https://github.com/Uniswap/calibur'>Uniswap Calibur Account</a>
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.30  | :white_check_mark: |
+| 0.3.1   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -124,6 +124,22 @@ export class Bundler {
 				preVerificationGas: BigInt(res.preVerificationGas),
 				verificationGasLimit: BigInt(res.verificationGasLimit),
 			};
+			// `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit`
+			// are standard ERC-4337 UserOperation fields but NOT part of the
+			// bundler-spec `GasInfo`. Some bundlers return them as a
+			// non-standard extension when a paymaster is attached; forwarded
+			// here for compatibility. Guarded with `!= null` so spec-compliant
+			// bundlers still work.
+			if (res.paymasterVerificationGasLimit != null) {
+				gasEstimationResult.paymasterVerificationGasLimit = BigInt(
+					res.paymasterVerificationGasLimit,
+				);
+			}
+			if (res.paymasterPostOpGasLimit != null) {
+				gasEstimationResult.paymasterPostOpGasLimit = BigInt(
+					res.paymasterPostOpGasLimit,
+				);
+			}
 
 			return gasEstimationResult;
 		} catch (err) {

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -38,6 +38,17 @@ export { SafeAccountFactory } from "./factory/SafeAccountFactory";
 export { Bundler } from "./Bundler";
 
 export { CandidePaymaster } from "./paymaster/CandidePaymaster";
+export { Erc7677Paymaster } from "./paymaster/Erc7677Paymaster";
+export type {
+	Erc7677Context,
+	Erc7677PaymasterFields,
+	Erc7677StubDataResult,
+} from "./paymaster/Erc7677Paymaster";
+export type {
+	Erc7677Provider,
+	Erc7677PaymasterConstructorOptions,
+	GasPaymasterUserOperationOverrides,
+} from "./paymaster/types";
 export { ExperimentalAllowAllParallelPaymaster } from "./paymaster/AllowAllPaymaster";
 
 export { 

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -330,7 +330,7 @@ export class Calibur7702Account extends SmartAccount
 				);
 			}
 
-			const ops: Promise<any>[] = [eip7702AuthNonceOp];
+			const ops: Promise<unknown>[] = [eip7702AuthNonceOp];
 			if (nonceOp != null) ops.push(nonceOp);
 			if (gasPriceOp != null) ops.push(gasPriceOp);
 			if (delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -338,8 +338,8 @@ export class Calibur7702Account extends SmartAccount
 			const values = await Promise.all(ops);
 			let idx = 0;
 			eip7702AuthNonce = BigInt(values[idx++] as string);
-			if (nonceOp != null) nonce = values[idx++];
-			if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+			if (nonceOp != null) nonce = values[idx++] as bigint;
+			if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
 			if (delegationCheckOp != null) {
 				const delegatedTo = values[idx++] as string | null;
 				if (delegatedTo != null &&
@@ -348,7 +348,7 @@ export class Calibur7702Account extends SmartAccount
 				}
 			}
 		} else if (overrides.eip7702Auth != null) {
-			const ops: Promise<any>[] = [];
+			const ops: Promise<unknown>[] = [];
 			if (nonceOp != null) ops.push(nonceOp);
 			if (gasPriceOp != null) ops.push(gasPriceOp);
 			if (delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -356,8 +356,8 @@ export class Calibur7702Account extends SmartAccount
 			if (ops.length > 0) {
 				const values = await Promise.all(ops);
 				let idx = 0;
-				if (nonceOp != null) nonce = values[idx++];
-				if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+				if (nonceOp != null) nonce = values[idx++] as bigint;
+				if (gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
 				if (delegationCheckOp != null) {
 					const delegatedTo = values[idx++] as string | null;
 					if (delegatedTo != null &&
@@ -1306,7 +1306,7 @@ export class Calibur7702Account extends SmartAccount
 		if (count === 0) return [];
 
 		// Batch all keyAt calls in parallel
-		const keyAtPromises: Promise<any>[] = [];
+		const keyAtPromises: Promise<unknown>[] = [];
 		for (let i = 0; i < count; i++) {
 			const keyAtCallData = KEY_AT_SELECTOR + abiCoder.encode(
 				["uint256"],

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -12,6 +12,7 @@ import {
     SignerSignaturePair,
     WebAuthnSignatureOverrides,
     WebauthnPublicKey,
+    UserOperationToSignWithOverrides,
 } from "./types";
 
 import { UserOperationV9, MetaTransaction, OnChainIdentifierParamsType } from "../../types";
@@ -603,14 +604,13 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * @returns signature
 	 */
 	public static formatSignaturesToUseroperationsSignatures(
-		userOperationsToSign: UserOperationToSign[],
+		userOperationsToSign: UserOperationToSignWithOverrides[],
 		signerSignaturePairs: SignerSignaturePair[],
-		overrides: WebAuthnSignatureOverrides = {},
 	): string[] {
 		if (userOperationsToSign.length < 1) {
 			throw new RangeError("There should be at least one userOperationsToSign");
 		}
-		const resolvedOverrides: WebAuthnSignatureOverrides = {
+		const defaultOverrides: WebAuthnSignatureOverrides = {
 			eip7212WebAuthnPrecompileVerifier:
 				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_PRECOMPILE,
 			eip7212WebAuthnContractVerifier:
@@ -625,50 +625,57 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 				SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
 			webAuthnSharedSigner:
 				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SHARED_SIGNER,
-			...overrides,
 		};
-        if (userOperationsToSign.length === 1) {
-            return [
-                SafeAccount.formatSignaturesToUseroperationSignature(
-                    signerSignaturePairs,
-                    {
-                        ...resolvedOverrides,
-                        isMultiChainSignature: true,
-                    },
-                ),
-            ];
-        }
-        const userOperationsHashes: string[] = [];
-        userOperationsToSign.forEach(
-            (userOperationsToSign, _index) => {
-                const userOperationHash = SafeAccount.getUserOperationEip712Hash_V9(
-                    userOperationsToSign.userOperation,
-                    userOperationsToSign.chainId,
-                    {
-                        validAfter: userOperationsToSign.validAfter,
-                        validUntil: userOperationsToSign.validUntil,
-                        safe4337ModuleAddress: resolvedOverrides.safe4337ModuleAddress,
-                    },
-                );
-                userOperationsHashes.push(userOperationHash);
-        });
-        const [_root, proofs] = generateMerkleProofs(userOperationsHashes);
-        const userOpSignatures: string[] = [];
-        userOperationsToSign.forEach(
-            (_userOperationsToSign, index) => {
-                userOpSignatures.push(
-                    SafeAccount.formatSignaturesToUseroperationSignature(
-                        signerSignaturePairs,
-                        {
-                            ...resolvedOverrides,
-                            isMultiChainSignature:true,
-                            multiChainMerkleProof: proofs[index],
-                        },
-                    )
-                );
-        });
-        return userOpSignatures;
-    }
+		if (userOperationsToSign.length === 1) {
+			return [
+				SafeAccount.formatSignaturesToUseroperationSignature(
+					signerSignaturePairs,
+					{
+						...defaultOverrides,
+						...userOperationsToSign[0].overrides,
+						validAfter: userOperationsToSign[0].validAfter,
+						validUntil: userOperationsToSign[0].validUntil,
+						isMultiChainSignature: true,
+					},
+				),
+			];
+		}
+		const userOperationsHashes: string[] = [];
+		userOperationsToSign.forEach(
+			(userOperationToSign, _index) => {
+				const userOperationHash = SafeAccount.getUserOperationEip712Hash_V9(
+					userOperationToSign.userOperation,
+					userOperationToSign.chainId,
+					{
+						validAfter: userOperationToSign.validAfter,
+						validUntil: userOperationToSign.validUntil,
+						safe4337ModuleAddress:
+							userOperationToSign.overrides?.safe4337ModuleAddress ??
+							defaultOverrides.safe4337ModuleAddress,
+					},
+				);
+				userOperationsHashes.push(userOperationHash);
+			},
+		);
+		const [_root, proofs] = generateMerkleProofs(userOperationsHashes);
+		const userOpSignatures: string[] = [];
+		userOperationsToSign.forEach(
+			(userOperationToSign, index) => {
+				userOpSignatures.push(
+					SafeAccount.formatSignaturesToUseroperationSignature(
+						signerSignaturePairs,
+						{
+							...defaultOverrides,
+							...userOperationToSign.overrides,
+							isMultiChainSignature: true,
+							multiChainMerkleProof: proofs[index],
+						},
+					),
+				);
+			},
+		);
+		return userOpSignatures;
+	}
 
 	public static createWebAuthnSignerVerifierAddress(
 		x: bigint,

--- a/src/account/Safe/types.ts
+++ b/src/account/Safe/types.ts
@@ -300,6 +300,20 @@ export interface UserOperationToSign {
     validUntil?: bigint;
 }
 
+/** Extends UserOperationToSign with per-operation WebAuthn/module overrides. */
+export interface UserOperationToSignWithOverrides extends UserOperationToSign {
+	overrides?: {
+		isInit?: boolean;
+		webAuthnSharedSigner?: string;
+		eip7212WebAuthnPrecompileVerifier?: string;
+		eip7212WebAuthnContractVerifier?: string;
+		webAuthnSignerFactory?: string;
+		webAuthnSignerSingleton?: string;
+		webAuthnSignerProxyCreationCode?: string;
+		safe4337ModuleAddress?: string;
+	};
+}
+
 /** EIP-712 domain for multi-chain signature Merkle tree root. */
 export interface MultiChainSignatureMerkleTreeRootTypedDataDomain {
 	verifyingContract: string;

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -453,7 +453,7 @@ export class BaseSimple7702Account extends SmartAccount {
             const values = await Promise.all(ops);
             let idx = 0;
             eip7702AuthNonce = BigInt(values[idx++] as string);
-            if(nonceOp != null) nonce = values[idx++] as bigint | null;
+            if(nonceOp != null) nonce = values[idx++] as bigint;
             if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
             if(delegationCheckOp != null){
                 const delegatedTo = values[idx++] as string|null;
@@ -472,7 +472,7 @@ export class BaseSimple7702Account extends SmartAccount {
             if(ops.length > 0){
                 const values = await Promise.all(ops);
                 let idx = 0;
-                if(nonceOp != null) nonce = values[idx++] as bigint | null;
+                if(nonceOp != null) nonce = values[idx++] as bigint;
                 if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
                 if(delegationCheckOp != null){
                     const delegatedTo = values[idx++] as string|null;

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -445,7 +445,7 @@ export class BaseSimple7702Account extends SmartAccount {
             }
 
             // Build array of all parallel operations
-            const ops:Promise<any>[] = [eip7702AuthNonceOp];
+            const ops: Promise<unknown>[] = [eip7702AuthNonceOp];
             if(nonceOp != null) ops.push(nonceOp);
             if(gasPriceOp != null) ops.push(gasPriceOp);
             if(delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -453,8 +453,8 @@ export class BaseSimple7702Account extends SmartAccount {
             const values = await Promise.all(ops);
             let idx = 0;
             eip7702AuthNonce = BigInt(values[idx++] as string);
-            if(nonceOp != null) nonce = values[idx++];
-            if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+            if(nonceOp != null) nonce = values[idx++] as bigint | null;
+            if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
             if(delegationCheckOp != null){
                 const delegatedTo = values[idx++] as string|null;
                 if(delegatedTo != null &&
@@ -464,7 +464,7 @@ export class BaseSimple7702Account extends SmartAccount {
             }
         }else if(overrides.eip7702Auth != null){
             // eip7702AuthNonce was provided, but still need delegation check + other ops
-            const ops:Promise<any>[] = [];
+            const ops: Promise<unknown>[] = [];
             if(nonceOp != null) ops.push(nonceOp);
             if(gasPriceOp != null) ops.push(gasPriceOp);
             if(delegationCheckOp != null) ops.push(delegationCheckOp);
@@ -472,8 +472,8 @@ export class BaseSimple7702Account extends SmartAccount {
             if(ops.length > 0){
                 const values = await Promise.all(ops);
                 let idx = 0;
-                if(nonceOp != null) nonce = values[idx++];
-                if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++];
+                if(nonceOp != null) nonce = values[idx++] as bigint | null;
+                if(gasPriceOp != null) [maxFeePerGas, maxPriorityFeePerGas] = values[idx++] as [bigint, bigint];
                 if(delegationCheckOp != null){
                     const delegatedTo = values[idx++] as string|null;
                     if(delegatedTo != null &&

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -1,0 +1,947 @@
+import { Paymaster } from "./Paymaster";
+import { Bundler } from "../Bundler";
+import { calculateUserOperationMaxGasCost, sendJsonRpcRequest } from "../utils";
+import { AbstractionKitError, ensureError } from "../errors";
+import {
+	ENTRYPOINT_V6,
+	ENTRYPOINT_V7,
+	ENTRYPOINT_V8,
+	ENTRYPOINT_V9,
+} from "../constants";
+import type { StateOverrideSet } from "../types";
+import {
+	AnyUserOperation,
+	SameUserOp,
+	SmartAccountWithEntrypoint,
+	PrependTokenPaymasterApproveAccount,
+	GasPaymasterUserOperationOverrides,
+	Erc7677Provider,
+	Erc7677PaymasterConstructorOptions,
+} from "./types";
+
+/** Max value for uint256 */
+const UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457584007913129639935n;
+/** Multiplier for token approve amount to cover paymasterAndData cost variance */
+const TOKEN_APPROVE_AMOUNT_MULTIPLIER = 2n;
+/**
+ * ERC-20 tokens that require resetting their allowance to 0 before setting a
+ * new approval amount (e.g. USDT on mainnet).
+ */
+const TOKENS_REQUIRING_ALLOWANCE_RESET: string[] = [
+	"0xdac17f958d2ee523a2206206994597c13d831ec7", // USDT (Ethereum mainnet)
+];
+/**
+ * Time-to-live for cached Candide `pm_supportedERC20Tokens` responses, applied
+ * only when the fetch is initiated for an exchange-rate lookup. Stub-data
+ * lookups (paymaster address + dummyPaymasterAndData) reuse the cache
+ * indefinitely since those fields are effectively static per EP.
+ */
+const CANDIDE_TOKEN_QUOTE_TTL_MS = 45_000;
+
+/**
+ * Opaque context object forwarded to the paymaster RPC as the fourth argument
+ * of `pm_getPaymasterStubData` / `pm_getPaymasterData`.
+ *
+ * The shape is provider-specific: Candide uses `{ token }` for token paymaster
+ * and `{ sponsorshipPolicyId }` for sponsored operations; other providers
+ * (Pimlico, Alchemy, …) have their own conventions. Refer to the
+ * paymaster provider's documentation for the exact fields.
+ *
+ * ## Reserved fields consumed by this class (not forwarded to the RPC)
+ *
+ * - `exchangeRate` - token-to-ETH exchange rate as a bigint or hex/decimal
+ *   string, scaled by 10^18 (i.e. the value of 1 ETH expressed in the token's
+ *   smallest unit). Used to calculate the ERC-20 approval amount when no
+ *   provider is auto-detected. Not needed when `provider` is `"pimlico"` or
+ *   `"candide"`; the class fetches the rate from the provider's RPC.
+ */
+export type Erc7677Context = Record<string, unknown>;
+
+/**
+ * Paymaster gas/data fields returned by `pm_getPaymasterStubData` and
+ * `pm_getPaymasterData` for EntryPoint v0.7+ UserOperations.
+ */
+export interface Erc7677PaymasterFields {
+	paymaster?: string;
+	paymasterData?: string;
+	paymasterVerificationGasLimit?: bigint | string;
+	paymasterPostOpGasLimit?: bigint | string;
+	/** Present on v0.6 responses; mutually exclusive with the split fields above. */
+	paymasterAndData?: string;
+}
+
+/**
+ * Response from `pm_getPaymasterStubData`. Includes `isFinal` when the paymaster
+ * signs immediately and does not require a follow-up `pm_getPaymasterData` call.
+ */
+export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
+	/** When true, skip pm_getPaymasterData and use these fields as the final signature. */
+	isFinal?: boolean;
+	[key: string]: unknown;
+}
+
+/**
+ * Generic ERC-7677 paymaster client.
+ *
+ * Speaks the [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) JSON-RPC
+ * protocol: `pm_getPaymasterStubData` for gas-estimation stubs and
+ * `pm_getPaymasterData` for the final signed paymaster fields. Works with any
+ * paymaster provider that implements the standard (Candide, Pimlico, Alchemy, …).
+ *
+ * For Candide-hosted paymasters, {@link CandidePaymaster} is the dedicated
+ * client and offers extra features (parallel signing phases, etc.). This
+ * generic class is provided so consumers retain the freedom to switch
+ * providers without changing the SDK.
+ *
+ * ## Flow
+ *
+ * {@link Erc7677Paymaster.createPaymasterUserOperation} runs the full pipeline:
+ *
+ * 1. `pm_getPaymasterStubData(userOp, entrypoint, chainId, context)` — stub
+ *    paymaster fields for gas estimation.
+ * 2. Apply stub fields to the UserOperation.
+ * 3. `eth_estimateUserOperationGas` via the bundler, reading back the bundler's
+ *    paymaster gas limits (v0.7+).
+ * 4. Apply gas limits to the UserOperation.
+ * 5. If the stub response includes `isFinal: true`, skip to step 7.
+ * 6. `pm_getPaymasterData(userOp, entrypoint, chainId, context)` — final
+ *    paymaster signature.
+ * 7. Return the UserOperation with paymaster fields populated, ready to sign.
+ *
+ * Owner signing is intentionally out of scope — call the smart account's
+ * `signUserOperation` (or your external signer) after this method returns.
+ *
+ * ## Token paymaster flows
+ *
+ * When `context.token` is set and the smart account implements
+ * `prependTokenPaymasterApproveToCallData`, the class automatically runs the
+ * token paymaster pipeline:
+ *
+ * - **Provider detected** (Candide, Pimlico): fetches exchange rate and
+ *   paymaster address via provider-specific RPC, then handles approval
+ *   prepending, gas estimation, and final paymaster data automatically.
+ * - **No provider, `context.exchangeRate` set**: uses the provided rate;
+ *   paymaster address comes from `pm_getPaymasterStubData`.
+ * - **No provider, no `exchangeRate`**: falls through to the regular
+ *   sponsored flow — the developer is responsible for prepending the
+ *   approval and calculating the amount.
+ *
+ * @example Sponsored UserOperation (Candide)
+ * ```ts
+ * const paymaster = new Erc7677Paymaster(candideUrl);
+ * const sponsoredOp = await paymaster.createPaymasterUserOperation(
+ *   smartAccount,
+ *   userOp,
+ *   bundlerRpc,
+ *   { sponsorshipPolicyId: "sp_melted_jackpot" },
+ * );
+ * sponsoredOp.signature = smartAccount.signUserOperation(sponsoredOp, [pk], chainId);
+ * await new Bundler(bundlerRpc).sendUserOperation(sponsoredOp, smartAccount.entrypointAddress);
+ * ```
+ *
+ * @example Token paymaster (Candide — automatic, provider auto-detected)
+ * ```ts
+ * const paymaster = new Erc7677Paymaster(candideUrl);
+ * const tokenOp = await paymaster.createPaymasterUserOperation(
+ *   smartAccount,
+ *   userOp,
+ *   bundlerRpc,
+ *   { token: usdtAddress },
+ * );
+ * ```
+ *
+ * @example Token paymaster (unknown provider, exchangeRate supplied)
+ * ```ts
+ * const paymaster = new Erc7677Paymaster(customUrl);
+ * const tokenOp = await paymaster.createPaymasterUserOperation(
+ *   smartAccount,
+ *   userOp,
+ *   bundlerRpc,
+ *   { token: usdtAddress, exchangeRate: "1000000000000000000" },
+ * );
+ * ```
+ */
+/**
+ * Raw shape of Candide's `pm_supportedERC20Tokens` response.
+ * `dummyPaymasterAndData` is a concatenated hex string for EntryPoint v0.6 and
+ * a structured object for v0.7+.
+ */
+interface CandideSupportedResponse {
+	tokens: Array<{ address: string; exchangeRate: string }>;
+	paymasterMetadata: {
+		address: string;
+		dummyPaymasterAndData:
+			| string
+			| {
+				paymaster: string;
+				paymasterVerificationGasLimit: string;
+				paymasterPostOpGasLimit: string;
+				paymasterData: string;
+			};
+	};
+}
+
+export class Erc7677Paymaster extends Paymaster {
+	/** The paymaster JSON-RPC endpoint URL */
+	readonly rpcUrl: string;
+	/** Cached chain ID (hex string). Passed via constructor or resolved from the bundler at first use. */
+	private chainId: string | null;
+	/** Detected or explicitly set paymaster provider. `null` means no provider-specific features. */
+	readonly provider: Erc7677Provider;
+	/**
+	 * Cached Candide `pm_supportedERC20Tokens` response, keyed by lowercase
+	 * entrypoint. Used for both token quotes and stub data to avoid a second
+	 * round-trip (`pm_getPaymasterStubData`) for Candide-hosted paymasters.
+	 *
+	 * The cache is indefinite for stub-data lookups but has a TTL for
+	 * exchange-rate lookups — see {@link CANDIDE_TOKEN_QUOTE_TTL_MS}.
+	 */
+	private candideCache = new Map<string, { data: CandideSupportedResponse; fetchedAt: number }>();
+
+	/**
+	 * Detect the paymaster provider from the RPC URL hostname.
+	 * Returns `null` for unknown hosts or malformed URLs.
+	 *
+	 * Hostname-based (not substring) so that proxies or paths containing a
+	 * provider name (e.g. `https://my-proxy.com/pimlico-compat/...`) are not
+	 * misidentified.
+	 */
+	static detectProvider(rpcUrl: string): Erc7677Provider {
+		let host: string;
+		try {
+			host = new URL(rpcUrl).hostname.toLowerCase();
+		} catch {
+			return null;
+		}
+		if (host === "pimlico.io" || host.endsWith(".pimlico.io")) return "pimlico";
+		if (host === "candide.dev" || host.endsWith(".candide.dev")) return "candide";
+		return null;
+	}
+
+	/**
+	 * @param rpcUrl - Paymaster JSON-RPC endpoint. Can be the same URL as the
+	 *   bundler when the provider bundles both (Candide, Pimlico, Alchemy);
+	 *   can also be a separate paymaster-only endpoint.
+	 * @param options
+	 * @param options.chainId - Optional chain id as a bigint (e.g. `1n` for
+	 *   mainnet). When provided, avoids a lookup at first use. Otherwise,
+	 *   resolved from the bundler via `eth_chainId` on the first call.
+	 * @param options.provider - Paymaster provider. `"auto"` (default) detects
+	 *   from the RPC URL. Set explicitly to override, or `null` to disable.
+	 */
+	constructor(rpcUrl: string, options: Erc7677PaymasterConstructorOptions = {}) {
+		super();
+		this.rpcUrl = rpcUrl;
+		this.chainId = options.chainId != null ? "0x" + options.chainId.toString(16) : null;
+		if (options.provider === undefined || options.provider === "auto") {
+			this.provider = Erc7677Paymaster.detectProvider(rpcUrl);
+		} else {
+			this.provider = options.provider;
+		}
+	}
+
+	/**
+	 * Resolve the chain id, querying the bundler if not provided at construction.
+	 */
+	private async getChainId(bundlerRpc: string): Promise<string> {
+		if (this.chainId != null) return this.chainId;
+		const id = await new Bundler(bundlerRpc).chainId();
+		this.chainId = id;
+		return id;
+	}
+
+	/**
+	 * Determine the EntryPoint address from the UserOperation shape.
+	 * V6 ops have `initCode`, V8+ ops have `eip7702Auth`, V7 is the default.
+	 */
+	private resolveEntrypoint(
+		smartAccount: SmartAccountWithEntrypoint,
+		userOperation: AnyUserOperation,
+	): string {
+		if (
+			smartAccount.entrypointAddress != null &&
+			smartAccount.entrypointAddress.trim() !== ""
+		) {
+			return smartAccount.entrypointAddress;
+		}
+		if ("initCode" in userOperation) return ENTRYPOINT_V6;
+		if ("eip7702Auth" in userOperation) return ENTRYPOINT_V8;
+		return ENTRYPOINT_V7;
+	}
+
+	/**
+	 * Low-level ERC-7677 `pm_getPaymasterStubData` call.
+	 * Returns dummy paymaster fields intended for gas estimation.
+	 *
+	 * Most consumers should prefer {@link createPaymasterUserOperation}, which
+	 * runs the full stub → estimate → final pipeline. Use this directly if you
+	 * need to drive the flow manually.
+	 */
+	async getPaymasterStubData(
+		userOperation: AnyUserOperation,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context = {},
+	): Promise<Erc7677StubDataResult> {
+		try {
+			const result = await sendJsonRpcRequest(
+				this.rpcUrl,
+				"pm_getPaymasterStubData",
+				[userOperation, entrypoint, chainIdHex, context],
+			);
+			return result as Erc7677StubDataResult;
+		} catch (err) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"pm_getPaymasterStubData failed",
+				{ cause: ensureError(err) },
+			);
+		}
+	}
+
+	/**
+	 * Low-level ERC-7677 `pm_getPaymasterData` call.
+	 * Returns the final signed paymaster fields.
+	 */
+	async getPaymasterData(
+		userOperation: AnyUserOperation,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context = {},
+	): Promise<Erc7677PaymasterFields> {
+		try {
+			const result = await sendJsonRpcRequest(
+				this.rpcUrl,
+				"pm_getPaymasterData",
+				[userOperation, entrypoint, chainIdHex, context],
+			);
+			return result as Erc7677PaymasterFields;
+		} catch (err) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"pm_getPaymasterData failed",
+				{ cause: ensureError(err) },
+			);
+		}
+	}
+
+	/**
+	 * Send an arbitrary JSON-RPC request through the paymaster endpoint.
+	 * Useful for provider-specific methods that fall outside the ERC-7677 spec.
+	 *
+	 * @param method - The JSON-RPC method name
+	 * @param params - The JSON-RPC params array
+	 * @returns The `result` field from the JSON-RPC response
+	 */
+	async sendRPCRequest(
+		method: string,
+		params: unknown[] = [],
+	): Promise<unknown> {
+		try {
+			return await sendJsonRpcRequest(this.rpcUrl, method, params);
+		} catch (err) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`sendRPCRequest(${method}) failed`,
+				{ cause: ensureError(err) },
+			);
+		}
+	}
+
+	/**
+	 * Runs the full ERC-7677 pipeline and returns a UserOperation with paymaster
+	 * fields populated. The caller is responsible for signing and sending.
+	 *
+	 * @param smartAccount - Provides the target EntryPoint; not mutated.
+	 * @param userOperation - Starting UserOperation. Not mutated — a shallow copy is returned.
+	 * @param bundlerRpc - Bundler URL used for gas estimation and, if
+	 *   `options.chainId` was not provided to the constructor, chain-id lookup.
+	 * @param context - Provider-specific paymaster context
+	 *   (e.g. `{ sponsorshipPolicyId }` or `{ token }`).
+	 * @param overrides - Gas estimation overrides and state-override set.
+	 *
+	 * @returns The UserOperation with paymaster + gas fields populated.
+	 */
+	async createPaymasterUserOperation<T extends AnyUserOperation>(
+		smartAccount: SmartAccountWithEntrypoint,
+		userOperation: T,
+		bundlerRpc: string,
+		context: Erc7677Context = {},
+		overrides: GasPaymasterUserOperationOverrides = {},
+	): Promise<SameUserOp<T>> {
+		try {
+			const userOp = { ...userOperation } as T;
+			const entrypoint =
+				overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
+			const chainIdHex = await this.getChainId(bundlerRpc);
+
+			// Token paymaster flow: triggered when context.token is set
+			if (
+				context.token != null &&
+				typeof context.token === "string"
+			) {
+				return this.tokenPaymasterFlow(
+					smartAccount as unknown as PrependTokenPaymasterApproveAccount,
+					userOp,
+					context.token as string,
+					bundlerRpc,
+					entrypoint,
+					chainIdHex,
+					context,
+					overrides,
+				);
+			}
+
+			// Delegate to the sponsored flow (stub → estimate → final).
+			return this.sponsoredFlow(
+				userOp,
+				bundlerRpc,
+				entrypoint,
+				chainIdHex,
+				context,
+				overrides,
+			);
+		} catch (err) {
+			const error = ensureError(err);
+			if (error instanceof AbstractionKitError) throw error;
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"createPaymasterUserOperation failed",
+				{ cause: error },
+			);
+		}
+	}
+
+	/**
+	 * Merge paymaster fields into a UserOperation. Handles both v0.6
+	 * (`paymasterAndData`) and v0.7+ split fields.
+	 */
+	private applyPaymasterFields(
+		userOp: AnyUserOperation,
+		fields: Erc7677PaymasterFields,
+	): void {
+		if ("initCode" in userOp) {
+			if (fields.paymasterAndData != null) {
+				userOp.paymasterAndData = fields.paymasterAndData;
+			}
+			return;
+		}
+		if (fields.paymaster != null) userOp.paymaster = fields.paymaster;
+		if (fields.paymasterData != null) userOp.paymasterData = fields.paymasterData;
+		if (fields.paymasterVerificationGasLimit != null) {
+			userOp.paymasterVerificationGasLimit = BigInt(
+				fields.paymasterVerificationGasLimit,
+			);
+		}
+		if (fields.paymasterPostOpGasLimit != null) {
+			userOp.paymasterPostOpGasLimit = BigInt(fields.paymasterPostOpGasLimit);
+		}
+	}
+
+	/**
+	 * Estimate gas limits via the bundler and apply them (with multipliers).
+	 * Reads paymaster gas fields back from the bundler when present — some
+	 * providers' `pm_getPaymasterStubData` returns `paymasterPostOpGasLimit: 0x1`
+	 * as a placeholder, relying on the bundler's estimate for the real value.
+	 *
+	 * Mirrors CandidePaymaster.estimateAndApplyGasLimits default multipliers
+	 * (5%/10%/10% on preVerification/verification/call) for consistent UX.
+	 */
+	private async estimateAndApplyGasLimits(
+		userOp: AnyUserOperation,
+		bundlerRpc: string,
+		entrypoint: string,
+		overrides: GasPaymasterUserOperationOverrides,
+	): Promise<void> {
+		let preVerificationGas = userOp.preVerificationGas;
+		let verificationGasLimit = userOp.verificationGasLimit;
+		let callGasLimit = userOp.callGasLimit;
+
+		if (
+			overrides.preVerificationGas == null ||
+			overrides.verificationGasLimit == null ||
+			overrides.callGasLimit == null
+		) {
+			if (bundlerRpc == null) {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"bundlerRpc can't be null if preVerificationGas, verificationGasLimit and callGasLimit are not overridden",
+				);
+			}
+			const bundler = new Bundler(bundlerRpc);
+			userOp.callGasLimit = 0n;
+			userOp.verificationGasLimit = 0n;
+			userOp.preVerificationGas = 0n;
+			// Some bundlers reject estimation when fees are set and the sender
+			// has insufficient balance to pay them. Zero them during the
+			// estimate and restore after — same pattern as CandidePaymaster.
+			//
+			// Pimlico is an exception: estimating with maxFeePerGas = 0 makes
+			// its paymaster postOp divide by the fee and revert with
+			// "AA50 postOp reverted: divide by zero". Skip the zeroing for
+			// Pimlico and pass the user-supplied fees through unchanged.
+			const skipFeeZeroing = this.provider === "pimlico";
+			const inputMaxFeePerGas = userOp.maxFeePerGas;
+			const inputMaxPriorityFeePerGas = userOp.maxPriorityFeePerGas;
+			if (!skipFeeZeroing) {
+				userOp.maxFeePerGas = 0n;
+				userOp.maxPriorityFeePerGas = 0n;
+			}
+
+			const estimation = await bundler.estimateUserOperationGas(
+				userOp,
+				entrypoint,
+				overrides.state_override_set as StateOverrideSet | undefined,
+			);
+
+			if (!skipFeeZeroing) {
+				userOp.maxFeePerGas = inputMaxFeePerGas;
+				userOp.maxPriorityFeePerGas = inputMaxPriorityFeePerGas;
+			}
+
+			if (estimation.preVerificationGas > preVerificationGas) {
+				preVerificationGas = estimation.preVerificationGas;
+			}
+			if (estimation.verificationGasLimit > verificationGasLimit) {
+				verificationGasLimit = estimation.verificationGasLimit;
+			}
+			if (estimation.callGasLimit > callGasLimit) {
+				callGasLimit = estimation.callGasLimit;
+			}
+
+			// Overwrite paymaster gas fields with bundler-reported values when
+			// available. Stub responses often leave these as placeholders.
+			if (
+				"paymaster" in userOp &&
+				estimation.paymasterVerificationGasLimit != null
+			) {
+				userOp.paymasterVerificationGasLimit =
+					estimation.paymasterVerificationGasLimit;
+			}
+			if (
+				"paymaster" in userOp &&
+				estimation.paymasterPostOpGasLimit != null
+			) {
+				userOp.paymasterPostOpGasLimit = estimation.paymasterPostOpGasLimit;
+			}
+		}
+
+		if (
+			typeof overrides.preVerificationGas === "bigint" &&
+			overrides.preVerificationGas < 0n
+		) {
+			throw new RangeError("preVerificationGas override can't be negative");
+		}
+		if (
+			typeof overrides.verificationGasLimit === "bigint" &&
+			overrides.verificationGasLimit < 0n
+		) {
+			throw new RangeError("verificationGasLimit override can't be negative");
+		}
+		if (
+			typeof overrides.callGasLimit === "bigint" &&
+			overrides.callGasLimit < 0n
+		) {
+			throw new RangeError("callGasLimit override can't be negative");
+		}
+
+		const applyMultiplier = (value: bigint, multiplier?: number): bigint =>
+			value +
+			(value * BigInt(Math.round((multiplier ?? 0) * 100))) / 10000n;
+
+		userOp.preVerificationGas =
+			overrides.preVerificationGas ??
+			applyMultiplier(
+				preVerificationGas,
+				overrides.preVerificationGasPercentageMultiplier ?? 5,
+			);
+		userOp.verificationGasLimit =
+			overrides.verificationGasLimit ??
+			applyMultiplier(
+				verificationGasLimit,
+				overrides.verificationGasLimitPercentageMultiplier ?? 10,
+			);
+		userOp.callGasLimit =
+			overrides.callGasLimit ??
+			applyMultiplier(
+				callGasLimit,
+				overrides.callGasLimitPercentageMultiplier ?? 10,
+			);
+
+		if (entrypoint.toLowerCase() === ENTRYPOINT_V6.toLowerCase()) {
+			// Align with CandidePaymaster: add paymaster verification overhead for v0.6.
+			// Lowercase compare — overrides.entrypoint is arbitrary user input
+			// and ENTRYPOINT_V6 is checksummed.
+			userOp.verificationGasLimit += 40_000n;
+		}
+		// entrypoint v9 has no special handling here; kept for future use.
+		void ENTRYPOINT_V9;
+	}
+
+	// ── Provider-specific exchange-rate helpers ──────────────────────────
+
+	/**
+	 * Fetch token exchange rate and paymaster address via Pimlico's
+	 * `pimlico_getTokenQuotes` RPC.
+	 *
+	 * @returns `exchangeRate` as a bigint scaled by 10^18 (the value of 1 ETH
+	 *   expressed in the token's smallest unit). Used to compute the token
+	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`.
+	 */
+	private async fetchPimlicoTokenQuote(
+		tokenAddress: string,
+		entrypoint: string,
+		chainIdHex: string,
+	): Promise<{ exchangeRate: bigint; paymasterAddress: string }> {
+		const result = await sendJsonRpcRequest(
+			this.rpcUrl,
+			"pimlico_getTokenQuotes",
+			[{ tokens: [tokenAddress] }, entrypoint, chainIdHex],
+		) as { quotes?: Array<{ paymaster: string; token: string; exchangeRate: string }> };
+
+		const quotes = result?.quotes;
+		if (!Array.isArray(quotes) || quotes.length === 0) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`pimlico_getTokenQuotes returned no quotes for token ${tokenAddress}`,
+			);
+		}
+		const quote = quotes.find(
+			(q) => q.token.toLowerCase() === tokenAddress.toLowerCase(),
+		);
+		if (quote == null) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`pimlico_getTokenQuotes did not include token ${tokenAddress}`,
+			);
+		}
+		return {
+			exchangeRate: BigInt(quote.exchangeRate),
+			paymasterAddress: quote.paymaster,
+		};
+	}
+
+	/**
+	 * Fetch (and cache) Candide's `pm_supportedERC20Tokens` response for the
+	 * given entrypoint. The response carries both exchange rates and the
+	 * `dummyPaymasterAndData` used for gas estimation, so one round-trip
+	 * suffices for the entire paymaster flow.
+	 *
+	 * @param options.enforceTTL - When true, re-fetches if the cached entry is
+	 *   older than {@link CANDIDE_TOKEN_QUOTE_TTL_MS}. Set by exchange-rate
+	 *   lookups (where staleness matters). Stub-data lookups leave this false
+	 *   and reuse the cache indefinitely — the paymaster address and
+	 *   `dummyPaymasterAndData` are effectively static per paymaster version.
+	 */
+	private async fetchCandideSupportedTokens(
+		entrypoint: string,
+		options: { enforceTTL?: boolean } = {},
+	): Promise<CandideSupportedResponse> {
+		const key = entrypoint.toLowerCase();
+		const cached = this.candideCache.get(key);
+		const isStale = cached != null
+			&& options.enforceTTL === true
+			&& Date.now() - cached.fetchedAt > CANDIDE_TOKEN_QUOTE_TTL_MS;
+		if (cached != null && !isStale) return cached.data;
+		const result = await sendJsonRpcRequest(
+			this.rpcUrl,
+			"pm_supportedERC20Tokens",
+			[entrypoint],
+		) as unknown as CandideSupportedResponse;
+		this.candideCache.set(key, { data: result, fetchedAt: Date.now() });
+		return result;
+	}
+
+	/**
+	 * Fetch token exchange rate and paymaster address via Candide's
+	 * `pm_supportedERC20Tokens` RPC.
+	 *
+	 * @returns `exchangeRate` as a bigint scaled by 10^18 (the value of 1 ETH
+	 *   expressed in the token's smallest unit). Used to compute the token
+	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`.
+	 */
+	private async fetchCandideTokenQuote(
+		tokenAddress: string,
+		entrypoint: string,
+	): Promise<{ exchangeRate: bigint; paymasterAddress: string }> {
+		const result = await this.fetchCandideSupportedTokens(entrypoint, { enforceTTL: true });
+
+		const token = result.tokens?.find(
+			(t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
+		);
+		if (token == null) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`${tokenAddress} token is not supported by the Candide paymaster`,
+			);
+		}
+		return {
+			exchangeRate: BigInt(token.exchangeRate),
+			paymasterAddress: result.paymasterMetadata.address,
+		};
+	}
+
+	/**
+	 * Convert Candide's `dummyPaymasterAndData` metadata into a stub result
+	 * compatible with {@link applyPaymasterFields}. Handles both v0.6
+	 * (concatenated hex string) and v0.7+ (structured) shapes.
+	 */
+	private candideStubFromMetadata(
+		metadata: CandideSupportedResponse["paymasterMetadata"],
+	): Erc7677StubDataResult {
+		const dummy = metadata.dummyPaymasterAndData;
+		if (typeof dummy === "string") {
+			return { paymasterAndData: dummy };
+		}
+		return {
+			paymaster: dummy.paymaster,
+			paymasterData: dummy.paymasterData,
+			paymasterVerificationGasLimit: dummy.paymasterVerificationGasLimit,
+			paymasterPostOpGasLimit: dummy.paymasterPostOpGasLimit,
+		};
+	}
+
+	/**
+	 * Get stub paymaster data. For Candide-hosted paymasters this derives the
+	 * stub from the cached `pm_supportedERC20Tokens` response (no extra
+	 * round-trip). For other providers, falls back to `pm_getPaymasterStubData`.
+	 */
+	private async getStubData(
+		userOperation: AnyUserOperation,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context,
+	): Promise<Erc7677StubDataResult> {
+		if (this.provider === "candide") {
+			const response = await this.fetchCandideSupportedTokens(entrypoint);
+			return this.candideStubFromMetadata(response.paymasterMetadata);
+		}
+		return this.getPaymasterStubData(userOperation, entrypoint, chainIdHex, context);
+	}
+
+	/**
+	 * Route to the correct provider-specific token quote fetcher.
+	 * Returns `null` when no provider is configured.
+	 */
+	private async fetchProviderTokenQuote(
+		tokenAddress: string,
+		entrypoint: string,
+		chainIdHex: string,
+	): Promise<{ exchangeRate: bigint; paymasterAddress: string } | null> {
+		switch (this.provider) {
+			case "pimlico":
+				return this.fetchPimlicoTokenQuote(tokenAddress, entrypoint, chainIdHex);
+			case "candide":
+				return this.fetchCandideTokenQuote(tokenAddress, entrypoint);
+			default:
+				return null;
+		}
+	}
+
+	// ── Token paymaster flow ────────────────────────────────────────────
+
+	/**
+	 * Internal token paymaster pipeline. Called from `createPaymasterUserOperation`
+	 * when `context.token` is set and the smart account supports approval prepending.
+	 *
+	 * Three cases:
+	 * - **Provider detected**: exchange rate + paymaster address from provider RPC.
+	 * - **No provider, `context.exchangeRate` set**: uses provided rate, paymaster
+	 *   address from stub.
+	 * - **No provider, no rate**: falls through to the regular sponsored flow
+	 *   (developer already handled approval).
+	 */
+	private async tokenPaymasterFlow<T extends AnyUserOperation>(
+		smartAccount: PrependTokenPaymasterApproveAccount,
+		userOp: T,
+		tokenAddress: string,
+		bundlerRpc: string,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context,
+		overrides: GasPaymasterUserOperationOverrides,
+	): Promise<SameUserOp<T>> {
+		// Step 1 — resolve exchange rate + paymaster address.
+		let exchangeRate: bigint;
+		let paymasterAddress: string | null = null;
+
+		const providerQuote = await this.fetchProviderTokenQuote(
+			tokenAddress,
+			entrypoint,
+			chainIdHex,
+		);
+
+		if (providerQuote != null) {
+			// Case A: provider detected.
+			exchangeRate = providerQuote.exchangeRate;
+			paymasterAddress = providerQuote.paymasterAddress;
+		} else if (context.exchangeRate != null) {
+			// Case B: no provider, but exchangeRate in context.
+			// paymasterAddress is resolved from the stub response below.
+			try {
+				exchangeRate = BigInt(context.exchangeRate as string | bigint);
+			} catch (err) {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					`context.exchangeRate could not be parsed as a bigint: ${String(context.exchangeRate)}`,
+					{ cause: ensureError(err) },
+				);
+			}
+			if (exchangeRate <= 0n) {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					`context.exchangeRate must be > 0, got ${exchangeRate}`,
+				);
+			}
+		} else {
+			// Case C: no provider, no exchangeRate — fall through to regular flow.
+			return this.sponsoredFlow(
+				userOp,
+				bundlerRpc,
+				entrypoint,
+				chainIdHex,
+				context,
+				overrides,
+			);
+		}
+
+		// Step 2 — stub paymaster data for gas estimation.
+		// For Candide, this is derived from the cached `pm_supportedERC20Tokens`
+		// response (same RPC call used for the exchange rate above) — no extra
+		// `pm_getPaymasterStubData` round-trip.
+		const stub = await this.getStubData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, stub);
+
+		// For Case B, resolve paymasterAddress from stub or context override.
+		if (paymasterAddress == null) {
+			if (context.paymasterAddress != null) {
+				paymasterAddress = context.paymasterAddress as string;
+			} else if ("initCode" in userOp && stub.paymasterAndData != null) {
+				// v0.6: extract address from first 20 bytes of paymasterAndData.
+				paymasterAddress = "0x" + stub.paymasterAndData.slice(2, 42);
+			} else if (stub.paymaster != null) {
+				paymasterAddress = stub.paymaster;
+			} else {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					"pm_getPaymasterStubData did not return a paymaster address. " +
+					"Pass paymasterAddress in the context or set a provider.",
+				);
+			}
+		}
+
+		// Step 3 — save original callData, prepend approve(paymaster, UINT256_MAX).
+		const originalCallData = userOp.callData;
+		const requiresAllowanceReset = overrides.resetApproval
+			?? TOKENS_REQUIRING_ALLOWANCE_RESET.includes(tokenAddress.toLowerCase());
+
+		let callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+			userOp.callData,
+			tokenAddress,
+			paymasterAddress,
+			UINT256_MAX,
+		);
+		if (requiresAllowanceReset) {
+			callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+				callDataWithApprove,
+				tokenAddress,
+				paymasterAddress,
+				0n,
+			);
+		}
+		userOp.callData = callDataWithApprove;
+
+		// Step 4 — estimate gas limits.
+		await this.estimateAndApplyGasLimits(userOp, bundlerRpc, entrypoint, overrides);
+
+		// Step 5 — calculate real token cost.
+		const maxGasCostWei = calculateUserOperationMaxGasCost(userOp);
+		const tokenCost = (exchangeRate * maxGasCostWei) / (10n ** 18n);
+		const approveAmount = tokenCost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
+
+		// Step 6 — replace dummy approval with calculated amount on original callData.
+		callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+			originalCallData,
+			tokenAddress,
+			paymasterAddress,
+			approveAmount,
+		);
+		if (requiresAllowanceReset) {
+			callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
+				callDataWithApprove,
+				tokenAddress,
+				paymasterAddress,
+				0n,
+			);
+		}
+		userOp.callData = callDataWithApprove;
+
+		// Step 7 — final paymaster data (signature over the fully-populated
+		// userOp). The token flow always fetches fresh paymaster data: the
+		// stub's `isFinal` cannot be honored here because callData was mutated
+		// after the stub was generated, so any stub signature is over a
+		// different UserOp hash than the one we're about to return.
+		const final = await this.getPaymasterData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, final);
+
+		return userOp as unknown as SameUserOp<T>;
+	}
+
+	/**
+	 * The regular (non-token) sponsored flow: stub → estimate → final.
+	 * Extracted to allow `tokenPaymasterFlow` to fall through to it for Case C.
+	 */
+	private async sponsoredFlow<T extends AnyUserOperation>(
+		userOp: T,
+		bundlerRpc: string,
+		entrypoint: string,
+		chainIdHex: string,
+		context: Erc7677Context,
+		overrides: GasPaymasterUserOperationOverrides,
+	): Promise<SameUserOp<T>> {
+		// Step 1 — stub paymaster data for gas estimation.
+		// Candide-hosted paymasters skip `pm_getPaymasterStubData` and use the
+		// cached `pm_supportedERC20Tokens` response instead.
+		const stub = await this.getStubData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, stub);
+
+		// Step 2 — gas estimation with the stub paymaster applied.
+		await this.estimateAndApplyGasLimits(
+			userOp,
+			bundlerRpc,
+			entrypoint,
+			overrides,
+		);
+
+		// Step 3 — if the stub was already final, we're done.
+		if (stub.isFinal === true) {
+			return userOp as unknown as SameUserOp<T>;
+		}
+
+		// Step 4 — final paymaster data (signature over the fully-populated userOp).
+		const final = await this.getPaymasterData(
+			userOp,
+			entrypoint,
+			chainIdHex,
+			context,
+		);
+		this.applyPaymasterFields(userOp, final);
+
+		return userOp as unknown as SameUserOp<T>;
+	}
+}

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -148,6 +148,20 @@ export interface PrependTokenPaymasterApproveAccount extends SmartAccountWithEnt
 	): string;
 }
 
+/** Known paymaster provider identifiers for provider-specific features (token quotes, etc.). */
+export type Erc7677Provider = "pimlico" | "candide" | null;
+
+/** Constructor options for {@link Erc7677Paymaster}. */
+export interface Erc7677PaymasterConstructorOptions {
+	/** Chain id as a bigint (e.g. `1n` for mainnet). Avoids a lookup at first use. */
+	chainId?: bigint;
+	/**
+	 * Paymaster provider. `"auto"` (default) detects from the RPC URL.
+	 * Set explicitly to override detection, or `null` to disable provider features.
+	 */
+	provider?: "auto" | Erc7677Provider;
+}
+
 /**
  * Base overrides for paymaster-assisted UserOperation creation.
  * Allows manually specifying the EntryPoint address instead of auto-detection.

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,10 @@ export type GasEstimationResult = {
 	preVerificationGas: bigint;
 	/** Estimated gas limit for verification step */
 	verificationGasLimit: bigint;
+	/** Paymaster verification gas limit. Non-standard bundler extension; see `Bundler.estimateUserOperationGas`. */
+	paymasterVerificationGasLimit?: bigint;
+	/** Paymaster post-op gas limit. Non-standard bundler extension; see `Bundler.estimateUserOperationGas`. */
+	paymasterPostOpGasLimit?: bigint;
 };
 
 /** Result of eth_getUserOperationByHash. Null if not found. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,8 +108,8 @@ export type ChainIdResult = string;
 export type SupportedEntryPointsResult = string[];
 
 export type SingleTransactionTenderlySimulationResult = {
-    transaction: any
-    simulation: any
+    transaction: unknown;
+    simulation: { id: string } & Record<string, unknown>;
 }
 
 export type TenderlySimulationResult = SingleTransactionTenderlySimulationResult[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export type ChainIdResult = string;
 export type SupportedEntryPointsResult = string[];
 
 export type SingleTransactionTenderlySimulationResult = {
-    transaction: unknown;
+    transaction: Record<string, unknown>;
     simulation: { id: string } & Record<string, unknown>;
 }
 

--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -12,6 +12,7 @@ import {
 	AbstractionKitError
 } from "./errors";
 import { sendJsonRpcRequest, createUserOperationHash } from "./utils";
+import { Authorization7702Hex } from "./utils7702";
 
 /**
  * State override mapping for Tenderly simulations.
@@ -312,19 +313,19 @@ export interface BaseUserOperationToSimulate {
 	/** The encoded call data to execute on the account. */
 	callData: string;
 	/** The account nonce. */
-	nonce: any;
+	nonce: bigint;
 	/** The gas limit for the main execution call. */
-	callGasLimit: any;
+	callGasLimit: bigint;
 	/** The gas limit for the verification step. */
-	verificationGasLimit: any;
+	verificationGasLimit: bigint;
 	/** The gas overhead to compensate the bundler. */
-	preVerificationGas: any;
+	preVerificationGas: bigint;
 	/** The maximum fee per gas (EIP-1559). */
-	maxFeePerGas: any;
+	maxFeePerGas: bigint;
 	/** The maximum priority fee per gas (EIP-1559). */
-	maxPriorityFeePerGas: any;
+	maxPriorityFeePerGas: bigint;
 	/** The UserOperation signature. */
-	signature: any;
+	signature: string;
 }
 
 /**
@@ -335,7 +336,7 @@ export interface UserOperationV6ToSimulate extends BaseUserOperationToSimulate {
 	/** The concatenated factory address and factory data, or null if already deployed. */
 	initCode: string | null;
 	/** The concatenated paymaster address and paymaster-specific data. */
-	paymasterAndData: any;
+	paymasterAndData: string;
 }
 
 /**
@@ -348,13 +349,13 @@ export interface UserOperationV7ToSimulate extends BaseUserOperationToSimulate {
 	/** The factory-specific initialization data, or null if already deployed. */
 	factoryData: string | null;
 	/** The paymaster contract address. */
-	paymaster: any;
+	paymaster: string | null;
 	/** The gas limit for paymaster verification. */
-	paymasterVerificationGasLimit: any;
+	paymasterVerificationGasLimit: bigint | null;
 	/** The gas limit for paymaster postOp execution. */
-	paymasterPostOpGasLimit: any;
+	paymasterPostOpGasLimit: bigint | null;
 	/** The paymaster-specific data. */
-	paymasterData: any;
+	paymasterData: string | null;
 }
 
 /**
@@ -368,15 +369,15 @@ export interface UserOperationV8ToSimulate extends BaseUserOperationToSimulate {
 	/** The factory-specific initialization data, or null if already deployed. */
 	factoryData: string | null;
 	/** The paymaster contract address. */
-	paymaster: any;
+	paymaster: string | null;
 	/** The gas limit for paymaster verification. */
-	paymasterVerificationGasLimit: any;
+	paymasterVerificationGasLimit: bigint | null;
 	/** The gas limit for paymaster postOp execution. */
-	paymasterPostOpGasLimit: any;
+	paymasterPostOpGasLimit: bigint | null;
 	/** The paymaster-specific data. */
-	paymasterData: any;
+	paymasterData: string | null;
 	/** The EIP-7702 delegation authorization data. */
-    eip7702Auth: any;
+	eip7702Auth: Authorization7702Hex | null;
 }
 
 /**
@@ -421,7 +422,7 @@ export async function simulateUserOperationCallDataWithTenderlyAndCreateShareLin
         blockNumber,
         stateOverrides
     );
-    const simulationIds = simulation.map(s => s.simulation.id) as string[];
+    const simulationIds = simulation.map(s => s.simulation.id);
     await Promise.all(simulationIds.map(simulationId =>
         shareTenderlySimulationAndCreateLink(
             tenderlyAccountSlug,
@@ -643,7 +644,7 @@ export async function simulateSenderCallDataWithTenderlyAndCreateShareLink(
         blockNumber,
         stateOverrides
     );
-    const simulationIds = simulation.map(s => s.simulation.id) as string[];
+    const simulationIds = simulation.map(s => s.simulation.id);
     await Promise.all(simulationIds.map(simulationId =>
         shareTenderlySimulationAndCreateLink(
             tenderlyAccountSlug,

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -1,0 +1,1082 @@
+const http = require('node:http');
+const { Erc7677Paymaster } = require('../../dist/index.cjs');
+
+jest.setTimeout(30000);
+
+/**
+ * Spin up a local HTTP server that responds to a scripted sequence of
+ * JSON-RPC calls. The paymaster class has no network knowledge beyond the
+ * RPC URL we hand it, so a tiny loopback server is enough to cover the
+ * happy path + every branch of the flow.
+ */
+function makeMockRpcServer(handlers) {
+  const calls = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      const { method, params, id } = JSON.parse(body);
+      calls.push({ method, params });
+      const handler = handlers[method];
+      const payload = handler == null
+        ? { id, jsonrpc: '2.0', error: { code: -32601, message: `no mock for ${method}` } }
+        : { id, jsonrpc: '2.0', result: handler(params) };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        calls,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+function v7UserOp(overrides = {}) {
+  return {
+    sender: '0x' + '1'.repeat(40),
+    nonce: 0n,
+    callData: '0x',
+    callGasLimit: 0n,
+    verificationGasLimit: 0n,
+    preVerificationGas: 0n,
+    maxFeePerGas: 1_000_000_000n,
+    maxPriorityFeePerGas: 100_000_000n,
+    signature: '0x',
+    factory: null,
+    factoryData: null,
+    paymaster: null,
+    paymasterVerificationGasLimit: null,
+    paymasterPostOpGasLimit: null,
+    paymasterData: null,
+    ...overrides,
+  };
+}
+
+const CHAIN_ID_HEX = '0x1';
+const CHAIN_ID = 1n;
+const ENTRYPOINT_V7 = '0x0000000071727De22E5E9d8BAf0edAc6f37da032';
+
+/**
+ * Minimal smart account that implements prependTokenPaymasterApproveToCallData.
+ * Tracks calls for assertion purposes.
+ */
+function makeTokenAccount(entrypoint) {
+  const calls = [];
+  return {
+    entrypointAddress: entrypoint,
+    calls,
+    prependTokenPaymasterApproveToCallData(callData, tokenAddress, paymasterAddress, approveAmount) {
+      calls.push({ callData, tokenAddress, paymasterAddress, approveAmount });
+      // Simulate the real prepend semantics: the approve call comes BEFORE
+      // the original callData in execution order (Safe MultiSend / Calibur
+      // BatchedCall / Simple executeBatch all prepend).
+      const marker = `approve(${paymasterAddress},${approveAmount.toString(16)})`;
+      return `${marker}::${callData}`;
+    },
+  };
+}
+
+describe('Erc7677Paymaster', () => {
+  test('createPaymasterUserOperation runs stub → estimate → final', async () => {
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xabcd',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0x1', // placeholder — bundler returns real
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+        paymasterVerificationGasLimit: '0x9999',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xfinal',
+        paymasterVerificationGasLimit: '0x9999',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
+      const smartAccount = { entrypointAddress: ENTRYPOINT_V7 };
+      const userOp = v7UserOp();
+      const context = { sponsorshipPolicyId: 'sp_test' };
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        context,
+      );
+
+      // Final paymaster fields populated from pm_getPaymasterData.
+      expect(out.paymasterData).toBe('0xfinal');
+      // Bundler gas limits applied (with default 5%/10%/10% multipliers).
+      expect(out.preVerificationGas).toBe(0x3000n + (0x3000n * 500n) / 10000n);
+      expect(out.verificationGasLimit).toBe(0x2000n + (0x2000n * 1000n) / 10000n);
+      expect(out.callGasLimit).toBe(0x1000n + (0x1000n * 1000n) / 10000n);
+      // Paymaster gas fields taken from bundler estimation, not the stub placeholder.
+      expect(out.paymasterPostOpGasLimit).toBe(0xa000n);
+      expect(out.paymasterVerificationGasLimit).toBe(0x9999n);
+
+      // Input was not mutated.
+      expect(userOp.paymasterData).toBe(null);
+
+      // Call order: stub → estimate → final.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // Context forwarded verbatim.
+      expect(server.calls[0].params[3]).toEqual(context);
+      expect(server.calls[2].params[3]).toEqual(context);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('stub with isFinal: true skips pm_getPaymasterData', async () => {
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xonly',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+        isFinal: true,
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
+      const out = await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      expect(out.paymasterData).toBe('0xonly');
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual(['pm_getPaymasterStubData', 'eth_estimateUserOperationGas']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('forwards provider-specific context verbatim', async () => {
+    let stubContext = null;
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: (params) => {
+        stubContext = params[3];
+        return {
+          paymaster: '0xPaymaster'.padEnd(42, '0'),
+          paymasterData: '0x',
+          paymasterVerificationGasLimit: '0x8000',
+          paymasterPostOpGasLimit: '0xa000',
+          isFinal: true,
+        };
+      },
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
+      const context = { token: '0xUsdt', custom: { nested: 'value' } };
+      await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+        context,
+      );
+      expect(stubContext).toEqual(context);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('paymaster RPC error surfaces as AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          { entrypointAddress: ENTRYPOINT_V7 },
+          v7UserOp(),
+          server.url,
+        ),
+      ).rejects.toThrow(/pm_getPaymasterStubData failed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('getPaymasterStubData and getPaymasterData can be called independently', async () => {
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({ paymaster: '0xPaymaster'.padEnd(42, '0') }),
+      pm_getPaymasterData: () => ({ paymaster: '0xPaymaster'.padEnd(42, '0'), paymasterData: '0xfinal' }),
+    });
+    try {
+      const paymaster = new Erc7677Paymaster(server.url);
+      const userOp = v7UserOp();
+      const stub = await paymaster.getPaymasterStubData(userOp, ENTRYPOINT_V7, CHAIN_ID_HEX, {});
+      expect(stub.paymaster).toMatch(/^0xPaymaster/);
+      const final = await paymaster.getPaymasterData(userOp, ENTRYPOINT_V7, CHAIN_ID_HEX, {});
+      expect(final.paymasterData).toBe('0xfinal');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Provider detection ──────────────────────────────────────────────
+
+  test('auto-detects pimlico provider from URL', () => {
+    const paymaster = new Erc7677Paymaster('https://api.pimlico.io/v2/sepolia/rpc?apikey=test');
+    expect(paymaster.provider).toBe('pimlico');
+  });
+
+  test('auto-detects candide provider from URL', () => {
+    const paymaster = new Erc7677Paymaster('https://api.candide.dev/paymaster/v3/sepolia/xxx');
+    expect(paymaster.provider).toBe('candide');
+  });
+
+  test('auto-detects null for unknown URL', () => {
+    const paymaster = new Erc7677Paymaster('https://custom-rpc.example.com');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('auto-detect ignores provider name in path (proxy false-positive)', () => {
+    const paymaster = new Erc7677Paymaster('https://my-proxy.com/pimlico-compat/rpc');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('auto-detect ignores provider name in hostname suffix without dot delimiter', () => {
+    // evilpimlico.io ends with "pimlico.io" but is not a pimlico subdomain.
+    const paymaster = new Erc7677Paymaster('https://evilpimlico.io/rpc');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('auto-detect handles malformed URL by returning null', () => {
+    const paymaster = new Erc7677Paymaster('not-a-valid-url');
+    expect(paymaster.provider).toBe(null);
+  });
+
+  // ── Entrypoint case-sensitivity ─────────────────────────────────────
+
+  test('lowercase v0.6 entrypoint override applies the +40_000n overhead', async () => {
+    // ENTRYPOINT_V6 is checksummed in constants.ts; user input may be lowercase.
+    const ENTRYPOINT_V6_LOWER = '0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789';
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: '0xPaymaster'.padEnd(42, '0'),
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
+      const out = await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+        {},
+        { entrypoint: ENTRYPOINT_V6_LOWER },
+      );
+
+      // verificationGasLimit = (0x2000 + 10%) + 40_000n overhead.
+      const baseVgl = 0x2000n + (0x2000n * 1000n) / 10000n;
+      expect(out.verificationGasLimit).toBe(baseVgl + 40_000n);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('explicit provider overrides auto-detection', () => {
+    const paymaster = new Erc7677Paymaster('https://api.pimlico.io/v2/sepolia/rpc', { provider: null });
+    expect(paymaster.provider).toBe(null);
+  });
+
+  test('explicit provider on non-matching URL', () => {
+    const paymaster = new Erc7677Paymaster('https://custom-proxy.example.com', { provider: 'pimlico' });
+    expect(paymaster.provider).toBe('pimlico');
+  });
+
+  // ── sendRPCRequest ──────────────────────────────────────────────────
+
+  test('sendRPCRequest forwards method and params', async () => {
+    const server = await makeMockRpcServer({
+      custom_method: (params) => ({ echo: params }),
+    });
+    try {
+      const paymaster = new Erc7677Paymaster(server.url);
+      const result = await paymaster.sendRPCRequest('custom_method', ['arg1', 'arg2']);
+      expect(result).toEqual({ echo: ['arg1', 'arg2'] });
+      expect(server.calls[0].method).toBe('custom_method');
+      expect(server.calls[0].params).toEqual(['arg1', 'arg2']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('sendRPCRequest wraps errors as AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url);
+      await expect(
+        paymaster.sendRPCRequest('nonexistent_method'),
+      ).rejects.toThrow(/sendRPCRequest\(nonexistent_method\) failed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case A (Pimlico provider) ─────────────────
+
+  test('Case A: pimlico provider runs full token flow', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20);
+    const EXCHANGE_RATE = '0xde0b6b3a7640000'; // 1e18
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: EXCHANGE_RATE,
+          postOpGas: '0x1000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0x1',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+        paymasterVerificationGasLimit: '0x9999',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinaltoken',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Call order: pimlico_getTokenQuotes → stub → estimate → final.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pimlico_getTokenQuotes',
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // Final paymaster data applied.
+      expect(out.paymasterData).toBe('0xfinaltoken');
+
+      // prependTokenPaymasterApproveToCallData was called (first with MAX, then with calculated).
+      expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
+
+      // Input not mutated.
+      expect(userOp.paymasterData).toBe(null);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case A (Candide provider) ─────────────────
+
+  test('Case A: candide provider runs full token flow', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalcandide',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Call order: pm_supportedERC20Tokens → estimate → final.
+      // No pm_getPaymasterStubData — stub data comes from the cached response.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_supportedERC20Tokens',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      expect(out.paymasterData).toBe('0xfinalcandide');
+      expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Candide sponsored flow: skips pm_getPaymasterStubData ──────────
+
+  test('Candide provider: sponsored flow skips pm_getPaymasterStubData', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalsponsored',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const out = await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      // Call order: pm_supportedERC20Tokens → estimate → final.
+      // Skips pm_getPaymasterStubData by deriving stub from the cached response.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_supportedERC20Tokens',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+      expect(out.paymasterData).toBe('0xfinalsponsored');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Candide TTL: token flow re-fetches after 45s ────────────────────
+
+  test('Candide provider: token flow re-fetches pm_supportedERC20Tokens after TTL', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    jest.useFakeTimers({ doNotFake: ['setTimeout', 'setInterval', 'setImmediate', 'clearTimeout', 'clearInterval', 'clearImmediate', 'nextTick', 'queueMicrotask'] });
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      // 1st token flow call — fetches pm_supportedERC20Tokens.
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Advance time past the 45s TTL.
+      jest.setSystemTime(new Date('2024-01-01T00:00:46Z'));
+
+      // 2nd token flow call — TTL expired, should re-fetch.
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      const supportedCalls = server.calls.filter((c) => c.method === 'pm_supportedERC20Tokens');
+      expect(supportedCalls.length).toBe(2);
+    } finally {
+      jest.useRealTimers();
+      await server.close();
+    }
+  });
+
+  test('Candide provider: sponsored flow uses cache indefinitely (ignores TTL)', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    jest.useFakeTimers({ doNotFake: ['setTimeout', 'setInterval', 'setImmediate', 'clearTimeout', 'clearInterval', 'clearImmediate', 'nextTick', 'queueMicrotask'] });
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+
+      // 1st sponsored call — fetches pm_supportedERC20Tokens for stub data.
+      await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      // Advance time far past TTL.
+      jest.setSystemTime(new Date('2024-01-01T01:00:00Z'));
+
+      // 2nd sponsored call — TTL does NOT apply, reuses cache.
+      await paymaster.createPaymasterUserOperation(
+        { entrypointAddress: ENTRYPOINT_V7 },
+        v7UserOp(),
+        server.url,
+      );
+
+      const supportedCalls = server.calls.filter((c) => c.method === 'pm_supportedERC20Tokens');
+      expect(supportedCalls.length).toBe(1);
+    } finally {
+      jest.useRealTimers();
+      await server.close();
+    }
+  });
+
+  // ── Candide: single pm_supportedERC20Tokens call for combined flow ──
+
+  test('Candide provider: only one pm_supportedERC20Tokens call (cached)', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummydata',
+          },
+        },
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      // Token quote + stub data both come from a SINGLE pm_supportedERC20Tokens call.
+      const supportedCalls = server.calls.filter((c) => c.method === 'pm_supportedERC20Tokens');
+      expect(supportedCalls.length).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case B (exchangeRate in context) ──────────
+
+  test('Case B: no provider, exchangeRate in context runs token flow', async () => {
+    const PAYMASTER_ADDR = '0x' + 'ee'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'ff'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalrate',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' },
+      );
+
+      // No provider-specific RPC call.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // Paymaster address from stub was used in approve calls.
+      expect(smartAccount.calls[0].paymasterAddress).toBe(PAYMASTER_ADDR);
+      expect(out.paymasterData).toBe('0xfinalrate');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: Case C (fallthrough) ──────────────────────
+
+  test('Case C: no provider, no exchangeRate falls through to sponsored flow', async () => {
+    const PAYMASTER_ADDR = '0x' + '11'.repeat(20);
+    const TOKEN_ADDR = '0x' + '22'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalsponsored',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const originalCallData = '0xoriginal';
+      const userOp = v7UserOp({ callData: originalCallData });
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR }, // no exchangeRate
+      );
+
+      // Regular sponsored flow — no provider RPC, no prependTokenPaymasterApproveToCallData calls.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toEqual([
+        'pm_getPaymasterStubData',
+        'eth_estimateUserOperationGas',
+        'pm_getPaymasterData',
+      ]);
+
+      // prependTokenPaymasterApproveToCallData was NOT called.
+      expect(smartAccount.calls.length).toBe(0);
+
+      // context.token was forwarded to paymaster RPCs.
+      expect(server.calls[0].params[3]).toEqual({ token: TOKEN_ADDR });
+      expect(out.paymasterData).toBe('0xfinalsponsored');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token flow ignores stub.isFinal (callData mutates after stub) ──
+
+  test('token flow still calls pm_getPaymasterData even when stub.isFinal is true', async () => {
+    const PAYMASTER_ADDR = '0x' + 'ee'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'ff'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+        isFinal: true, // would be unsafe to honor — callData mutates after stub
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      const out = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR, exchangeRate: '0xde0b6b3a7640000' },
+      );
+
+      // pm_getPaymasterData was called even though the stub claimed isFinal:
+      // the token flow mutates callData, so the stub's signature would be
+      // invalid against the final UserOp hash.
+      const methods = server.calls.map((c) => c.method);
+      expect(methods).toContain('pm_getPaymasterData');
+      expect(out.paymasterData).toBe('0xfinal');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Case B: invalid exchangeRate validation ─────────────────────────
+
+  test('Case B: unparseable exchangeRate throws AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: '0x' + 'aa'.repeat(20), exchangeRate: 'not-a-number' },
+        ),
+      ).rejects.toThrow(/exchangeRate could not be parsed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('Case B: zero exchangeRate throws AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: '0x' + 'aa'.repeat(20), exchangeRate: 0n },
+        ),
+      ).rejects.toThrow(/exchangeRate must be > 0/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('Case B: negative exchangeRate throws AbstractionKitError', async () => {
+    const server = await makeMockRpcServer({});
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: '0x' + 'aa'.repeat(20), exchangeRate: '-1' },
+        ),
+      ).rejects.toThrow(/exchangeRate must be > 0/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: USDT allowance reset ──────────────────────
+
+  test('USDT-like token gets approve(0) prepended', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    // Mainnet USDT address (in the TOKENS_REQUIRING_ALLOWANCE_RESET list)
+    const USDT_ADDR = '0xdac17f958d2ee523a2206206994597c13d831ec7';
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: USDT_ADDR,
+          exchangeRate: '0xde0b6b3a7640000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinalusdt',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: USDT_ADDR },
+      );
+
+      // Should have approve(0) calls (for reset) in addition to approve(MAX) and approve(calculated).
+      const zeroApproveCalls = smartAccount.calls.filter((c) => c.approveAmount === 0n);
+      expect(zeroApproveCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: resetApproval override ────────────────────
+
+  test('resetApproval override forces approve(0) for non-USDT token', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20); // Not USDT
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: '0xde0b6b3a7640000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        v7UserOp(),
+        server.url,
+        { token: TOKEN_ADDR },
+        { resetApproval: true },
+      );
+
+      // Should have approve(0) calls even though token is not USDT.
+      const zeroApproveCalls = smartAccount.calls.filter((c) => c.approveAmount === 0n);
+      expect(zeroApproveCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  // ── Token paymaster flow: input not mutated ─────────────────────────
+
+  test('token flow does not mutate the input UserOperation', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: '0xde0b6b3a7640000',
+        }],
+      }),
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      const userOp = v7UserOp();
+      const originalCallData = userOp.callData;
+      const originalPaymasterData = userOp.paymasterData;
+
+      await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR },
+      );
+
+      expect(userOp.callData).toBe(originalCallData);
+      expect(userOp.paymasterData).toBe(originalPaymasterData);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
Release 0.3.1. See [CHANGELOG.md](../blob/dev/CHANGELOG.md#031) for full notes.

**Highlights**
- New `Erc7677Paymaster` (provider-agnostic ERC-7677 client; works with Candide/Pimlico/Alchemy/...)
- Breaking: `SafeMultiChainSigAccountV1.formatSignaturesToUseroperationsSignatures` now takes per-op overrides (see CHANGELOG for migration)