### PR TITLE
feat(account): add signUserOperationWithSigner across accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
     signature: wallet.signingKey.sign(userOpHash).serialized,
   });
   ```
-  The recommended signing path is raw-hash ECDSA over `userOpHash` (viem: `walletClient.sign({ hash })`, ethers: `wallet.signingKey.sign(hash)`). Simple7702 and Calibur only accept the raw form; Safe additionally accepts EIP-191-wrapped signatures but only with `v ∈ {31, 32}`, which default `signMessage` tooling does not produce. For Safe, `walletClient.signTypedData(...)` with the supplied `typedData` is the structured-UX equivalent of raw signing.
+  The recommended signing path is raw-hash ECDSA over `userOpHash` (viem: `privateKeyToAccount(pk).sign({ hash })` on a Local Account; ethers: `wallet.signingKey.sign(hash)`). Raw-hash signing requires a local/derived key — JSON-RPC wallets (MetaMask, etc.) do not expose it. Simple7702 and Calibur only accept the raw form, so they cannot be driven by JSON-RPC wallets. Safe additionally accepts EIP-191-wrapped signatures but only with `v ∈ {31, 32}`, which default `signMessage` tooling does not produce; for Safe, `signTypedData(...)` with the supplied `typedData` is the structured-UX equivalent of raw signing and works with JSON-RPC wallets.
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [Unreleased]
+
+### New Features
+
+- **`signUserOperationWithSigner`**: new method on `Calibur7702Account`, `Simple7702Account`, `Simple7702AccountV09`, `SafeAccountV0_2_0`, `SafeAccountV0_3_0`, and `SafeAccountV1_5_0_M_0_3_0` for integrating external signers (viem, ethers Signers, hardware wallets, MPC signers) without passing raw private keys.
+- **Shared `SignerFunction` / `AddressedSignerFunction` / `SignerInput` / `SignerResult` / `SignerTypedData` types** exported from the package root. `SignerInput` carries `userOpHash`, the full `userOperation`, `chainId`, `entryPoint`, and — for Safe accounts — an EIP-712 `typedData` bundle so signers can use `signTypedData` for structured wallet display. Signers return `{ signerAddress?: string; signature: string }`. Safe accounts require the stricter `AddressedSignerFunction` (signer must declare its address) — signatures are ordered by signer address on-chain and ecrecover is unreliable for contract signers, WebAuthn-wrapped signatures, and `eth_sign`-flavored signatures with `v ∈ {31, 32}`.
+
+### Breaking Changes
+
+> **Note on versioning.** The `SignerFunction` shape change below is a breaking change, but it does not necessarily trigger a major version bump. `Calibur7702Account` is not yet in use in any production environment, and we're communicating directly with the developers currently building against it to coordinate the migration.
+
+- **`Calibur7702Account` `SignerFunction` shape changed.** The callback now receives a `SignerInput` context object and returns `{ signerAddress?, signature }` instead of a bare signature string. Migration:
+  ```ts
+  // Before (0.3.1):
+  const signer = (hash) => wallet.signingKey.sign(hash).serialized;
+  // After (0.4.0):
+  const signer = async ({ userOpHash }) => ({
+    signature: wallet.signingKey.sign(userOpHash).serialized,
+  });
+  ```
+  The recommended signing path is raw-hash ECDSA over `userOpHash` (viem: `walletClient.sign({ hash })`, ethers: `wallet.signingKey.sign(hash)`). Simple7702 and Calibur only accept the raw form; Safe additionally accepts EIP-191-wrapped signatures but only with `v ∈ {31, 32}`, which default `signMessage` tooling does not produce. For Safe, `walletClient.signTypedData(...)` with the supplied `typedData` is the structured-UX equivalent of raw signing.
+
 ## 0.3.1
 
 ### New Features

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -7,7 +7,7 @@ export { CaliburKeyType } from "./account/Calibur/types";
 export type {
 	CaliburKey, CaliburKeySettings, CaliburKeySettingsResult,
 	WebAuthnSignatureData, CaliburCreateUserOperationOverrides,
-	CaliburSignatureOverrides, SignerFunction,
+	CaliburSignatureOverrides,
 } from "./account/Calibur/types";
 export {
 	SocialRecoveryModule,
@@ -135,6 +135,11 @@ export type {
 	MetaTransaction,
     SponsorMetadata,
     ParallelPaymasterInitValues,
+    SignerFunction,
+    AddressedSignerFunction,
+    SignerInput,
+    SignerResult,
+    SignerTypedData,
 } from "./types";
 
 export {

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -627,11 +627,19 @@ export class Calibur7702Account extends SmartAccount
 	 * // EIP-191 prefix. Use a raw-hash signing API, not `personal_sign` /
 	 * // `signMessage`, or the signature will not verify.
 	 * // The signer may omit `signerAddress` — it is ignored for Calibur.
+	 * //
+	 * // Raw-hash signing requires a local/derived key (private key, mnemonic,
+	 * // HD key, or hardware wallet exposed as a local account). JSON-RPC
+	 * // wallets like MetaMask do NOT expose raw-hash signing — they only
+	 * // support `personal_sign` and `eth_signTypedData_v4`.
+	 * import { privateKeyToAccount } from 'viem/accounts';
+	 * const localAccount = privateKeyToAccount(privateKey);
+	 *
 	 * userOp.signature = await account.signUserOperationWithSigner(
 	 *   userOp,
-	 *   // viem:
+	 *   // viem local account:
 	 *   async ({ userOpHash }) => ({
-	 *     signature: await walletClient.sign({ hash: userOpHash }),
+	 *     signature: await localAccount.sign({ hash: userOpHash }),
 	 *   }),
 	 *   // ethers v6:
 	 *   // async ({ userOpHash }) => ({

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -4,7 +4,7 @@ import {
 	createCallData, createUserOperationHash, fetchAccountNonce,
 	getDelegatedAddress, getFunctionSelector, handlefetchGasPrice, sendJsonRpcRequest
 } from "../../utils";
-import { UserOperationV8 } from "src/types";
+import { SignerFunction, UserOperationV8 } from "src/types";
 import { AbstractionKitError } from "src/errors";
 import {
 	Authorization7702Hex, bigintToHex,
@@ -19,7 +19,7 @@ import { PrependTokenPaymasterApproveAccount } from "src/paymaster/types";
 import {
 	CaliburKeyType, CaliburKey, CaliburKeySettings, CaliburKeySettingsResult,
 	WebAuthnSignatureData, CaliburCreateUserOperationOverrides,
-	CaliburSignatureOverrides, SignerFunction,
+	CaliburSignatureOverrides,
 } from "./types";
 
 
@@ -617,22 +617,32 @@ export class Calibur7702Account extends SmartAccount
 	 * secondary key, pass its key hash via `overrides.keyHash`.
 	 *
 	 * @param userOperation - The UserOperation to sign
-	 * @param signer - Async signing function: `(hash: string) => Promise<string>`
+	 * @param signer - Async signing function receiving a {@link SignerInput}
 	 * @param chainId - Target chain ID
 	 * @param overrides - Optional overrides (keyHash for secondary keys, hookData)
 	 * @returns Promise resolving to the hex-encoded wrapped signature
 	 *
 	 * @example
-	 * // Sign with a viem wallet client
+	 * // Calibur verifies a raw ECDSA signature over the userOp hash — no
+	 * // EIP-191 prefix. Use a raw-hash signing API, not `personal_sign` /
+	 * // `signMessage`, or the signature will not verify.
+	 * // The signer may omit `signerAddress` — it is ignored for Calibur.
 	 * userOp.signature = await account.signUserOperationWithSigner(
 	 *   userOp,
-	 *   (hash) => walletClient.signMessage({ message: { raw: hash } }),
+	 *   // viem:
+	 *   async ({ userOpHash }) => ({
+	 *     signature: await walletClient.sign({ hash: userOpHash }),
+	 *   }),
+	 *   // ethers v6:
+	 *   // async ({ userOpHash }) => ({
+	 *   //   signature: wallet.signingKey.sign(userOpHash).serialized,
+	 *   // }),
 	 *   chainId,
 	 * );
 	 */
 	public async signUserOperationWithSigner(
 		userOperation: UserOperationV8,
-		signer: SignerFunction,
+		signer: SignerFunction<UserOperationV8>,
 		chainId: bigint,
 		overrides: CaliburSignatureOverrides = {},
 	): Promise<string> {
@@ -643,8 +653,13 @@ export class Calibur7702Account extends SmartAccount
 		);
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
 		const hookData = overrides.hookData ?? "0x";
-		const ecdsaSig = await signer(userOperationHash);
-		return Calibur7702Account.wrapSignature(keyHash, ecdsaSig, hookData);
+		const { signature } = await signer({
+			userOpHash: userOperationHash,
+			userOperation,
+			chainId,
+			entryPoint: this.entrypointAddress,
+		});
+		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);
 	}
 
 	/**

--- a/src/account/Calibur/types.ts
+++ b/src/account/Calibur/types.ts
@@ -146,9 +146,3 @@ export interface CaliburSignatureOverrides {
 	keyHash?: string;
 }
 
-/**
- * A signing function that takes a hash and returns a raw signature.
- * Use this to integrate viem, ethers Signers, hardware wallets, or MPC signers
- * without passing raw private keys.
- */
-export type SignerFunction = (hash: string) => Promise<string>;

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1917,6 +1917,10 @@ export class SafeAccount extends SmartAccount {
 	 * recovery is unreliable for contract signers, WebAuthn-wrapped
 	 * signatures, and `v ∈ {31, 32}` eth_sign-flavored signatures.
 	 *
+	 * Signers are invoked in parallel; if multiple callbacks share an
+	 * interactive wallet session (e.g., `window.ethereum` prompts), sequence
+	 * them inside your callback to avoid overlapping popups.
+	 *
 	 * @param useroperation - useroperation to sign
 	 * @param signers - one signer function per signer (any order)
 	 * @param chainId - target chain id

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -17,6 +17,7 @@ import {
 	ENTRYPOINT_V7,
 	EIP712_SAFE_OPERATION_V7_TYPE,
 	EIP712_SAFE_OPERATION_V6_TYPE,
+	EIP712_SAFE_OPERATION_PRIMARY_TYPE,
     ENTRYPOINT_V9,
 } from "../../constants";
 import {
@@ -31,6 +32,7 @@ import {
     OnChainIdentifierParamsType,
     TenderlySimulationResult,
     UserOperationV9,
+    AddressedSignerFunction,
 } from "../../types";
 import {
 	createCallData,
@@ -1898,6 +1900,105 @@ export class SafeAccount extends SmartAccount {
 				validAfter,
 				validUntil,
                 isMultiChainSignature:overrides.isMultiChainSignature
+			},
+		);
+	}
+
+	/**
+	 * Create a useroperation signature using external signer functions
+	 * (viem, ethers Signers, hardware wallets, MPC signers, etc.) instead
+	 * of raw private keys. Each signer is invoked with a {@link SignerInput}
+	 * exposing both the EIP-712 hash (`userOpHash`) and the full typed-data
+	 * bundle (`typedData`), so the signer can use `signTypedData` for
+	 * structured wallet display or sign the raw hash directly.
+	 *
+	 * Each signer MUST return its own `signerAddress` alongside the
+	 * signature — Safe orders signatures by signer address on-chain and
+	 * recovery is unreliable for contract signers, WebAuthn-wrapped
+	 * signatures, and `v ∈ {31, 32}` eth_sign-flavored signatures.
+	 *
+	 * @param useroperation - useroperation to sign
+	 * @param signers - one signer function per signer (any order)
+	 * @param chainId - target chain id
+	 * @param entrypointAddress - target entrypoint
+	 * @param safe4337ModuleAddress - safe 4337 module address
+	 * @param overrides - overrides for the default values
+	 * @returns signature
+	 */
+	public static async baseSignSingleUserOperationWithSigner<
+		T extends UserOperationV6 | UserOperationV7,
+	>(
+		useroperation: T,
+		signers: AddressedSignerFunction<T>[],
+		chainId: bigint,
+		entrypointAddress: string,
+		safe4337ModuleAddress: string,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			isMultiChainSignature?: boolean;
+		} = {},
+	): Promise<string> {
+		const validAfter = overrides.validAfter ?? 0n;
+		const validUntil = overrides.validUntil ?? 0n;
+
+		if (signers.length < 1) {
+			throw new RangeError("There should be at least one signer");
+		}
+		if (chainId < 0n) {
+			throw new RangeError("chainId can't be negative");
+		}
+		if (validAfter < 0n) {
+			throw new RangeError("validAfter can't be negative");
+		}
+		if (validUntil < 0n) {
+			throw new RangeError("validUntil can't be negative");
+		}
+
+		const typedData = SafeAccount.getUserOperationEip712Data(
+			useroperation,
+			chainId,
+			{
+				validAfter,
+				validUntil,
+				entrypointAddress,
+				safe4337ModuleAddress,
+			},
+		);
+		const userOperationEip712Hash = TypedDataEncoder.hash(
+			typedData.domain,
+			typedData.types,
+			typedData.messageValue,
+		);
+
+		const signerInput = {
+			userOpHash: userOperationEip712Hash,
+			userOperation: useroperation,
+			chainId,
+			entryPoint: entrypointAddress,
+			typedData: {
+				domain: typedData.domain,
+				types: typedData.types,
+				primaryType: EIP712_SAFE_OPERATION_PRIMARY_TYPE,
+				message: typedData.messageValue,
+			},
+		};
+
+		const results = await Promise.all(
+			signers.map((sign) => sign(signerInput)),
+		);
+
+		const signerSignaturePairs = results.map(({ signerAddress, signature }) => ({
+			signer: getAddress(signerAddress),
+			signature,
+		}));
+
+		return SafeAccount.formatSignaturesToUseroperationSignature(
+			signerSignaturePairs,
+			{
+				validAfter,
+				validUntil,
+				isMultiChainSignature: overrides.isMultiChainSignature,
 			},
 		);
 	}

--- a/src/account/Safe/SafeAccountV0_2_0.ts
+++ b/src/account/Safe/SafeAccountV0_2_0.ts
@@ -9,7 +9,7 @@ import {
 	SignerSignaturePair,
 } from "./types";
 
-import { UserOperationV6, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
+import { UserOperationV6, MetaTransaction, OnChainIdentifierParamsType, AddressedSignerFunction, StateOverrideSet } from "../../types";
 import { ENTRYPOINT_V6 } from "src/constants";
 import { createCallData } from "src/utils";
 import { SafeAccountV0_3_0 } from "./SafeAccountV0_3_0";
@@ -493,5 +493,40 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 			this.safe4337ModuleAddress,
 			overrides
 		)
+	}
+
+	/**
+	 * Sign a UserOperation using one or more external {@link AddressedSignerFunction}s
+	 * (viem, ethers Signers, hardware wallets, MPC signers, etc.) instead of
+	 * raw private keys. Each signer receives a {@link SignerInput} exposing
+	 * both the EIP-712 hash and the full typed-data bundle, and must return
+	 * `{ signerAddress, signature }` — Safe orders signatures by signer
+	 * address on-chain, and recovery is unreliable for contract signers,
+	 * WebAuthn-wrapped signatures, and `v ∈ {31, 32}` eth_sign-flavored
+	 * signatures.
+	 *
+	 * @param useroperation - The UserOperation to sign
+	 * @param signers - One addressed signer function per signer
+	 * @param chainId - The target chain ID
+	 * @param overrides - Override validAfter / validUntil
+	 * @returns Promise resolving to the formatted signature string
+	 */
+	public signUserOperationWithSigner(
+		useroperation: UserOperationV6,
+		signers: AddressedSignerFunction<UserOperationV6>[],
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+		} = {},
+	): Promise<string> {
+		return SafeAccount.baseSignSingleUserOperationWithSigner(
+			useroperation,
+			signers,
+			chainId,
+			this.entrypointAddress,
+			this.safe4337ModuleAddress,
+			overrides,
+		);
 	}
 }

--- a/src/account/Safe/SafeAccountV0_2_0.ts
+++ b/src/account/Safe/SafeAccountV0_2_0.ts
@@ -505,6 +505,10 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 	 * WebAuthn-wrapped signatures, and `v ∈ {31, 32}` eth_sign-flavored
 	 * signatures.
 	 *
+	 * Signers are invoked in parallel; if multiple callbacks share an
+	 * interactive wallet session (e.g., `window.ethereum` prompts), sequence
+	 * them inside your callback to avoid overlapping popups.
+	 *
 	 * @param useroperation - The UserOperation to sign
 	 * @param signers - One addressed signer function per signer
 	 * @param chainId - The target chain ID

--- a/src/account/Safe/SafeAccountV0_3_0.ts
+++ b/src/account/Safe/SafeAccountV0_3_0.ts
@@ -409,6 +409,10 @@ export class SafeAccountV0_3_0 extends SafeAccount {
 	 * WebAuthn-wrapped signatures, and `v ∈ {31, 32}` eth_sign-flavored
 	 * signatures.
 	 *
+	 * Signers are invoked in parallel; if multiple callbacks share an
+	 * interactive wallet session (e.g., `window.ethereum` prompts), sequence
+	 * them inside your callback to avoid overlapping popups.
+	 *
 	 * @param useroperation - The UserOperation to sign
 	 * @param signers - One addressed signer function per signer
 	 * @param chainId - The target chain ID

--- a/src/account/Safe/SafeAccountV0_3_0.ts
+++ b/src/account/Safe/SafeAccountV0_3_0.ts
@@ -9,7 +9,7 @@ import {
 	SignerSignaturePair,
 } from "./types";
 
-import { UserOperationV7, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
+import { UserOperationV7, MetaTransaction, OnChainIdentifierParamsType, AddressedSignerFunction, StateOverrideSet } from "../../types";
 import { ENTRYPOINT_V7, Safe_L2_V1_4_1 } from "src/constants";
 
 /**
@@ -397,6 +397,41 @@ export class SafeAccountV0_3_0 extends SafeAccount {
 			this.safe4337ModuleAddress,
 			overrides
 		)
+	}
+
+	/**
+	 * Sign a UserOperation using one or more external {@link AddressedSignerFunction}s
+	 * (viem, ethers Signers, hardware wallets, MPC signers, etc.) instead of
+	 * raw private keys. Each signer receives a {@link SignerInput} exposing
+	 * both the EIP-712 hash and the full typed-data bundle, and must return
+	 * `{ signerAddress, signature }` — Safe orders signatures by signer
+	 * address on-chain, and recovery is unreliable for contract signers,
+	 * WebAuthn-wrapped signatures, and `v ∈ {31, 32}` eth_sign-flavored
+	 * signatures.
+	 *
+	 * @param useroperation - The UserOperation to sign
+	 * @param signers - One addressed signer function per signer
+	 * @param chainId - The target chain ID
+	 * @param overrides - Override validAfter / validUntil
+	 * @returns Promise resolving to the formatted signature string
+	 */
+	public signUserOperationWithSigner(
+		useroperation: UserOperationV7,
+		signers: AddressedSignerFunction<UserOperationV7>[],
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+		} = {},
+	): Promise<string> {
+		return SafeAccount.baseSignSingleUserOperationWithSigner(
+			useroperation,
+			signers,
+			chainId,
+			this.entrypointAddress,
+			this.safe4337ModuleAddress,
+			overrides,
+		);
 	}
 }
 

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -5,7 +5,7 @@ import {
     getDelegatedAddress, getFunctionSelector, handlefetchGasPrice,
     sendJsonRpcRequest
 } from "../../utils";
-import { GasOption, PolygonChain, StateOverrideSet, UserOperationV8, UserOperationV9 } from "src/types";
+import { GasOption, PolygonChain, SignerFunction, StateOverrideSet, UserOperationV8, UserOperationV9 } from "src/types";
 import { AbstractionKitError } from "src/errors";
 import {
     Authorization7702Hex, bigintToHex,
@@ -760,6 +760,38 @@ export class BaseSimple7702Account extends SmartAccount {
 		const wallet = new Wallet(privateKey);
         return wallet.signingKey.sign(userOperationHash).serialized;
 	}
+
+    /**
+     * Sign a UserOperation with an external {@link SignerFunction} (viem,
+     * ethers Signer, hardware wallet, MPC signer, etc.). Computes the
+     * UserOperation hash and invokes the signer with a {@link SignerInput}
+     * context so it can choose raw vs EIP-191 signing.
+     *
+     * @param useroperation - The UserOperation to sign
+     * @param signer - Async signing function receiving a SignerInput
+     * @param chainId - Target chain ID
+     * @returns Promise resolving to the hex-encoded signature
+     */
+    protected async baseSignUserOperationWithSigner<
+        T extends UserOperationV8 | UserOperationV9,
+    >(
+        useroperation: T,
+        signer: SignerFunction<T>,
+        chainId: bigint,
+    ): Promise<string> {
+        const userOperationHash = createUserOperationHash(
+            useroperation,
+            this.entrypointAddress,
+            chainId,
+        );
+        const { signature } = await signer({
+            userOpHash: userOperationHash,
+            userOperation: useroperation,
+            chainId,
+            entryPoint: this.entrypointAddress,
+        });
+        return signature;
+    }
     
     /**
 	 * Submit a signed UserOperation to a bundler for on-chain inclusion.
@@ -974,6 +1006,45 @@ export class Simple7702Account extends BaseSimple7702Account {
 		chainId: bigint,
     ): string {
         return this.baseSignUserOperation(useroperation, privateKey, chainId);
+    }
+
+    /**
+     * Sign a {@link UserOperationV8} with an external signer (viem, ethers
+     * Signer, hardware wallet, MPC signer, etc.) instead of a raw private key.
+     *
+     * @param useroperation - The UserOperation to sign
+     * @param signer - Async signing function receiving a SignerInput
+     * @param chainId - Target chain ID
+     * @returns Promise resolving to the hex-encoded signature
+     *
+     * @example
+     * // The Simple7702 delegatee verifies a raw ECDSA signature over the
+     * // userOp hash — no EIP-191 prefix. Use a raw-hash signing API, not
+     * // `personal_sign` / `signMessage`, or the signature will not verify.
+     * // The signer may omit `signerAddress` — it is ignored for Simple7702.
+     * userOp.signature = await account.signUserOperationWithSigner(
+     *   userOp,
+     *   // viem:
+     *   async ({ userOpHash }) => ({
+     *     signature: await walletClient.sign({ hash: userOpHash }),
+     *   }),
+     *   // ethers v6:
+     *   // async ({ userOpHash }) => ({
+     *   //   signature: wallet.signingKey.sign(userOpHash).serialized,
+     *   // }),
+     *   chainId,
+     * );
+     */
+    public async signUserOperationWithSigner(
+        useroperation: UserOperationV8,
+        signer: SignerFunction<UserOperationV8>,
+        chainId: bigint,
+    ): Promise<string> {
+        return this.baseSignUserOperationWithSigner(
+            useroperation,
+            signer,
+            chainId,
+        );
     }
 
     /**

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -1022,11 +1022,19 @@ export class Simple7702Account extends BaseSimple7702Account {
      * // userOp hash — no EIP-191 prefix. Use a raw-hash signing API, not
      * // `personal_sign` / `signMessage`, or the signature will not verify.
      * // The signer may omit `signerAddress` — it is ignored for Simple7702.
+     * //
+     * // Raw-hash signing requires a local/derived key (private key, mnemonic,
+     * // HD key, or hardware wallet exposed as a local account). JSON-RPC
+     * // wallets like MetaMask do NOT expose raw-hash signing — they only
+     * // support `personal_sign` and `eth_signTypedData_v4`.
+     * import { privateKeyToAccount } from 'viem/accounts';
+     * const localAccount = privateKeyToAccount(privateKey);
+     *
      * userOp.signature = await account.signUserOperationWithSigner(
      *   userOp,
-     *   // viem:
+     *   // viem local account:
      *   async ({ userOpHash }) => ({
-     *     signature: await walletClient.sign({ hash: userOpHash }),
+     *     signature: await localAccount.sign({ hash: userOpHash }),
      *   }),
      *   // ethers v6:
      *   // async ({ userOpHash }) => ({

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -1,4 +1,4 @@
-import { StateOverrideSet, UserOperationV9 } from "src/types";
+import { SignerFunction, StateOverrideSet, UserOperationV9 } from "src/types";
 import { BaseSimple7702Account, CreateUserOperationOverrides, SimpleMetaTransaction } from "./Simple7702Account";
 import { ENTRYPOINT_V9 } from "src/constants";
 import { SendUseroperationResponse } from "../SendUseroperationResponse";
@@ -94,6 +94,27 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 		chainId: bigint,
     ): string {
         return this.baseSignUserOperation(useroperation, privateKey, chainId);
+    }
+
+    /**
+     * Sign a {@link UserOperationV9} with an external signer (viem, ethers
+     * Signer, hardware wallet, MPC signer, etc.) instead of a raw private key.
+     *
+     * @param useroperation - The UserOperation to sign
+     * @param signer - Async signing function receiving a SignerInput
+     * @param chainId - Target chain ID
+     * @returns Promise resolving to the hex-encoded signature
+     */
+    public async signUserOperationWithSigner(
+        useroperation: UserOperationV9,
+        signer: SignerFunction<UserOperationV9>,
+        chainId: bigint,
+    ): Promise<string> {
+        return this.baseSignUserOperationWithSigner(
+            useroperation,
+            signer,
+            chainId,
+        );
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -499,10 +499,19 @@ export interface SignerTypedData {
  *   output directly to a Safe account will still fail verification unless
  *   the caller manually adds 4 to `v`.
  *
- * **Recommended**: sign `userOpHash` raw (viem: `walletClient.sign({ hash })`,
- * ethers: `wallet.signingKey.sign(hash).serialized`), or — for Safe —
- * use `typedData` with `signTypedData(...)` for structured wallet UX. These
+ * **Recommended**: sign `userOpHash` raw (viem:
+ * `privateKeyToAccount(pk).sign({ hash })`, ethers:
+ * `wallet.signingKey.sign(hash).serialized`), or — for Safe — use
+ * `typedData` with `signTypedData(...)` for structured wallet UX. These
  * paths work across every account in this SDK without `v` manipulation.
+ *
+ * Raw-hash signing requires a local/derived key: a private key, mnemonic,
+ * HD key, or hardware wallet exposed as a viem Local Account / ethers
+ * Signer. JSON-RPC wallets (MetaMask, WalletConnect-backed wallets, etc.)
+ * do NOT expose raw-hash signing — they only implement `personal_sign` and
+ * `eth_signTypedData_v4`. For those, use `typedData` + `signTypedData(...)`
+ * on Safe accounts; Simple7702 and Calibur are incompatible with JSON-RPC
+ * signers for UserOp signing.
  */
 export interface SignerInput<
 	TUserOp extends
@@ -519,8 +528,9 @@ export interface SignerInput<
 	 * The 32-byte hash the signer should produce a signature over (hex string).
 	 *
 	 * The simplest and most portable choice is to sign this hash raw
-	 * (`signingKey.sign(hash)` in ethers, `walletClient.sign({ hash })` in
-	 * viem). Every account in this SDK accepts a raw signature.
+	 * (`signingKey.sign(hash)` in ethers, `account.sign({ hash })` on a
+	 * viem Local Account). Every account in this SDK accepts a raw
+	 * signature.
 	 *
 	 * Simple7702 and Calibur only accept the raw form. Safe additionally
 	 * accepts an EIP-191-wrapped (`eth_sign`) signature, but only when the

--- a/src/types.ts
+++ b/src/types.ts
@@ -453,3 +453,150 @@ export interface ParallelPaymasterInitValues {
 	paymasterPostOpGasLimit: bigint;
 	paymasterData: string;
 }
+
+/**
+ * EIP-712 typed data bundle. Exposed to signers that prefer structured
+ * `signTypedData` over raw hash signing (better wallet UX — Metamask &
+ * hardware wallets can display structured fields instead of a hex blob).
+ */
+export interface SignerTypedData {
+	/** EIP-712 domain separator fields */
+	domain: {
+		name?: string;
+		version?: string;
+		chainId?: number | bigint;
+		verifyingContract?: string;
+		salt?: string;
+	};
+	/** EIP-712 type definitions */
+	types: Record<string, { name: string; type: string }[]>;
+	/** Name of the root type being signed */
+	primaryType: string;
+	/** The structured message to sign */
+	message: unknown;
+}
+
+/**
+ * Context passed to a {@link SignerFunction}.
+ * Exposes the hash to sign plus surrounding context so the signer can
+ * choose its preferred signing scheme.
+ *
+ * The `userOpHash` is what the on-chain validator recovers against —
+ * for Simple7702 and Calibur it is the ERC-4337 userOperation hash; for
+ * Safe accounts it is the EIP-712 digest of the SafeOp struct. When
+ * `typedData` is present, signing it via `signTypedData` is equivalent to
+ * signing `userOpHash` raw (both produce the same digest).
+ *
+ * ## Which signing scheme is accepted?
+ *
+ * - **Simple7702** (eth-infinitism reference) and **Calibur** verify a
+ *   plain ECDSA signature over `userOpHash` — raw only, no EIP-191.
+ * - **Safe** (4337 module → `Safe.checkSignatures`) accepts **both** a
+ *   raw signature over the EIP-712 digest (`v ∈ {27, 28}`) and an
+ *   `eth_sign`-style EIP-191-wrapped signature (`v ∈ {31, 32}`, i.e.
+ *   standard `v + 4`). Most tooling (`viem.signMessage`, `ethers.signMessage`)
+ *   emits `v = 27 / 28` even when wrapping with EIP-191, so passing that
+ *   output directly to a Safe account will still fail verification unless
+ *   the caller manually adds 4 to `v`.
+ *
+ * **Recommended**: sign `userOpHash` raw (viem: `walletClient.sign({ hash })`,
+ * ethers: `wallet.signingKey.sign(hash).serialized`), or — for Safe —
+ * use `typedData` with `signTypedData(...)` for structured wallet UX. These
+ * paths work across every account in this SDK without `v` manipulation.
+ */
+export interface SignerInput<
+	TUserOp extends
+		| UserOperationV6
+		| UserOperationV7
+		| UserOperationV8
+		| UserOperationV9 =
+		| UserOperationV6
+		| UserOperationV7
+		| UserOperationV8
+		| UserOperationV9,
+> {
+	/**
+	 * The 32-byte hash the signer should produce a signature over (hex string).
+	 *
+	 * The simplest and most portable choice is to sign this hash raw
+	 * (`signingKey.sign(hash)` in ethers, `walletClient.sign({ hash })` in
+	 * viem). Every account in this SDK accepts a raw signature.
+	 *
+	 * Simple7702 and Calibur only accept the raw form. Safe additionally
+	 * accepts an EIP-191-wrapped (`eth_sign`) signature, but only when the
+	 * signature's `v` byte is 31 or 32 — which default `signMessage` tooling
+	 * does not produce.
+	 */
+	userOpHash: string;
+	/** The full UserOperation — useful for signers that want to inspect or display it. */
+	userOperation: TUserOp;
+	/** Target chain ID. */
+	chainId: bigint;
+	/** EntryPoint contract address the userOp will be submitted to. */
+	entryPoint: string;
+	/**
+	 * EIP-712 typed data equivalent of `userOpHash`, when the account signs
+	 * via EIP-712 (Safe accounts). Absent for accounts that sign the raw
+	 * userOp hash directly (Simple7702, Calibur). Signing via
+	 * `signTypedData(domain, types, message)` produces a signature over the
+	 * same digest as signing `userOpHash` raw.
+	 */
+	typedData?: SignerTypedData;
+}
+
+/**
+ * Result returned by a {@link SignerFunction}.
+ * `signerAddress` is optional for accounts that don't need it (Simple7702,
+ * Calibur). For accounts that require it (Safe — see {@link AddressedSignerFunction}),
+ * the type system enforces that it is present.
+ */
+export interface SignerResult {
+	/**
+	 * The Ethereum address that produced `signature`. Optional here so a
+	 * signer targeting Simple7702 / Calibur can return just `{ signature }`.
+	 * Safe account methods require this via {@link AddressedSignerFunction}.
+	 */
+	signerAddress?: string;
+	/** The hex-encoded signature bytes. */
+	signature: string;
+}
+
+/**
+ * A signing function that receives a {@link SignerInput} context and returns
+ * a {@link SignerResult}. Use this to integrate viem, ethers Signers,
+ * hardware wallets, or MPC signers without passing raw private keys.
+ *
+ * Assignable from {@link AddressedSignerFunction} (return-type covariance),
+ * so a "proper" signer that always reports its address works anywhere a
+ * lax `SignerFunction` is expected.
+ */
+export type SignerFunction<
+	TUserOp extends
+		| UserOperationV6
+		| UserOperationV7
+		| UserOperationV8
+		| UserOperationV9 =
+		| UserOperationV6
+		| UserOperationV7
+		| UserOperationV8
+		| UserOperationV9,
+> = (input: SignerInput<TUserOp>) => Promise<SignerResult>;
+
+/**
+ * A stricter {@link SignerFunction} that MUST return `signerAddress`.
+ * Used by Safe accounts, where signatures must be ordered by signer address
+ * on-chain and the signer's address cannot be inferred reliably (contract
+ * signers, WebAuthn-wrapped signatures, and `eth_sign`-flavored signatures
+ * with `v ∈ {31, 32}` all break naive ecrecover).
+ */
+export type AddressedSignerFunction<
+	TUserOp extends
+		| UserOperationV6
+		| UserOperationV7
+		| UserOperationV8
+		| UserOperationV9 =
+		| UserOperationV6
+		| UserOperationV7
+		| UserOperationV8
+		| UserOperationV9,
+> = (input: SignerInput<TUserOp>) => Promise<Required<SignerResult>>;

--- a/test/calibur/calibur7702Account.test.js
+++ b/test/calibur/calibur7702Account.test.js
@@ -699,9 +699,9 @@ describe('Calibur7702Account', () => {
             eip7702Auth: null,
         };
 
-        const signerFn = async (hash) => {
-            return wallet.signingKey.sign(hash).serialized;
-        };
+        const signerFn = async ({ userOpHash }) => ({
+            signature: wallet.signingKey.sign(userOpHash).serialized,
+        });
 
         const sigFromSigner = await account.signUserOperationWithSigner(userOp, signerFn, 11155111n);
         const sigFromKey = account.signUserOperation(userOp, signingKey, 11155111n);
@@ -726,7 +726,9 @@ describe('Calibur7702Account', () => {
             eip7702Auth: null,
         };
 
-        const signerFn = async (hash) => wallet.signingKey.sign(hash).serialized;
+        const signerFn = async ({ userOpHash }) => ({
+            signature: wallet.signingKey.sign(userOpHash).serialized,
+        });
 
         const sigFromSigner = await account.signUserOperationWithSigner(userOp, signerFn, 11155111n, { keyHash });
         const sigFromKey = account.signUserOperation(userOp, signingKey, 11155111n, { keyHash });


### PR DESCRIPTION
## Summary
  - Adds `signUserOperationWithSigner` to `Simple7702Account`, `Simple7702AccountV09`, `SafeAccountV0_2_0`, and
  `SafeAccountV0_3_0` for integrating viem / ethers Signers / hardware wallets / MPC signers without raw private keys.
  - Introduces shared `SignerFunction`, `AddressedSignerFunction`, `SignerInput`, `SignerResult`, and `SignerTypedData`
  types in `src/types.ts` (re-exported from the package root). Safe accounts use the stricter `AddressedSignerFunction`
  since signatures are ordered by signer address on-chain and ecrecover is unreliable for contract / WebAuthn / `v ∈
  {31, 32}` signatures.
  - Safe `SignerInput` includes a `typedData` bundle so signers can use `signTypedData` for structured wallet UX instead
   of signing an opaque hash.

  ## Breaking changes
  - `Calibur7702Account.signUserOperationWithSigner` callback shape changed: signer now receives a `SignerInput` context
   and returns `{ signerAddress?, signature }` instead of taking a bare hash and returning a string. See `CHANGELOG.md`
  for the migration snippet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external signer integration methods to all major account types, enabling signing via external services (viem, ethers, hardware, MPC) without raw private keys
  * New shared signer types exported for broader ecosystem integration

* **Breaking Changes**
  * SignerFunction callback return type changed from a bare signature string to a structured object containing signature and optional signer address

* **Documentation**
  * Updated changelog documenting new signer capabilities and integration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->