### PR TITLE
feat(safe): add signUserOperationWithSigner for external signers

### DIFF
--- a/src/account/Safe/SafeAccountV0_2_0.ts
+++ b/src/account/Safe/SafeAccountV0_2_0.ts
@@ -8,6 +8,7 @@ import {
     SafeUserOperationV6TypedMessageValue,
 	SignerSignaturePair,
 } from "./types";
+import type { SignerFunction } from "../Calibur/types";
 
 import { UserOperationV6, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
 import { ENTRYPOINT_V6 } from "src/constants";
@@ -493,5 +494,38 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 			this.safe4337ModuleAddress,
 			overrides
 		)
+	}
+
+	/**
+	 * Sign a UserOperation with an external signer.
+	 * See {@link SafeAccountV0_3_0.signUserOperationWithSigner} for full
+	 * documentation and examples.
+	 */
+	public async signUserOperationWithSigner(
+		useroperation: UserOperationV6,
+		signer: SignerFunction,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+		} = {},
+	): Promise<string> {
+		const userOperationEip712Hash =
+			SafeAccountV0_2_0.getUserOperationEip712Hash(
+				useroperation,
+				chainId,
+				{
+					entrypointAddress: this.entrypointAddress,
+					safe4337ModuleAddress: this.safe4337ModuleAddress,
+					...overrides,
+				},
+			);
+
+		const signature = await signer(userOperationEip712Hash);
+
+		return SafeAccount.formatEip712SingleSignatureToUseroperationSignature(
+			signature,
+			overrides,
+		);
 	}
 }

--- a/src/account/Safe/SafeAccountV0_3_0.ts
+++ b/src/account/Safe/SafeAccountV0_3_0.ts
@@ -8,6 +8,7 @@ import {
     SafeAccountSingleton,
 	SignerSignaturePair,
 } from "./types";
+import type { SignerFunction } from "../Calibur/types";
 
 import { UserOperationV7, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
 import { ENTRYPOINT_V7, Safe_L2_V1_4_1 } from "src/constants";
@@ -397,6 +398,82 @@ export class SafeAccountV0_3_0 extends SafeAccount {
 			this.safe4337ModuleAddress,
 			overrides
 		)
+	}
+
+	/**
+	 * Sign a UserOperation with an external signer (viem, ethers Signer,
+	 * hardware wallet, MPC signer, Uint8Array-based key, etc.).
+	 *
+	 * Computes the Safe EIP-712 hash, passes it to the provided async
+	 * callback, and wraps the returned ECDSA signature in the Safe 4337
+	 * module's expected format (validAfter ‖ validUntil ‖ signature).
+	 *
+	 * This method never receives or handles the private key itself — only
+	 * the opaque signing callback. This is important for integrations that
+	 * keep keys in non-exportable storage (HSMs, secure enclaves, passkey
+	 * providers) or as non-string types (Uint8Array) that can be zeroed
+	 * after use.
+	 *
+	 * @param useroperation - The UserOperation to sign
+	 * @param signer - Async signing function: receives the EIP-712 hash as a
+	 *   hex string (`0x`-prefixed, 32 bytes) and must return the 65-byte ECDSA
+	 *   signature as a hex string (`0x`-prefixed, `r ‖ s ‖ v`).
+	 * @param chainId - Target chain ID
+	 * @param overrides - Override validAfter and validUntil timestamps
+	 * @returns Promise resolving to the formatted signature string ready to
+	 *   set on the UserOperation
+	 *
+	 * @example
+	 * // Sign with a Uint8Array private key via \@noble/curves
+	 * import { secp256k1 } from "\@noble/curves/secp256k1";
+	 *
+	 * userOp.signature = await smartAccount.signUserOperationWithSigner(
+	 *   userOp,
+	 *   async (hash) => {
+	 *     const { r, s, recovery } = secp256k1.sign(
+	 *       hash.slice(2), privateKeyBytes, { lowS: true },
+	 *     );
+	 *     const v = recovery === 1 ? "1c" : "1b";
+	 *     return "0x" + r.toString(16).padStart(64, "0")
+	 *                  + s.toString(16).padStart(64, "0") + v;
+	 *   },
+	 *   chainId,
+	 * );
+	 *
+	 * @example
+	 * // Sign with an ethers Signer
+	 * userOp.signature = await smartAccount.signUserOperationWithSigner(
+	 *   userOp,
+	 *   (hash) => ethersSigner.signMessage(ethers.getBytes(hash)),
+	 *   chainId,
+	 * );
+	 */
+	public async signUserOperationWithSigner(
+		useroperation: UserOperationV7,
+		signer: SignerFunction,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+		} = {},
+	): Promise<string> {
+		const userOperationEip712Hash =
+			SafeAccountV0_3_0.getUserOperationEip712Hash(
+				useroperation,
+				chainId,
+				{
+					entrypointAddress: this.entrypointAddress,
+					safe4337ModuleAddress: this.safe4337ModuleAddress,
+					...overrides,
+				},
+			);
+
+		const signature = await signer(userOperationEip712Hash);
+
+		return SafeAccount.formatEip712SingleSignatureToUseroperationSignature(
+			signature,
+			overrides,
+		);
 	}
 }
 

--- a/test/safe/signUserOperationWithSigner.test.js
+++ b/test/safe/signUserOperationWithSigner.test.js
@@ -1,0 +1,167 @@
+const { SafeAccountV0_3_0, SafeAccountV0_2_0 } = require('../../dist/index.cjs');
+const { Wallet } = require('ethers');
+
+jest.setTimeout(30000);
+
+// Well-known test key — never used on mainnet.
+const TEST_PRIVATE_KEY =
+	'0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_WALLET = new Wallet(TEST_PRIVATE_KEY);
+const CHAIN_ID = 11155111n; // Sepolia
+
+function v7UserOp(overrides = {}) {
+	return {
+		sender: '0x' + '1'.repeat(40),
+		nonce: 0n,
+		callData: '0xdeadbeef',
+		callGasLimit: 10000n,
+		verificationGasLimit: 20000n,
+		preVerificationGas: 30000n,
+		maxFeePerGas: 1_000_000_000n,
+		maxPriorityFeePerGas: 100_000_000n,
+		signature: '0x',
+		factory: null,
+		factoryData: null,
+		paymaster: null,
+		paymasterVerificationGasLimit: null,
+		paymasterPostOpGasLimit: null,
+		paymasterData: null,
+		...overrides,
+	};
+}
+
+function v6UserOp(overrides = {}) {
+	return {
+		sender: '0x' + '1'.repeat(40),
+		nonce: 0n,
+		callData: '0xdeadbeef',
+		callGasLimit: 10000n,
+		verificationGasLimit: 20000n,
+		preVerificationGas: 30000n,
+		maxFeePerGas: 1_000_000_000n,
+		maxPriorityFeePerGas: 100_000_000n,
+		signature: '0x',
+		initCode: '0x',
+		paymasterAndData: '0x',
+		...overrides,
+	};
+}
+
+describe('SafeAccountV0_3_0.signUserOperationWithSigner', () => {
+	test('produces same signature as signUserOperation with matching key', async () => {
+		const account = SafeAccountV0_3_0.initializeNewAccount([
+			TEST_WALLET.address,
+		]);
+		const userOp = v7UserOp();
+
+		// Sign with the existing string-key method.
+		const expected = account.signUserOperation(
+			userOp,
+			[TEST_PRIVATE_KEY],
+			CHAIN_ID,
+		);
+
+		// Sign with the new callback method.
+		// The callback receives the EIP-712 hash and returns an ECDSA signature.
+		const actual = await account.signUserOperationWithSigner(
+			userOp,
+			async (hash) => {
+				return TEST_WALLET.signingKey.sign(hash).serialized;
+			},
+			CHAIN_ID,
+		);
+
+		expect(actual).toBe(expected);
+	});
+
+	test('works with validAfter and validUntil overrides', async () => {
+		const account = SafeAccountV0_3_0.initializeNewAccount([
+			TEST_WALLET.address,
+		]);
+		const userOp = v7UserOp();
+		const overrides = { validAfter: 1000n, validUntil: 2000n };
+
+		const expected = account.signUserOperation(
+			userOp,
+			[TEST_PRIVATE_KEY],
+			CHAIN_ID,
+			overrides,
+		);
+
+		const actual = await account.signUserOperationWithSigner(
+			userOp,
+			async (hash) => TEST_WALLET.signingKey.sign(hash).serialized,
+			CHAIN_ID,
+			overrides,
+		);
+
+		expect(actual).toBe(expected);
+	});
+
+	test('works with an already-deployed account (no factory)', async () => {
+		const account = new SafeAccountV0_3_0(
+			'0xA3B60390b4F0223714bbAB69226AC7A81B3f111C',
+		);
+		const userOp = v7UserOp();
+
+		const actual = await account.signUserOperationWithSigner(
+			userOp,
+			async (hash) => TEST_WALLET.signingKey.sign(hash).serialized,
+			CHAIN_ID,
+		);
+
+		// Signature should be a valid hex string with the Safe 4337 format:
+		// uint48 validAfter + uint48 validUntil + 65-byte ECDSA signature
+		expect(actual).toMatch(/^0x[0-9a-f]+$/i);
+		// 12 bytes (validAfter + validUntil) + 65 bytes (signature) = 77 bytes
+		// = 154 hex chars + 2 for '0x' prefix
+		expect(actual.length).toBe(2 + 154);
+	});
+
+	test('signer receives the EIP-712 hash, not the raw UserOp hash', async () => {
+		const account = SafeAccountV0_3_0.initializeNewAccount([
+			TEST_WALLET.address,
+		]);
+		const userOp = v7UserOp();
+
+		let receivedHash = null;
+		await account.signUserOperationWithSigner(
+			userOp,
+			async (hash) => {
+				receivedHash = hash;
+				return TEST_WALLET.signingKey.sign(hash).serialized;
+			},
+			CHAIN_ID,
+		);
+
+		// The hash should be the Safe EIP-712 hash, not the EntryPoint userOp hash.
+		const expectedHash = SafeAccountV0_3_0.getUserOperationEip712Hash(
+			userOp,
+			CHAIN_ID,
+		);
+		expect(receivedHash).toBe(expectedHash);
+	});
+});
+
+describe('SafeAccountV0_2_0.signUserOperationWithSigner', () => {
+	test('produces same signature as signUserOperation with matching key', async () => {
+		const account = SafeAccountV0_2_0.initializeNewAccount([
+			TEST_WALLET.address,
+		]);
+		const userOp = v6UserOp();
+
+		const expected = account.signUserOperation(
+			userOp,
+			[TEST_PRIVATE_KEY],
+			CHAIN_ID,
+		);
+
+		const actual = await account.signUserOperationWithSigner(
+			userOp,
+			async (hash) => TEST_WALLET.signingKey.sign(hash).serialized,
+			CHAIN_ID,
+		);
+
+		expect(actual).toBe(expected);
+	});
+});


### PR DESCRIPTION
## Summary

Adds `signUserOperationWithSigner` to `SafeAccountV0_3_0`, `SafeAccountV0_2_0`, and `SafeAccountV1_5_0_M_0_3_0` (via inheritance). Follows the same pattern as `Calibur7702Account.signUserOperationWithSigner` — async callback that receives the EIP-712 hash and returns an ECDSA signature.

Follow-up to the conversation in PR #102 about accommodating external signers.

## Why

`signUserOperation(op, privateKeys: string[], chainId)` requires hex-stringifying the private key. This is a problem for integrations that:

- Keep keys as `Uint8Array` and zero the buffer on dispose (Tether WDK's security posture)
- Use HSMs or secure enclaves where the key never leaves the hardware
- Use passkey/WebAuthn providers
- Use MPC signers where no single party holds the full key

The workaround was reaching past the public API to call `getUserOperationEip712Hash` + `formatEip712SingleSignatureToUseroperationSignature` directly. This method makes that a first-class, documented API.

## API

```ts
// SafeAccountV0_3_0 (and SafeAccountV1_5_0_M_0_3_0 via inheritance)
async signUserOperationWithSigner(
  useroperation: UserOperationV7,
  signer: SignerFunction,  // (hash: string) => Promise<string>
  chainId: bigint,
  overrides?: { validAfter?: bigint; validUntil?: bigint },
): Promise<string>

// SafeAccountV0_2_0
async signUserOperationWithSigner(
  useroperation: UserOperationV6,
  signer: SignerFunction,
  chainId: bigint,
  overrides?: { validAfter?: bigint; validUntil?: bigint },
): Promise<string>
```

`SignerFunction` is the same type already exported from Calibur types — `(hash: string) => Promise<string>`.

## Flow

1. Compute the Safe EIP-712 hash via `getUserOperationEip712Hash`
2. Pass the hash to the async `signer` callback
3. Wrap the returned signature via `formatEip712SingleSignatureToUseroperationSignature`

## Compatibility

Strictly additive — no existing methods changed, no signatures modified, no exports removed.

Reuses `SignerFunction` from `src/account/Calibur/types.ts` (already exported at top level) to avoid duplicating the type.

## Tests

5 tests covering:
- Signature parity with `signUserOperation` using the same key
- `validAfter` / `validUntil` overrides
- Already-deployed accounts (no factory)
- Signer receives EIP-712 hash (not raw UserOp hash)
- V0_2_0 parity

## End-to-end validation

Validated against live Pimlico and Candide bundlers on Sepolia via Tether's WDK integration (28/28 flows pass). The WDK's signer uses `@noble/curves/secp256k1` with a `Uint8Array` private key — the key never touches a string at any point in the flow.

## Test plan

- [x] New unit tests pass (5/5)
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Build succeeds (`yarn build`)
- [x] Live Sepolia — Pimlico 14/14
- [x] Live Sepolia — Candide 14/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new signing method for Safe accounts, allowing custom signer functions to sign user operations while supporting optional validity time parameter overrides.

* **Tests**
  * Added extensive test coverage for the new signing method across Safe account versions, validating signature formatting and signer callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->