### PR TITLE
feat(signer)!: add capability-oriented ExternalSigner signing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 
 - **`ExternalSigner` interface**: `{ address, signHash?, signTypedData? }` discriminated union that enforces at least one of the two methods at compile time. Accepts any signer that matches the shape (viem local account, viem WalletClient, ethers Wallet, hardware wallet, MPC, WebAuthn, Uint8Array-held keys). The library has zero runtime dependency on viem or ethers for this surface.
 - **`fromPrivateKey(pk)` / `fromViem(account)` / `fromEthersWallet(wallet)` / `fromViemWalletClient(client)` adapters**: one-line factories returning an `ExternalSigner`. Structural types only. `fromViem` / `fromViemWalletClient` require viem ≥ 2.0; `fromEthersWallet` requires ethers ≥ 6.0.
-- **`SignHashFn` / `SignTypedDataFn` / `TypedData` / `SigningScheme` types** exported from the package root for implementers of custom signers.
+- **`SignHashFn` / `SignTypedDataFn` / `TypedData` / `SigningScheme` / `SignContext` / `MultiOpSignContext` types** exported from the package root for implementers of custom signers.
+- **`SignContext` forwarded to signers, narrowly typed per signing path**: signers receive a context as the second arg of `signHash` / `signTypedData` so custom validator implementations can inspect the userOp. `Signer<C>` is generic over context (default `C = SignContext` for single-op `{userOperation, chainId, entryPoint}`; opt into `ExternalSigner<MultiOpSignContext>` for `signUserOperationsWithSigners`'s `{userOperations[], entryPoint}`). Built-in adapters return `Signer<unknown>` and work everywhere. See `src/signer/types.ts`.
 - **`SafeMultiChainSigAccountV1.signUserOperationsWithSigners`**: new async multi-op variant that signs a Merkle-rooted bundle of UserOperations with a single signature across chains, using `ExternalSigner[]`.
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [Unreleased]
+
+### New Features
+
+- **`signUserOperationWithSigner(s)` + `ExternalSigner` (capability-oriented signing API)**: new async method on every account class for integrating viem, ethers Signers, hardware wallets, HSMs, MPC, WebAuthn, or Uint8Array-only signers without passing raw private keys. Each account declares its accepted schemes via a static `ACCEPTED_SIGNING_SCHEMES: ReadonlyArray<"hash" | "typedData">`, and incompatible signers fail offline with an actionable error. The method naming mirrors the parameter arity:
+  - Safe accounts (multi-signer): `signUserOperationWithSigners(op, signers[], chainId)` — plural.
+  - Simple7702 / Calibur (single signer): `signUserOperationWithSigner(op, signer, chainId)` — singular.
+
+  Call-site is one line:
+  ```ts
+  import { fromViem } from "abstractionkit"
+  userOp.signature = await safe.signUserOperationWithSigners(
+      userOp, [fromViem(account)], chainId,
+  )
+  ```
+
+- **`ExternalSigner` interface**: `{ address, signHash?, signTypedData? }` discriminated union that enforces at least one of the two methods at compile time. Accepts any signer that matches the shape (viem local account, viem WalletClient, ethers Wallet, hardware wallet, MPC, WebAuthn, Uint8Array-held keys). The library has zero runtime dependency on viem or ethers for this surface.
+- **`fromPrivateKey(pk)` / `fromViem(account)` / `fromEthersWallet(wallet)` / `fromViemWalletClient(client)` adapters**: one-line factories returning an `ExternalSigner`. Structural types only. `fromViem` / `fromViemWalletClient` require viem ≥ 2.0; `fromEthersWallet` requires ethers ≥ 6.0.
+- **`SignHashFn` / `SignTypedDataFn` / `TypedData` / `SigningScheme` types** exported from the package root for implementers of custom signers.
+- **`SafeMultiChainSigAccountV1.signUserOperationsWithSigners`**: new async multi-op variant that signs a Merkle-rooted bundle of UserOperations with a single signature across chains, using `ExternalSigner[]`.
+
+### Breaking Changes
+
+> **Note on versioning.** The callback-API removal below is a breaking change for callers of `signUserOperationWithSigner`'s prior callback shape on `Calibur7702Account`. Calibur is not yet in use in any production environment; we're communicating directly with the developers currently building against it to coordinate the migration.
+
+- **Callback signing API removed.** `signUserOperationWithSigner(op, callback, chainId)` as introduced in the original signer PR is gone, along with the `SignerFunction`, `AddressedSignerFunction`, `SignerInput`, `SignerResult`, and `SignerTypedData` types. The callback method name is now reused for the new capability-oriented API on single-signer accounts (Simple7702, Calibur) with a different parameter shape. Migration:
+  ```ts
+  // Before:
+  const signer = async ({ userOpHash }) => ({
+    signature: wallet.signingKey.sign(userOpHash).serialized,
+  });
+  userOp.signature = await account.signUserOperationWithSigner(userOp, signer, chainId);
+
+  // After — Simple7702 / Calibur (single signer):
+  import { fromEthersWallet } from "abstractionkit";
+  userOp.signature = await account.signUserOperationWithSigner(
+    userOp, fromEthersWallet(wallet), chainId,
+  );
+
+  // After — Safe accounts (multi-signer, plural method name):
+  userOp.signature = await safe.signUserOperationWithSigners(
+    userOp, [fromEthersWallet(wallet)], chainId,
+  );
+  ```
+
+### Migration: Signing with a raw private key
+
+The existing sync `signUserOperation(op, pk[] | pk, chainId): string` method on every account **is untouched**. If your code passes a hex private-key string directly, no change needed. The new `signUserOperationWithSigner(s)` methods are Signers-only — they do NOT accept bare pk strings. To sign with a pk string via the new API, wrap explicitly:
+
+```ts
+import { fromPrivateKey } from "abstractionkit";
+userOp.signature = await safe.signUserOperationWithSigners(
+  userOp, [fromPrivateKey(pk)], chainId,
+);
+```
+
 ## 0.3.1
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@
 
 > **Note on versioning.** The callback-API removal below is a breaking change for callers of `signUserOperationWithSigner`'s prior callback shape on `Calibur7702Account`. Calibur is not yet in use in any production environment; we're communicating directly with the developers currently building against it to coordinate the migration.
 
+- **`SafeAccount.baseSignSingleUserOperation` is now `protected static`.** Previously `public static`, which leaked an internal helper into the package surface. All callers should use the version-specific subclass methods that wrap it (`SafeAccountV0_2_0#signUserOperation`, `SafeAccountV0_3_0#signUserOperation`, etc.) — they auto-inject the correct entrypoint and 4337 module addresses. Migration:
+  ```ts
+  // Before:
+  const sig = SafeAccount.baseSignSingleUserOperation(
+    op, [pk], chainId,
+    SafeAccountV0_3_0.DEFAULT_ENTRYPOINT_ADDRESS,
+    SafeAccountV0_3_0.DEFAULT_SAFE_4337_MODULE_ADDRESS,
+  );
+  // After:
+  const sig = safeV3.signUserOperation(op, [pk], chainId);
+  ```
+  `baseSignUserOperationWithSigners` (introduced earlier in this Unreleased window) is also `protected static` for the same reason; no migration needed since it was never on a released `latest` tag.
+- **`ViemLocalAccountLike` / `ViemWalletClientLike` / `EthersWalletLike` are no longer exported.** They're internal structural shapes the adapters match against; pass concrete viem / ethers instances directly to `fromViem` / `fromViemWalletClient` / `fromEthersWallet`. If you need to type a wrapper, use `Parameters<typeof fromViem>[0]` (etc.).
 - **Callback signing API removed.** `signUserOperationWithSigner(op, callback, chainId)` as introduced in the original signer PR is gone, along with the `SignerFunction`, `AddressedSignerFunction`, `SignerInput`, `SignerResult`, and `SignerTypedData` types. The callback method name is now reused for the new capability-oriented API on single-signer accounts (Simple7702, Calibur) with a different parameter shape. Migration:
   ```ts
   // Before:

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -20,6 +20,8 @@ export type {
 	TypedData,
 	SignHashFn,
 	SignTypedDataFn,
+	SignContext,
+	MultiOpSignContext,
 } from "./signer/types";
 export {
 	fromPrivateKey,

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -7,8 +7,27 @@ export { CaliburKeyType } from "./account/Calibur/types";
 export type {
 	CaliburKey, CaliburKeySettings, CaliburKeySettingsResult,
 	WebAuthnSignatureData, CaliburCreateUserOperationOverrides,
-	CaliburSignatureOverrides, SignerFunction,
+	CaliburSignatureOverrides,
 } from "./account/Calibur/types";
+
+// ─── Signer interface design (capability-oriented) ──────────────────────
+// Exported as `ExternalSigner` because the old package-level `Signer` is
+// already taken by an owner-identifier union in Safe/types. An eventual
+// rename there would promote this to the unqualified `Signer`.
+export type {
+	Signer as ExternalSigner,
+	SigningScheme,
+	TypedData,
+	SignHashFn,
+	SignTypedDataFn,
+} from "./signer/types";
+export {
+	fromPrivateKey,
+	fromViem, fromEthersWallet, fromViemWalletClient,
+} from "./signer/adapters";
+export type {
+	ViemLocalAccountLike, ViemWalletClientLike, EthersWalletLike,
+} from "./signer/adapters";
 export {
 	SocialRecoveryModule,
 	SocialRecoveryModuleGracePeriodSelector,

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -27,9 +27,10 @@ export {
 	fromPrivateKey,
 	fromViem, fromEthersWallet, fromViemWalletClient,
 } from "./signer/adapters";
-export type {
-	ViemLocalAccountLike, ViemWalletClientLike, EthersWalletLike,
-} from "./signer/adapters";
+// ViemLocalAccountLike / ViemWalletClientLike / EthersWalletLike are NOT
+// exported. They're internal structural shapes the adapters match against;
+// callers pass concrete viem / ethers instances directly. If you need the
+// input type for a wrapper, use `Parameters<typeof fromViem>[0]` etc.
 export {
 	SocialRecoveryModule,
 	SocialRecoveryModuleGracePeriodSelector,

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -5,6 +5,8 @@ import {
 	getDelegatedAddress, getFunctionSelector, handlefetchGasPrice, sendJsonRpcRequest
 } from "../../utils";
 import { UserOperationV8 } from "src/types";
+import { Signer as AkSigner, SigningScheme } from "src/signer/types";
+import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { AbstractionKitError } from "src/errors";
 import {
 	Authorization7702Hex, bigintToHex,
@@ -19,7 +21,7 @@ import { PrependTokenPaymasterApproveAccount } from "src/paymaster/types";
 import {
 	CaliburKeyType, CaliburKey, CaliburKeySettings, CaliburKeySettingsResult,
 	WebAuthnSignatureData, CaliburCreateUserOperationOverrides,
-	CaliburSignatureOverrides, SignerFunction,
+	CaliburSignatureOverrides,
 } from "./types";
 
 
@@ -608,43 +610,47 @@ export class Calibur7702Account extends SmartAccount
 	}
 
 	/**
-	 * Sign a UserOperation with an external signer (viem, ethers Signer,
-	 * hardware wallet, MPC signer, etc.).
-	 * Computes the UserOperation hash and wraps the returned signature in
-	 * Calibur's format: `abi.encode(keyHash, ecdsaSig, hookData)`.
+	 * Schemes Calibur accepts from a Signer. Only raw-hash ECDSA, since
+	 * the account verifies a plain signature over the userOp hash, then
+	 * wraps with `(keyHash, signature, hookData)`.
+	 */
+	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["hash"];
+
+	/**
+	 * Sign a UserOperation using an {@link ExternalSigner}. Calibur only
+	 * accepts raw-hash ECDSA; signers without `signHash` fail offline with
+	 * an actionable error.
 	 *
-	 * By default signs with the root key. To sign with a registered
-	 * secondary key, pass its key hash via `overrides.keyHash`.
-	 *
-	 * @param userOperation - The UserOperation to sign
-	 * @param signer - Async signing function: `(hash: string) => Promise<string>`
-	 * @param chainId - Target chain ID
-	 * @param overrides - Optional overrides (keyHash for secondary keys, hookData)
-	 * @returns Promise resolving to the hex-encoded wrapped signature
+	 * For signing with a raw private-key string, use the sync
+	 * {@link signUserOperation} method, or wrap explicitly with
+	 * `fromPrivateKey(pk)`. For secondary (non-root) keys, pass the key
+	 * hash via `overrides.keyHash`.
 	 *
 	 * @example
-	 * // Sign with a viem wallet client
+	 * import { fromViem, fromEthersWallet } from "abstractionkit";
 	 * userOp.signature = await account.signUserOperationWithSigner(
-	 *   userOp,
-	 *   (hash) => walletClient.signMessage({ message: { raw: hash } }),
-	 *   chainId,
+	 *   userOp, fromViem(privateKeyToAccount(pk)), chainId,
 	 * );
 	 */
 	public async signUserOperationWithSigner(
 		userOperation: UserOperationV8,
-		signer: SignerFunction,
+		signer: AkSigner,
 		chainId: bigint,
 		overrides: CaliburSignatureOverrides = {},
 	): Promise<string> {
-		const userOperationHash = createUserOperationHash(
+		pickScheme(signer, Calibur7702Account.ACCEPTED_SIGNING_SCHEMES, {
+			accountName: "Calibur (raw ECDSA over userOpHash)",
+			signerIndex: 0,
+		});
+		const hash = createUserOperationHash(
 			userOperation,
 			this.entrypointAddress,
 			chainId,
-		);
+		) as `0x${string}`;
+		const signature = await invokeSigner(signer, "hash", { hash });
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
 		const hookData = overrides.hookData ?? "0x";
-		const ecdsaSig = await signer(userOperationHash);
-		return Calibur7702Account.wrapSignature(keyHash, ecdsaSig, hookData);
+		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);
 	}
 
 	/**

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -5,7 +5,7 @@ import {
 	getDelegatedAddress, getFunctionSelector, handlefetchGasPrice, sendJsonRpcRequest
 } from "../../utils";
 import { UserOperationV8 } from "src/types";
-import { Signer as AkSigner, SigningScheme } from "src/signer/types";
+import { Signer as AkSigner, SignContext, SigningScheme } from "src/signer/types";
 import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { AbstractionKitError } from "src/errors";
 import {
@@ -647,7 +647,12 @@ export class Calibur7702Account extends SmartAccount
 			this.entrypointAddress,
 			chainId,
 		) as `0x${string}`;
-		const signature = await invokeSigner(signer, scheme, { hash });
+		const context: SignContext<UserOperationV8> = {
+			userOperation,
+			chainId,
+			entryPoint: this.entrypointAddress,
+		};
+		const signature = await invokeSigner(signer, scheme, { hash, context });
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
 		const hookData = overrides.hookData ?? "0x";
 		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -638,7 +638,7 @@ export class Calibur7702Account extends SmartAccount
 		chainId: bigint,
 		overrides: CaliburSignatureOverrides = {},
 	): Promise<string> {
-		pickScheme(signer, Calibur7702Account.ACCEPTED_SIGNING_SCHEMES, {
+		const scheme = pickScheme(signer, Calibur7702Account.ACCEPTED_SIGNING_SCHEMES, {
 			accountName: "Calibur (raw ECDSA over userOpHash)",
 			signerIndex: 0,
 		});
@@ -647,7 +647,7 @@ export class Calibur7702Account extends SmartAccount
 			this.entrypointAddress,
 			chainId,
 		) as `0x${string}`;
-		const signature = await invokeSigner(signer, "hash", { hash });
+		const signature = await invokeSigner(signer, scheme, { hash });
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
 		const hookData = overrides.hookData ?? "0x";
 		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);

--- a/src/account/Calibur/types.ts
+++ b/src/account/Calibur/types.ts
@@ -146,9 +146,3 @@ export interface CaliburSignatureOverrides {
 	keyHash?: string;
 }
 
-/**
- * A signing function that takes a hash and returns a raw signature.
- * Use this to integrate viem, ethers Signers, hardware wallets, or MPC signers
- * without passing raw private keys.
- */
-export type SignerFunction = (hash: string) => Promise<string>;

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -53,6 +53,7 @@ import {
 	SafeUserOperationTypedDataDomain,
 	SafeUserOperationV6TypedMessageValue,
 	SafeUserOperationV7TypedMessageValue,
+	SafeUserOperationV9TypedMessageValue,
 	SignerSignaturePair,
 	WebauthnSignatureData,
 	SafeModuleExecutorFunctionSelector,
@@ -599,7 +600,10 @@ export class SafeAccount extends SmartAccount {
 	): {
         domain: SafeUserOperationTypedDataDomain,
         types:Record<string, {name: string;type: string;}[]>,
-        messageValue: SafeUserOperationV6TypedMessageValue | SafeUserOperationV6TypedMessageValue
+        messageValue:
+            | SafeUserOperationV6TypedMessageValue
+            | SafeUserOperationV7TypedMessageValue
+            | SafeUserOperationV9TypedMessageValue
     }  {
 		if ("initCode" in useroperation) {
 			const data = SafeAccount.getUserOperationEip712Data_V6(
@@ -918,7 +922,7 @@ export class SafeAccount extends SmartAccount {
     ): {
         domain: SafeUserOperationTypedDataDomain,
         types:Record<string, {name: string;type: string;}[]>,
-        messageValue: SafeUserOperationV6TypedMessageValue
+        messageValue: SafeUserOperationV9TypedMessageValue
     } {
 		const safe4337ModuleAddress =
 			overrides.safe4337ModuleAddress ??
@@ -1935,7 +1939,7 @@ export class SafeAccount extends SmartAccount {
 	 * @returns formatted signature
 	 */
 	public static async baseSignUserOperationWithSigners<
-		T extends UserOperationV6 | UserOperationV7,
+		T extends UserOperationV6 | UserOperationV7 | UserOperationV9,
 	>(
 		useroperation: T,
 		signers: ReadonlyArray<AkSigner>,
@@ -1975,7 +1979,10 @@ export class SafeAccount extends SmartAccount {
 			domain: typedDataRaw.domain as TypedData["domain"],
 			types: primaryTypes,
 			primaryType: EIP712_SAFE_OPERATION_PRIMARY_TYPE,
-			message: typedDataRaw.messageValue as Record<string, unknown>,
+			// SafeUserOperationVxTypedMessageValue has fixed fields, not an
+			// index signature, so TS rejects a direct cast to Record. Route
+			// through `unknown` to acknowledge the structural conversion.
+			message: typedDataRaw.messageValue as unknown as Record<string, unknown>,
 		};
 
 		// Preflight: validate + checksum every signer's address before

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -17,6 +17,7 @@ import {
 	ENTRYPOINT_V7,
 	EIP712_SAFE_OPERATION_V7_TYPE,
 	EIP712_SAFE_OPERATION_V6_TYPE,
+	EIP712_SAFE_OPERATION_PRIMARY_TYPE,
     ENTRYPOINT_V9,
 } from "../../constants";
 import {
@@ -63,6 +64,8 @@ import {
     SafeAccountSingleton,
 } from "./types";
 import { decodeMultiSendCallData, encodeMultiSendCallData } from "./multisend";
+import { Signer as AkSigner, SigningScheme, TypedData } from "src/signer/types";
+import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { AbstractionKitError, ensureError } from "src/errors";
 import { Bundler } from "src/Bundler";
 import { SendUseroperationResponse } from "../SendUseroperationResponse";
@@ -1898,6 +1901,109 @@ export class SafeAccount extends SmartAccount {
 				validAfter,
 				validUntil,
                 isMultiChainSignature:overrides.isMultiChainSignature
+			},
+		);
+	}
+
+	/**
+	 * Schemes Safe accepts from a {@link Signer}, in preference order.
+	 * `typedData` is preferred because wallets can display structured fields
+	 * rather than a hex blob; `hash` is accepted as a fallback for signers
+	 * that only support raw ECDSA.
+	 */
+	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = [
+		"typedData",
+		"hash",
+	];
+
+	/**
+	 * Sign a UserOperation using one or more {@link Signer}s. This is the
+	 * capability-oriented signing path: each signer declares what it can do
+	 * (`signHash`, `signTypedData`, both) and the account picks the best
+	 * match per signer. Incompatible signers fail offline with an actionable
+	 * error rather than a silent bundler rejection.
+	 *
+	 * Signers are invoked in parallel. For interactive wallets that share a
+	 * popup session, sequence the prompts inside your Signer implementation.
+	 *
+	 * @param useroperation - UserOperation to sign
+	 * @param signers - Signer instances (`fromViem(account)`, `fromEthersWallet(wallet)`, etc.)
+	 * @param chainId - target chain id
+	 * @param entrypointAddress - target EntryPoint
+	 * @param safe4337ModuleAddress - Safe 4337 module
+	 * @param overrides - optional validAfter / validUntil / multi-chain flag
+	 * @returns formatted signature
+	 */
+	public static async baseSignUserOperationWithSigners<
+		T extends UserOperationV6 | UserOperationV7,
+	>(
+		useroperation: T,
+		signers: ReadonlyArray<AkSigner>,
+		chainId: bigint,
+		entrypointAddress: string,
+		safe4337ModuleAddress: string,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			isMultiChainSignature?: boolean;
+		} = {},
+	): Promise<string> {
+		const validAfter = overrides.validAfter ?? 0n;
+		const validUntil = overrides.validUntil ?? 0n;
+
+		if (signers.length < 1) {
+			throw new RangeError("There should be at least one signer");
+		}
+
+		const typedDataRaw = SafeAccount.getUserOperationEip712Data(
+			useroperation,
+			chainId,
+			{ validAfter, validUntil, entrypointAddress, safe4337ModuleAddress },
+		);
+		const userOpHash = TypedDataEncoder.hash(
+			typedDataRaw.domain,
+			typedDataRaw.types,
+			typedDataRaw.messageValue,
+		) as `0x${string}`;
+
+		// Strip EIP712Domain; every downstream signTypedData API rejects it
+		// when it appears alongside the primary type.
+		const { EIP712Domain: _drop, ...primaryTypes } = typedDataRaw.types as Record<
+			string, { name: string; type: string }[]
+		>;
+		const typedData: TypedData = {
+			domain: typedDataRaw.domain as TypedData["domain"],
+			types: primaryTypes,
+			primaryType: EIP712_SAFE_OPERATION_PRIMARY_TYPE,
+			message: typedDataRaw.messageValue as Record<string, unknown>,
+		};
+
+		// Offline capability check: throws with an actionable message if
+		// any signer can't produce what Safe accepts.
+		const schemes = signers.map((signer, signerIndex) =>
+			pickScheme(signer, SafeAccount.ACCEPTED_SIGNING_SCHEMES, {
+				accountName: "Safe (EIP-712 or raw hash over SafeOp digest)",
+				signerIndex,
+			}),
+		);
+
+		const signatures = await Promise.all(
+			signers.map((signer, i) =>
+				invokeSigner(signer, schemes[i], { hash: userOpHash, typedData }),
+			),
+		);
+
+		const signerSignaturePairs = signatures.map((signature, i) => ({
+			signer: getAddress(signers[i].address),
+			signature,
+		}));
+
+		return SafeAccount.formatSignaturesToUseroperationSignature(
+			signerSignaturePairs,
+			{
+				validAfter,
+				validUntil,
+				isMultiChainSignature: overrides.isMultiChainSignature,
 			},
 		);
 	}

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1978,6 +1978,14 @@ export class SafeAccount extends SmartAccount {
 			message: typedDataRaw.messageValue as Record<string, unknown>,
 		};
 
+		// Preflight: validate + checksum every signer's address before
+		// calling any signer. Catches malformed addresses offline instead
+		// of after an external signer (HSM, hardware wallet) has already
+		// been prompted.
+		const normalizedAddresses = signers.map((signer) =>
+			getAddress(signer.address),
+		);
+
 		// Offline capability check: throws with an actionable message if
 		// any signer can't produce what Safe accepts.
 		const schemes = signers.map((signer, signerIndex) =>
@@ -1994,7 +2002,7 @@ export class SafeAccount extends SmartAccount {
 		);
 
 		const signerSignaturePairs = signatures.map((signature, i) => ({
-			signer: getAddress(signers[i].address),
+			signer: normalizedAddresses[i],
 			signature,
 		}));
 

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1848,7 +1848,7 @@ export class SafeAccount extends SmartAccount {
 	 * @param overrides.validUntil - timestamp the signature will be valid until
 	 * @returns signature
 	 */
-	public static baseSignSingleUserOperation(
+	protected static baseSignSingleUserOperation(
 		useroperation: UserOperationV6 | UserOperationV7,
 		privateKeys: string[],
 		chainId: bigint,
@@ -1938,7 +1938,7 @@ export class SafeAccount extends SmartAccount {
 	 * @param overrides - optional validAfter / validUntil / multi-chain flag
 	 * @returns formatted signature
 	 */
-	public static async baseSignUserOperationWithSigners<
+	protected static async baseSignUserOperationWithSigners<
 		T extends UserOperationV6 | UserOperationV7 | UserOperationV9,
 		C,
 	>(

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1940,12 +1940,14 @@ export class SafeAccount extends SmartAccount {
 	 */
 	public static async baseSignUserOperationWithSigners<
 		T extends UserOperationV6 | UserOperationV7 | UserOperationV9,
+		C,
 	>(
 		useroperation: T,
-		signers: ReadonlyArray<AkSigner>,
+		signers: ReadonlyArray<AkSigner<C>>,
 		chainId: bigint,
 		entrypointAddress: string,
 		safe4337ModuleAddress: string,
+		context: C,
 		overrides: {
 			validAfter?: bigint;
 			validUntil?: bigint;
@@ -2004,7 +2006,11 @@ export class SafeAccount extends SmartAccount {
 
 		const signatures = await Promise.all(
 			signers.map((signer, i) =>
-				invokeSigner(signer, schemes[i], { hash: userOpHash, typedData }),
+				invokeSigner(signer, schemes[i], {
+					hash: userOpHash,
+					typedData,
+					context,
+				}),
 			),
 		);
 

--- a/src/account/Safe/SafeAccountV0_2_0.ts
+++ b/src/account/Safe/SafeAccountV0_2_0.ts
@@ -10,7 +10,7 @@ import {
 } from "./types";
 
 import { UserOperationV6, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
-import { Signer as AkSigner } from "src/signer/types";
+import { Signer as AkSigner, SignContext } from "src/signer/types";
 import { ENTRYPOINT_V6 } from "src/constants";
 import { createCallData } from "src/utils";
 import { SafeAccountV0_3_0 } from "./SafeAccountV0_3_0";
@@ -511,12 +511,18 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 			isMultiChainSignature?: boolean;
 		} = {},
 	): Promise<string> {
+		const context: SignContext<UserOperationV6> = {
+			userOperation: useroperation,
+			chainId,
+			entryPoint: this.entrypointAddress,
+		};
 		return SafeAccount.baseSignUserOperationWithSigners(
 			useroperation,
 			signers,
 			chainId,
 			this.entrypointAddress,
 			this.safe4337ModuleAddress,
+			context,
 			overrides,
 		);
 	}

--- a/src/account/Safe/SafeAccountV0_2_0.ts
+++ b/src/account/Safe/SafeAccountV0_2_0.ts
@@ -10,6 +10,7 @@ import {
 } from "./types";
 
 import { UserOperationV6, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
+import { Signer as AkSigner } from "src/signer/types";
 import { ENTRYPOINT_V6 } from "src/constants";
 import { createCallData } from "src/utils";
 import { SafeAccountV0_3_0 } from "./SafeAccountV0_3_0";
@@ -493,5 +494,30 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 			this.safe4337ModuleAddress,
 			overrides
 		)
+	}
+
+	/**
+	 * Sign a UserOperation using one or more {@link AkSigner} instances.
+	 * See {@link SafeAccountV0_3_0.signUserOperationWithSigners} for full
+	 * design rationale and examples.
+	 */
+	public signUserOperationWithSigners(
+		useroperation: UserOperationV6,
+		signers: ReadonlyArray<AkSigner>,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			isMultiChainSignature?: boolean;
+		} = {},
+	): Promise<string> {
+		return SafeAccount.baseSignUserOperationWithSigners(
+			useroperation,
+			signers,
+			chainId,
+			this.entrypointAddress,
+			this.safe4337ModuleAddress,
+			overrides,
+		);
 	}
 }

--- a/src/account/Safe/SafeAccountV0_3_0.ts
+++ b/src/account/Safe/SafeAccountV0_3_0.ts
@@ -10,7 +10,7 @@ import {
 } from "./types";
 
 import { UserOperationV7, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
-import { Signer as AkSigner } from "src/signer/types";
+import { Signer as AkSigner, SignContext } from "src/signer/types";
 import { ENTRYPOINT_V7, Safe_L2_V1_4_1 } from "src/constants";
 
 /**
@@ -441,12 +441,18 @@ export class SafeAccountV0_3_0 extends SafeAccount {
 			isMultiChainSignature?: boolean;
 		} = {},
 	): Promise<string> {
+		const context: SignContext<UserOperationV7> = {
+			userOperation: useroperation,
+			chainId,
+			entryPoint: this.entrypointAddress,
+		};
 		return SafeAccount.baseSignUserOperationWithSigners(
 			useroperation,
 			signers,
 			chainId,
 			this.entrypointAddress,
 			this.safe4337ModuleAddress,
+			context,
 			overrides,
 		);
 	}

--- a/src/account/Safe/SafeAccountV0_3_0.ts
+++ b/src/account/Safe/SafeAccountV0_3_0.ts
@@ -10,6 +10,7 @@ import {
 } from "./types";
 
 import { UserOperationV7, MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet } from "../../types";
+import { Signer as AkSigner } from "src/signer/types";
 import { ENTRYPOINT_V7, Safe_L2_V1_4_1 } from "src/constants";
 
 /**
@@ -397,6 +398,57 @@ export class SafeAccountV0_3_0 extends SafeAccount {
 			this.safe4337ModuleAddress,
 			overrides
 		)
+	}
+
+	/**
+	 * Sign a UserOperation using one or more {@link ExternalSigner} instances.
+	 * Capability-oriented entry point: each Signer declares what it can do
+	 * (`signHash`, `signTypedData`, both) and the account picks the best
+	 * match per signer. Incompatible signers fail offline with an actionable
+	 * error — no silent bundler rejections.
+	 *
+	 * This method is for external signers only (viem, ethers, hardware
+	 * wallets, MPC, HSMs, Uint8Array-only signers). If you just have a raw
+	 * private-key string, use the sync {@link signUserOperation} method
+	 * instead, or wrap explicitly with `fromPrivateKey(pk)`.
+	 *
+	 * Prebuilt adapters: `fromViem`, `fromEthersWallet`,
+	 * `fromViemWalletClient`, `fromPrivateKey`. Custom signers just need to
+	 * match the `ExternalSigner` shape.
+	 *
+	 * @example
+	 * import { fromViem } from "abstractionkit";
+	 * import { privateKeyToAccount } from "viem/accounts";
+	 *
+	 * const signer = fromViem(privateKeyToAccount(pk));
+	 * userOp.signature = await account.signUserOperationWithSigners(
+	 *   userOp, [signer], chainId,
+	 * );
+	 *
+	 * @param useroperation - UserOperation to sign
+	 * @param signers - one ExternalSigner per owner (any order)
+	 * @param chainId - target chain ID
+	 * @param overrides - optional validAfter / validUntil / multi-chain flag
+	 * @returns Promise resolving to the formatted signature string
+	 */
+	public signUserOperationWithSigners(
+		useroperation: UserOperationV7,
+		signers: ReadonlyArray<AkSigner>,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			isMultiChainSignature?: boolean;
+		} = {},
+	): Promise<string> {
+		return SafeAccount.baseSignUserOperationWithSigners(
+			useroperation,
+			signers,
+			chainId,
+			this.entrypointAddress,
+			this.safe4337ModuleAddress,
+			overrides,
+		);
 	}
 }
 

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -16,7 +16,7 @@ import {
 } from "./types";
 
 import { UserOperationV9, MetaTransaction, OnChainIdentifierParamsType } from "../../types";
-import { Signer as AkSigner } from "src/signer/types";
+import { Signer as AkSigner, SignContext, MultiOpSignContext } from "src/signer/types";
 import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { EIP712_MULTI_CHAIN_OPERATIONS_TYPE, ENTRYPOINT_V9 } from "src/constants";
 import { generateMerkleProofs } from "./MerkleTree";
@@ -40,6 +40,17 @@ import {
  * with the Daimo P256 verifier instead of the FCL P256 verifier
  * used by the base SafeAccount class.
  * @see {@link https://github.com/safe-fndn/safe-modules/blob/04e65efbce634e776cc8c1fbe90061f09e09a71b/modules/passkey/CHANGELOG.md?plain=1#L23}
+ *
+ * @remarks Signer typing on this class is asymmetric:
+ * - {@link signUserOperationWithSigners} (singular Operation) signs one op
+ *   and uses {@link SignContext} like every other account.
+ * - {@link signUserOperationsWithSigners} (plural Operations) signs a bundle
+ *   under one signature and uses {@link MultiOpSignContext}.
+ *
+ * To author one signer that works on both methods, type it as
+ * `ExternalSigner<unknown>` (the shape returned by the built-in adapters).
+ * The two narrow context types exist so signers that DO read the context
+ * get accurate, non-optional fields per path.
  */
 export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	static readonly DEFAULT_ENTRYPOINT_ADDRESS = ENTRYPOINT_V9;
@@ -458,12 +469,18 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			validUntil?: bigint;
 		} = {},
 	): Promise<string> {
+		const context: SignContext<UserOperationV9> = {
+			userOperation,
+			chainId,
+			entryPoint: this.entrypointAddress,
+		};
 		return SafeAccount.baseSignUserOperationWithSigners(
 			userOperation,
 			signers,
 			chainId,
 			this.entrypointAddress,
 			this.safe4337ModuleAddress,
+			context,
 			{
 				...overrides,
 				isMultiChainSignature: true,
@@ -557,12 +574,20 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
-	 * Sign a list of UserOperations with a single multi-chain signature, using
-	 * {@link AkSigner} instances (viem, ethers, hardware wallet, HSM, MPC,
-	 * Uint8Array-only). Each signer signs the Merkle root of the UserOperation
-	 * EIP-712 hashes via raw-hash signing. `signTypedData` isn't exposed here
-	 * because the Merkle root is opaque and has no meaningful typed-data
-	 * display.
+	 * Sign a list of UserOperations with a single multi-chain signature,
+	 * using {@link AkSigner} instances typed for {@link MultiOpSignContext}
+	 * (viem, ethers, hardware wallet, HSM, MPC, Uint8Array-only). Each
+	 * signer signs the Merkle root of the UserOperation EIP-712 hashes via
+	 * raw-hash signing. `signTypedData` isn't exposed here because the
+	 * Merkle root is opaque and has no meaningful typed-data display.
+	 *
+	 * Signers always receive {@link MultiOpSignContext} regardless of bundle
+	 * length, so multi-op-typed signers can rely on `ctx.userOperations`
+	 * being defined. Pre-built adapters (`fromPrivateKey`, `fromViem`,
+	 * `fromEthersWallet`, `fromViemWalletClient`) return a universal
+	 * `Signer<unknown>` and work here without retyping; user-defined
+	 * single-op signers (`Signer<SignContext>`) do not — they would receive
+	 * a context shape they didn't declare.
 	 *
 	 * @param userOperationsToSign - UserOperations + chain IDs + validity windows
 	 * @param signers - one Signer per owner (any order; sorted by address on-chain)
@@ -570,7 +595,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 */
 	public async signUserOperationsWithSigners(
 		userOperationsToSign: UserOperationToSign[],
-		signers: ReadonlyArray<AkSigner>,
+		signers: ReadonlyArray<AkSigner<MultiOpSignContext<UserOperationV9>>>,
 	): Promise<string[]> {
 		if (userOperationsToSign.length < 1) {
 			throw new RangeError("There should be at least one userOperationsToSign");
@@ -578,6 +603,17 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		if (signers.length < 1) {
 			throw new RangeError("There should be at least one signer");
 		}
+
+		// Multi-op context: signers see the full bundle (length 1 or N) so
+		// they can log "authorizing N ops across these chains".
+		const context: MultiOpSignContext<UserOperationV9> = {
+			userOperations: userOperationsToSign.map((u) => ({
+				userOperation: u.userOperation,
+				chainId: u.chainId,
+			})),
+			entryPoint: this.entrypointAddress,
+		};
+
 		if (userOperationsToSign.length > 1) {
 			const userOperationsHashes: string[] = [];
 			userOperationsToSign.forEach((uopToSign) => {
@@ -616,9 +652,13 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 					signerIndex: i,
 				});
 			});
+
 			const signatures = await Promise.all(
 				signers.map((signer) =>
-					invokeSigner(signer, "hash", { hash: merkleTreeRootHash }),
+					invokeSigner(signer, "hash", {
+						hash: merkleTreeRootHash,
+						context,
+					}),
 				),
 			);
 			const signerSignaturePairs: SignerSignaturePair[] = signers.map(
@@ -644,17 +684,25 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			});
 			return userOpSignatures;
 		} else {
-			return [
-				await this.signUserOperationWithSigners(
-					userOperationsToSign[0].userOperation,
-					signers,
-					userOperationsToSign[0].chainId,
-					{
-						validUntil: userOperationsToSign[0].validUntil,
-						validAfter: userOperationsToSign[0].validAfter,
-					},
-				),
-			];
+			// length === 1: single op with multi-chain flag, but signers
+			// still see multi-op context (length-1 bundle). Routes through
+			// the base helper with multi-op context override so the runtime
+			// shape matches the signer's declared type.
+			const u = userOperationsToSign[0];
+			const sig = await SafeAccount.baseSignUserOperationWithSigners(
+				u.userOperation,
+				signers,
+				u.chainId,
+				this.entrypointAddress,
+				this.safe4337ModuleAddress,
+				context,
+				{
+					validAfter: u.validAfter,
+					validUntil: u.validUntil,
+					isMultiChainSignature: true,
+				},
+			);
+			return [sig];
 		}
 	}
 

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -601,22 +601,29 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 				{ merkleTreeRoot: root },
 			) as `0x${string}`;
 
+			// Preflight: validate + checksum every signer's address before
+			// calling any signer. Catches malformed addresses offline
+			// instead of after an external signer has been prompted.
+			const normalizedAddresses = signers.map((signer) =>
+				getAddress(signer.address),
+			);
+
 			// Merkle root is opaque; signTypedData has nothing meaningful to
 			// display, so we require raw-hash signing.
-			for (const signer of signers) {
+			signers.forEach((signer, i) => {
 				pickScheme(signer, ["hash"], {
 					accountName: "SafeMultiChainSigAccountV1 (multi-op Merkle root)",
-					signerIndex: 0,
+					signerIndex: i,
 				});
-			}
+			});
 			const signatures = await Promise.all(
 				signers.map((signer) =>
 					invokeSigner(signer, "hash", { hash: merkleTreeRootHash }),
 				),
 			);
 			const signerSignaturePairs: SignerSignaturePair[] = signers.map(
-				(signer, i) => ({
-					signer: getAddress(signer.address),
+				(_signer, i) => ({
+					signer: normalizedAddresses[i],
 					signature: signatures[i],
 				}),
 			);

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -583,11 +583,14 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 *
 	 * Signers always receive {@link MultiOpSignContext} regardless of bundle
 	 * length, so multi-op-typed signers can rely on `ctx.userOperations`
-	 * being defined. Pre-built adapters (`fromPrivateKey`, `fromViem`,
-	 * `fromEthersWallet`, `fromViemWalletClient`) return a universal
-	 * `Signer<unknown>` and work here without retyping; user-defined
-	 * single-op signers (`Signer<SignContext>`) do not — they would receive
-	 * a context shape they didn't declare.
+	 * being defined. Pre-built adapters `fromPrivateKey`, `fromViem`, and
+	 * `fromEthersWallet` return a universal `Signer<unknown>` and work
+	 * here without retyping; user-defined single-op signers
+	 * (`Signer<SignContext>`) do not — they would receive a context shape
+	 * they didn't declare. `fromViemWalletClient` is **not** usable on the
+	 * multi-op Merkle path: it only exposes `signTypedData`, and the
+	 * Merkle root has no meaningful typed-data display. {@link pickScheme}
+	 * rejects it offline with an actionable error.
 	 *
 	 * @param userOperationsToSign - UserOperations + chain IDs + validity windows
 	 * @param signers - one Signer per owner (any order; sorted by address on-chain)

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -16,9 +16,11 @@ import {
 } from "./types";
 
 import { UserOperationV9, MetaTransaction, OnChainIdentifierParamsType } from "../../types";
+import { Signer as AkSigner } from "src/signer/types";
+import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { EIP712_MULTI_CHAIN_OPERATIONS_TYPE, ENTRYPOINT_V9 } from "src/constants";
 import { generateMerkleProofs } from "./MerkleTree";
-import { TypedDataEncoder, Wallet } from "ethers";
+import { getAddress, TypedDataEncoder, Wallet } from "ethers";
 import {
 	DEFAULT_WEB_AUTHN_DAIMO_VERIFIER_V_0_2_1,
 	DEFAULT_WEB_AUTHN_PRECOMPILE_RIP_7951,
@@ -442,6 +444,34 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
+	 * Sign a single UserOperation for multi-chain using one or more
+	 * {@link AkSigner} instances. See
+	 * {@link SafeAccountV0_3_0.signUserOperationWithSigners} for the full
+	 * design rationale. Sets the multi-chain flag automatically.
+	 */
+	public signUserOperationWithSigners(
+		userOperation: UserOperationV9,
+		signers: ReadonlyArray<AkSigner>,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+		} = {},
+	): Promise<string> {
+		return SafeAccount.baseSignUserOperationWithSigners(
+			userOperation,
+			signers,
+			chainId,
+			this.entrypointAddress,
+			this.safe4337ModuleAddress,
+			{
+				...overrides,
+				isMultiChainSignature: true,
+			},
+		);
+	}
+
+	/**
 	 * sign a list of useroperations - multi chain signature
 	 * @param useroperation - useroperation to sign
 	 * @param privateKeys - for the signers
@@ -524,6 +554,101 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
                 }
             )];
         }
+	}
+
+	/**
+	 * Sign a list of UserOperations with a single multi-chain signature, using
+	 * {@link AkSigner} instances (viem, ethers, hardware wallet, HSM, MPC,
+	 * Uint8Array-only). Each signer signs the Merkle root of the UserOperation
+	 * EIP-712 hashes via raw-hash signing. `signTypedData` isn't exposed here
+	 * because the Merkle root is opaque and has no meaningful typed-data
+	 * display.
+	 *
+	 * @param userOperationsToSign - UserOperations + chain IDs + validity windows
+	 * @param signers - one Signer per owner (any order; sorted by address on-chain)
+	 * @returns one signature per input UserOperation, in the same order
+	 */
+	public async signUserOperationsWithSigners(
+		userOperationsToSign: UserOperationToSign[],
+		signers: ReadonlyArray<AkSigner>,
+	): Promise<string[]> {
+		if (userOperationsToSign.length < 1) {
+			throw new RangeError("There should be at least one userOperationsToSign");
+		}
+		if (signers.length < 1) {
+			throw new RangeError("There should be at least one signer");
+		}
+		if (userOperationsToSign.length > 1) {
+			const userOperationsHashes: string[] = [];
+			userOperationsToSign.forEach((uopToSign) => {
+				const userOperationHash = SafeAccount.getUserOperationEip712Hash_V9(
+					uopToSign.userOperation,
+					uopToSign.chainId,
+					{
+						validAfter: uopToSign.validAfter,
+						validUntil: uopToSign.validUntil,
+						safe4337ModuleAddress: this.safe4337ModuleAddress,
+						entrypointAddress: this.entrypointAddress,
+					},
+				);
+				userOperationsHashes.push(userOperationHash);
+			});
+			const [root, proofs] = generateMerkleProofs(userOperationsHashes);
+
+			const merkleTreeRootHash = TypedDataEncoder.hash(
+				{ verifyingContract: this.safe4337ModuleAddress },
+				EIP712_MULTI_CHAIN_OPERATIONS_TYPE,
+				{ merkleTreeRoot: root },
+			) as `0x${string}`;
+
+			// Merkle root is opaque; signTypedData has nothing meaningful to
+			// display, so we require raw-hash signing.
+			for (const signer of signers) {
+				pickScheme(signer, ["hash"], {
+					accountName: "SafeMultiChainSigAccountV1 (multi-op Merkle root)",
+					signerIndex: 0,
+				});
+			}
+			const signatures = await Promise.all(
+				signers.map((signer) =>
+					invokeSigner(signer, "hash", { hash: merkleTreeRootHash }),
+				),
+			);
+			const signerSignaturePairs: SignerSignaturePair[] = signers.map(
+				(signer, i) => ({
+					signer: getAddress(signer.address),
+					signature: signatures[i],
+				}),
+			);
+
+			const userOpSignatures: string[] = [];
+			userOperationsToSign.forEach((uopToSign, index) => {
+				userOpSignatures.push(
+					SafeAccount.formatSignaturesToUseroperationSignature(
+						signerSignaturePairs,
+						{
+							validAfter: uopToSign.validAfter,
+							validUntil: uopToSign.validUntil,
+							isMultiChainSignature: true,
+							multiChainMerkleProof: proofs[index],
+						},
+					),
+				);
+			});
+			return userOpSignatures;
+		} else {
+			return [
+				await this.signUserOperationWithSigners(
+					userOperationsToSign[0].userOperation,
+					signers,
+					userOperationsToSign[0].chainId,
+					{
+						validUntil: userOperationsToSign[0].validUntil,
+						validAfter: userOperationsToSign[0].validAfter,
+					},
+				),
+			];
+		}
 	}
 
 	/**

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -782,7 +782,7 @@ export class BaseSimple7702Account extends SmartAccount {
         signer: AkSigner,
         chainId: bigint,
     ): Promise<string> {
-        pickScheme(signer, BaseSimple7702Account.ACCEPTED_SIGNING_SCHEMES, {
+        const scheme = pickScheme(signer, BaseSimple7702Account.ACCEPTED_SIGNING_SCHEMES, {
             accountName: "Simple7702 (raw ECDSA over userOpHash)",
             signerIndex: 0,
         });
@@ -791,7 +791,7 @@ export class BaseSimple7702Account extends SmartAccount {
             this.entrypointAddress,
             chainId,
         ) as `0x${string}`;
-        return invokeSigner(signer, "hash", { hash });
+        return invokeSigner(signer, scheme, { hash });
     }
 
     /**

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -6,6 +6,8 @@ import {
     sendJsonRpcRequest
 } from "../../utils";
 import { GasOption, PolygonChain, StateOverrideSet, UserOperationV8, UserOperationV9 } from "src/types";
+import { Signer as AkSigner, SigningScheme } from "src/signer/types";
+import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { AbstractionKitError } from "src/errors";
 import {
     Authorization7702Hex, bigintToHex,
@@ -760,7 +762,38 @@ export class BaseSimple7702Account extends SmartAccount {
 		const wallet = new Wallet(privateKey);
         return wallet.signingKey.sign(userOperationHash).serialized;
 	}
-    
+
+    /**
+     * Schemes Simple7702 accepts from a Signer. Only raw-hash ECDSA, since
+     * the delegatee verifies a plain signature over the userOp hash.
+     */
+    public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["hash"];
+
+    /**
+     * Sign a UserOperation with an {@link AkSigner}. Signer must implement
+     * `signHash`, since Simple7702 only verifies raw ECDSA over the userOp
+     * hash. JSON-RPC wallets and anything that only provides `signTypedData`
+     * fail offline with a specific error.
+     */
+    protected async baseSignUserOperationWithSigner<
+        T extends UserOperationV8 | UserOperationV9,
+    >(
+        useroperation: T,
+        signer: AkSigner,
+        chainId: bigint,
+    ): Promise<string> {
+        pickScheme(signer, BaseSimple7702Account.ACCEPTED_SIGNING_SCHEMES, {
+            accountName: "Simple7702 (raw ECDSA over userOpHash)",
+            signerIndex: 0,
+        });
+        const hash = createUserOperationHash(
+            useroperation,
+            this.entrypointAddress,
+            chainId,
+        ) as `0x${string}`;
+        return invokeSigner(signer, "hash", { hash });
+    }
+
     /**
 	 * Submit a signed UserOperation to a bundler for on-chain inclusion.
 	 * @param userOperation - The signed UserOperation to submit
@@ -974,6 +1007,23 @@ export class Simple7702Account extends BaseSimple7702Account {
 		chainId: bigint,
     ): string {
         return this.baseSignUserOperation(useroperation, privateKey, chainId);
+    }
+
+    /**
+     * Sign a {@link UserOperationV8} using an {@link ExternalSigner}.
+     * Simple7702 only accepts raw-hash ECDSA; signers without `signHash`
+     * fail offline with an actionable error.
+     *
+     * For signing with a raw private-key string, use the sync
+     * {@link signUserOperation} method, or wrap explicitly with
+     * `fromPrivateKey(pk)`.
+     */
+    public async signUserOperationWithSigner(
+        useroperation: UserOperationV8,
+        signer: AkSigner,
+        chainId: bigint,
+    ): Promise<string> {
+        return this.baseSignUserOperationWithSigner(useroperation, signer, chainId);
     }
 
     /**

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -6,7 +6,7 @@ import {
     sendJsonRpcRequest
 } from "../../utils";
 import { GasOption, PolygonChain, StateOverrideSet, UserOperationV8, UserOperationV9 } from "src/types";
-import { Signer as AkSigner, SigningScheme } from "src/signer/types";
+import { Signer as AkSigner, SignContext, SigningScheme } from "src/signer/types";
 import { pickScheme, invokeSigner } from "src/signer/negotiate";
 import { AbstractionKitError } from "src/errors";
 import {
@@ -791,7 +791,12 @@ export class BaseSimple7702Account extends SmartAccount {
             this.entrypointAddress,
             chainId,
         ) as `0x${string}`;
-        return invokeSigner(signer, scheme, { hash });
+        const context: SignContext<T> = {
+            userOperation: useroperation,
+            chainId,
+            entryPoint: this.entrypointAddress,
+        };
+        return invokeSigner(signer, scheme, { hash, context });
     }
 
     /**

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -1,4 +1,5 @@
 import { StateOverrideSet, UserOperationV9 } from "src/types";
+import { Signer as AkSigner } from "src/signer/types";
 import { BaseSimple7702Account, CreateUserOperationOverrides, SimpleMetaTransaction } from "./Simple7702Account";
 import { ENTRYPOINT_V9 } from "src/constants";
 import { SendUseroperationResponse } from "../SendUseroperationResponse";
@@ -94,6 +95,20 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 		chainId: bigint,
     ): string {
         return this.baseSignUserOperation(useroperation, privateKey, chainId);
+    }
+
+    /**
+     * Sign a {@link UserOperationV9} using an {@link ExternalSigner}.
+     * Simple7702 only accepts raw-hash ECDSA; signers without `signHash`
+     * fail offline with an actionable error. For a raw pk string, use the
+     * sync {@link signUserOperation} method or wrap with `fromPrivateKey`.
+     */
+    public async signUserOperationWithSigner(
+        useroperation: UserOperationV9,
+        signer: AkSigner,
+        chainId: bigint,
+    ): Promise<string> {
+        return this.baseSignUserOperationWithSigner(useroperation, signer, chainId);
     }
 
     /**

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -103,7 +103,7 @@ export interface EthersWalletLike {
  * @example
  * import { fromPrivateKey } from "abstractionkit";
  * const signer = fromPrivateKey(process.env.PRIVATE_KEY!);
- * userOp.signature = await safe.signUserOp(userOp, [signer], chainId);
+ * userOp.signature = await safe.signUserOperationWithSigners(userOp, [signer], chainId);
  */
 export function fromPrivateKey(privateKey: string): Signer<unknown> {
 	const wallet = new Wallet(privateKey);

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -1,0 +1,186 @@
+import { Wallet, getAddress } from "ethers";
+import { Signer, TypedData } from "./types";
+
+// Structural types for well-known signers. NO imports from viem / ethers
+// at the type level (beyond the already-present ethers runtime dep used by
+// fromPrivateKey); these shapes match their public APIs so users can pass
+// an instance directly.
+
+/**
+ * Shape matching viem's `PrivateKeyAccount` / `LocalAccount`.
+ *
+ * @remarks Requires viem &gt;= 2.0. The `sign({ hash })` method was added in
+ * the viem 2.0 account refactor; viem 1.x callers see a type error and
+ * should upgrade.
+ */
+export interface ViemLocalAccountLike {
+	address: `0x${string}`;
+	sign: (args: { hash: `0x${string}` }) => Promise<`0x${string}`>;
+	signTypedData: (args: {
+		domain: TypedData["domain"];
+		types: Record<string, Array<{ name: string; type: string }>>;
+		primaryType: string;
+		message: Record<string, unknown>;
+	}) => Promise<`0x${string}`>;
+}
+
+/**
+ * Minimal shape required by {@link fromViemWalletClient}. We only need to
+ * read `account.address` structurally; `signTypedData` is invoked via a
+ * localized cast inside the adapter because viem types it with const
+ * generics that can't be reproduced without re-exporting viem's type
+ * system. The runtime call shape is stable across viem 2.x.
+ *
+ * @remarks Requires viem &gt;= 2.0.
+ */
+export interface ViemWalletClientLike {
+	account?: { address: `0x${string}` } | undefined;
+	signTypedData: unknown;
+}
+
+/**
+ * Internal shape that viem's `signTypedData` conforms to at runtime.
+ * Used only inside {@link fromViemWalletClient}.
+ */
+type ViemSignTypedDataCall = (args: {
+	account: { address: `0x${string}` } | `0x${string}`;
+	domain: TypedData["domain"];
+	types: TypedData["types"];
+	primaryType: string;
+	message: Record<string, unknown>;
+}) => Promise<`0x${string}`>;
+
+/**
+ * Shape matching ethers `Wallet` / `HDNodeWallet`.
+ *
+ * @remarks Requires ethers &gt;= 6.0. In ethers 5.x the typed-data method was
+ * the private `_signTypedData`; the structural match fails there and callers
+ * should upgrade.
+ *
+ * Parameter types intentionally widen ethers' concrete `TypedDataDomain` /
+ * `TypedDataField[]` so the interface doesn't depend on ethers' type
+ * exports while still accepting an ethers Wallet instance without casts
+ * at the call site.
+ */
+export interface EthersWalletLike {
+	address: string;
+	signingKey: {
+		sign: (hash: string) => { serialized: string };
+	};
+	signTypedData: (
+		domain: {
+			name?: string;
+			version?: string;
+			chainId?: number | bigint;
+			verifyingContract?: string;
+			salt?: string;
+		},
+		types: Record<string, Array<{ name: string; type: string }>>,
+		message: Record<string, unknown>,
+	) => Promise<string>;
+}
+
+/**
+ * Build a Signer from a raw private key. Uses the library's existing
+ * ethers dependency internally, so no additional packages are required on
+ * the caller side. Supports both raw-hash and typed-data signing.
+ *
+ * Prefer this when all you have is a private key (test suites, server-side
+ * scripts, scripts with env-injected keys, etc.). If you already hold a
+ * viem Account or ethers Wallet from elsewhere in your app, pass it to
+ * {@link fromViem} or {@link fromEthersWallet} instead.
+ *
+ * @example
+ * import { fromPrivateKey } from "abstractionkit";
+ * const signer = fromPrivateKey(process.env.PRIVATE_KEY!);
+ * userOp.signature = await safe.signUserOp(userOp, [signer], chainId);
+ */
+export function fromPrivateKey(privateKey: string): Signer {
+	const wallet = new Wallet(privateKey);
+	return {
+		address: getAddress(wallet.address) as `0x${string}`,
+		signHash: async (hash) =>
+			wallet.signingKey.sign(hash).serialized as `0x${string}`,
+		signTypedData: async (td) =>
+			(await wallet.signTypedData(
+				td.domain,
+				td.types,
+				td.message,
+			)) as `0x${string}`,
+	};
+}
+
+/**
+ * Adapt a viem Local Account (e.g. `privateKeyToAccount(pk)`) to a Signer.
+ * Supports both raw-hash and typed-data signing.
+ *
+ * @remarks Requires viem &gt;= 2.0.
+ */
+export function fromViem(account: ViemLocalAccountLike): Signer {
+	return {
+		address: account.address,
+		signHash: (hash) => account.sign({ hash }),
+		signTypedData: (td) =>
+			account.signTypedData({
+				domain: td.domain,
+				types: td.types,
+				primaryType: td.primaryType,
+				message: td.message,
+			}),
+	};
+}
+
+/**
+ * Adapt a viem WalletClient to a Signer. WalletClient is the client-style
+ * API dApps use to drive browser / JSON-RPC wallets, so only typed-data
+ * signing is exposed (JSON-RPC wallets can't sign raw hashes).
+ *
+ * Requires the client to have been constructed with an `account` (local or
+ * JSON-RPC). For local accounts, pass that directly to `fromViem` instead
+ * if you want raw-hash fallback.
+ *
+ * @remarks Requires viem &gt;= 2.0.
+ */
+export function fromViemWalletClient(client: ViemWalletClientLike): Signer {
+	if (!client.account) {
+		throw new Error(
+			"fromViemWalletClient: client has no `account` configured. " +
+				"Construct with `createWalletClient({ account, transport, chain })`.",
+		);
+	}
+	// Capture the full account object (at runtime it may expose local
+	// signing methods that cause viem to sign without hitting JSON-RPC).
+	// Passing just the address string here would force a route to
+	// `eth_signTypedData_v4`, which fails against an HTTP transport.
+	const account = client.account;
+	const signTypedData = client.signTypedData as ViemSignTypedDataCall;
+	return {
+		address: account.address,
+		signTypedData: (td) =>
+			signTypedData({
+				account,
+				domain: td.domain,
+				types: td.types,
+				primaryType: td.primaryType,
+				message: td.message,
+			}),
+	};
+}
+
+/**
+ * Adapt an ethers `Wallet` / `HDNodeWallet` to a Signer. Supports both
+ * raw-hash and typed-data signing.
+ *
+ * @remarks Requires ethers &gt;= 6.0.
+ */
+export function fromEthersWallet(wallet: EthersWalletLike): Signer {
+	// ethers types `address` as plain `string`; at runtime it's always
+	// checksummed 0x-prefixed hex.
+	return {
+		address: wallet.address as `0x${string}`,
+		signHash: async (hash) =>
+			wallet.signingKey.sign(hash).serialized as `0x${string}`,
+		signTypedData: async (td) =>
+			(await wallet.signTypedData(td.domain, td.types, td.message)) as `0x${string}`,
+	};
+}

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -12,6 +12,10 @@ import { Signer, TypedData } from "./types";
  * @remarks Requires viem &gt;= 2.0. The `sign({ hash })` method was added in
  * the viem 2.0 account refactor; viem 1.x callers see a type error and
  * should upgrade.
+ *
+ * @internal Not exported from the package root — pass concrete viem
+ * instances directly to {@link fromViem}. If you need to type a wrapper,
+ * use `Parameters<typeof fromViem>[0]`.
  */
 export interface ViemLocalAccountLike {
 	address: `0x${string}`;
@@ -32,6 +36,9 @@ export interface ViemLocalAccountLike {
  * system. The runtime call shape is stable across viem 2.x.
  *
  * @remarks Requires viem &gt;= 2.0.
+ *
+ * @internal Not exported from the package root — pass concrete viem
+ * `WalletClient` instances directly to {@link fromViemWalletClient}.
  */
 export interface ViemWalletClientLike {
 	account?: { address: `0x${string}` } | undefined;
@@ -61,6 +68,9 @@ type ViemSignTypedDataCall = (args: {
  * `TypedDataField[]` so the interface doesn't depend on ethers' type
  * exports while still accepting an ethers Wallet instance without casts
  * at the call site.
+ *
+ * @internal Not exported from the package root — pass concrete ethers
+ * `Wallet` / `HDNodeWallet` instances directly to {@link fromEthersWallet}.
  */
 export interface EthersWalletLike {
 	address: string;

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -95,7 +95,7 @@ export interface EthersWalletLike {
  * const signer = fromPrivateKey(process.env.PRIVATE_KEY!);
  * userOp.signature = await safe.signUserOp(userOp, [signer], chainId);
  */
-export function fromPrivateKey(privateKey: string): Signer {
+export function fromPrivateKey(privateKey: string): Signer<unknown> {
 	const wallet = new Wallet(privateKey);
 	return {
 		address: getAddress(wallet.address) as `0x${string}`,
@@ -116,7 +116,7 @@ export function fromPrivateKey(privateKey: string): Signer {
  *
  * @remarks Requires viem &gt;= 2.0.
  */
-export function fromViem(account: ViemLocalAccountLike): Signer {
+export function fromViem(account: ViemLocalAccountLike): Signer<unknown> {
 	return {
 		address: account.address,
 		signHash: (hash) => account.sign({ hash }),
@@ -141,7 +141,7 @@ export function fromViem(account: ViemLocalAccountLike): Signer {
  *
  * @remarks Requires viem &gt;= 2.0.
  */
-export function fromViemWalletClient(client: ViemWalletClientLike): Signer {
+export function fromViemWalletClient(client: ViemWalletClientLike): Signer<unknown> {
 	if (!client.account) {
 		throw new Error(
 			"fromViemWalletClient: client has no `account` configured. " +
@@ -173,7 +173,7 @@ export function fromViemWalletClient(client: ViemWalletClientLike): Signer {
  *
  * @remarks Requires ethers &gt;= 6.0.
  */
-export function fromEthersWallet(wallet: EthersWalletLike): Signer {
+export function fromEthersWallet(wallet: EthersWalletLike): Signer<unknown> {
 	// ethers types `address` as plain `string`; at runtime it's always
 	// checksummed 0x-prefixed hex.
 	return {

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -10,8 +10,8 @@ import { Signer, SigningScheme, TypedData } from "./types";
  * citing the signer's address, what the account accepts, and what the
  * signer can do.
  */
-export function pickScheme(
-	signer: Signer,
+export function pickScheme<C>(
+	signer: Signer<C>,
 	accepted: readonly SigningScheme[],
 	context: { accountName: string; signerIndex: number },
 ): SigningScheme {
@@ -56,11 +56,18 @@ function buildMismatchMessage(params: {
  * Invoke a signer for one scheme. Keeps the dispatch in one place so the
  * account-side code stays linear. `typedData` is optional: accounts that
  * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
+ *
+ * `context` is always forwarded to the signer so power-user implementations
+ * can inspect the userOp.
  */
-export async function invokeSigner(
-	signer: Signer,
+export async function invokeSigner<C>(
+	signer: Signer<C>,
 	scheme: SigningScheme,
-	payload: { hash: `0x${string}`; typedData?: TypedData },
+	payload: {
+		hash: `0x${string}`;
+		typedData?: TypedData;
+		context: C;
+	},
 ): Promise<`0x${string}`> {
 	if (scheme === "typedData") {
 		if (!signer.signTypedData) {
@@ -71,11 +78,11 @@ export async function invokeSigner(
 			throw new AbstractionKitError("BAD_DATA",
 				`scheme "typedData" selected but no typedData payload provided`);
 		}
-		return signer.signTypedData(payload.typedData);
+		return signer.signTypedData(payload.typedData, payload.context);
 	}
 	if (!signer.signHash) {
 		throw new AbstractionKitError("BAD_DATA",
 			`signer ${signer.address} is missing signHash`);
 	}
-	return signer.signHash(payload.hash);
+	return signer.signHash(payload.hash, payload.context);
 }

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -15,9 +15,13 @@ export function pickScheme<C>(
 	accepted: readonly SigningScheme[],
 	context: { accountName: string; signerIndex: number },
 ): SigningScheme {
+	// Use `typeof === "function"` (not truthiness) so a malformed signer
+	// like `{ signHash: true }` (e.g. from a JS caller bypassing types) is
+	// rejected via pickScheme's AbstractionKitError instead of crashing
+	// later with a raw TypeError on the call site.
 	const signerCan: SigningScheme[] = [];
-	if (signer.signTypedData) signerCan.push("typedData");
-	if (signer.signHash) signerCan.push("hash");
+	if (typeof signer.signTypedData === "function") signerCan.push("typedData");
+	if (typeof signer.signHash === "function") signerCan.push("hash");
 
 	for (const scheme of accepted) {
 		if (signerCan.includes(scheme)) return scheme;
@@ -70,7 +74,7 @@ export async function invokeSigner<C>(
 	},
 ): Promise<`0x${string}`> {
 	if (scheme === "typedData") {
-		if (!signer.signTypedData) {
+		if (typeof signer.signTypedData !== "function") {
 			throw new AbstractionKitError("BAD_DATA",
 				`signer ${signer.address} is missing signTypedData`);
 		}
@@ -80,7 +84,7 @@ export async function invokeSigner<C>(
 		}
 		return signer.signTypedData(payload.typedData, payload.context);
 	}
-	if (!signer.signHash) {
+	if (typeof signer.signHash !== "function") {
 		throw new AbstractionKitError("BAD_DATA",
 			`signer ${signer.address} is missing signHash`);
 	}

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -1,0 +1,81 @@
+import { AbstractionKitError } from "../errors";
+import { Signer, SigningScheme, TypedData } from "./types";
+
+/**
+ * Pick the best mutually-supported signing scheme for one signer against an
+ * account's accepted schemes. Later in the `accepted` array = lower preference;
+ * the account ranks by preference.
+ *
+ * Throws a detailed {@link AbstractionKitError} if no scheme overlaps,
+ * citing the signer's address, what the account accepts, and what the
+ * signer can do.
+ */
+export function pickScheme(
+	signer: Signer,
+	accepted: readonly SigningScheme[],
+	context: { accountName: string; signerIndex: number },
+): SigningScheme {
+	const signerCan: SigningScheme[] = [];
+	if (signer.signTypedData) signerCan.push("typedData");
+	if (signer.signHash) signerCan.push("hash");
+
+	for (const scheme of accepted) {
+		if (signerCan.includes(scheme)) return scheme;
+	}
+
+	throw new AbstractionKitError("BAD_DATA", buildMismatchMessage({
+		accountName: context.accountName,
+		signerIndex: context.signerIndex,
+		signerAddress: signer.address,
+		accepted,
+		signerCan,
+	}));
+}
+
+function buildMismatchMessage(params: {
+	accountName: string;
+	signerIndex: number;
+	signerAddress: string;
+	accepted: readonly SigningScheme[];
+	signerCan: SigningScheme[];
+}): string {
+	const { accountName, signerIndex, signerAddress, accepted, signerCan } = params;
+	const canStr = signerCan.length > 0 ? signerCan.join(", ") : "none";
+	return (
+		`No compatible signing scheme for signer[${signerIndex}] ${signerAddress}. ` +
+		`${accountName} accepts: [${accepted.join(", ")}]; signer provides: [${canStr}]. ` +
+		(signerCan.length === 0
+			? "Signer must implement at least one of `signHash` or `signTypedData`. "
+			: "") +
+		"Hint: `fromViem` / `fromEthersWallet` give both; " +
+		"`fromViemWalletClient` gives only `typedData` (use Safe for JSON-RPC wallets)."
+	);
+}
+
+/**
+ * Invoke a signer for one scheme. Keeps the dispatch in one place so the
+ * account-side code stays linear. `typedData` is optional: accounts that
+ * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
+ */
+export async function invokeSigner(
+	signer: Signer,
+	scheme: SigningScheme,
+	payload: { hash: `0x${string}`; typedData?: TypedData },
+): Promise<`0x${string}`> {
+	if (scheme === "typedData") {
+		if (!signer.signTypedData) {
+			throw new AbstractionKitError("BAD_DATA",
+				`signer ${signer.address} is missing signTypedData`);
+		}
+		if (!payload.typedData) {
+			throw new AbstractionKitError("BAD_DATA",
+				`scheme "typedData" selected but no typedData payload provided`);
+		}
+		return signer.signTypedData(payload.typedData);
+	}
+	if (!signer.signHash) {
+		throw new AbstractionKitError("BAD_DATA",
+			`signer ${signer.address} is missing signHash`);
+	}
+	return signer.signHash(payload.hash);
+}

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Narrow EIP-712 typed data payload. All hex fields are typed as
+ * `` `0x${string}` `` so callers don't need casts when handing this straight
+ * to viem / ethers. `EIP712Domain` is stripped from `types` before the payload
+ * is handed to a Signer, so consumers don't need to filter it out.
+ */
+export interface TypedData {
+	domain: {
+		name?: string;
+		version?: string;
+		chainId?: number | bigint;
+		verifyingContract?: `0x${string}`;
+		salt?: `0x${string}`;
+	};
+	types: Record<string, Array<{ name: string; type: string }>>;
+	primaryType: string;
+	message: Record<string, unknown>;
+}
+
+/** Signing schemes accounts may accept and signers may provide. */
+export type SigningScheme = "hash" | "typedData";
+
+/** Common fields every Signer exposes. */
+interface SignerBase {
+	/** Address that will recover from signatures this signer produces. */
+	readonly address: `0x${string}`;
+}
+
+/**
+ * Sign a 32-byte hash raw (no EIP-191 prefix). Required for Simple7702 /
+ * Calibur; acceptable fallback for Safe. Typical implementations:
+ * `wallet.signingKey.sign(hash).serialized` (ethers) or
+ * `account.sign({ hash })` (viem Local Account).
+ */
+export type SignHashFn = (hash: `0x${string}`) => Promise<`0x${string}`>;
+
+/**
+ * Sign an EIP-712 typed data payload. Preferred for Safe because wallets
+ * can display structured fields instead of a hex blob. Typical
+ * implementations: `wallet.signTypedData(domain, types, message)` (ethers)
+ * or `account.signTypedData({...})` (viem).
+ */
+export type SignTypedDataFn = (data: TypedData) => Promise<`0x${string}`>;
+
+/**
+ * A capability-oriented signer. Must declare at least one of `signHash` or
+ * `signTypedData`; the account picks the best match at sign time.
+ *
+ * Declared as a discriminated union so TypeScript rejects
+ * `{ address }` with neither method at compile time (not just at runtime).
+ * Implementations that provide both (the common case: `fromViem`,
+ * `fromEthersWallet`, `fromPrivateKey`) satisfy either variant.
+ *
+ * Structural typing means you don't need to import from this file to
+ * implement it; any object of this shape works. At the package root this
+ * type is re-exported as `ExternalSigner` to avoid colliding with the
+ * pre-existing `Signer` owner-identifier union.
+ *
+ * Notably absent: `signMessage` (EIP-191). It's intentionally omitted. The
+ * `v`-byte mismatch between default tooling and Safe's on-chain validator
+ * makes it a footgun. Use `signTypedData` for JSON-RPC wallets (the
+ * structured-UX equivalent) or `signHash` for local keys.
+ *
+ * @example Built-in adapters cover the common cases:
+ * ```ts
+ * import { fromPrivateKey, fromViem, fromEthersWallet } from "abstractionkit"
+ * const a = fromPrivateKey(pkHexString)
+ * const b = fromViem(privateKeyToAccount(pk))
+ * const c = fromEthersWallet(new Wallet(pk))
+ * ```
+ *
+ * @example Uint8Array-only / secure-dispose posture (key never hex-stringified):
+ * ```ts
+ * import { SigningKey, computeAddress } from "ethers"
+ * function fromPrivateKeyBytes(pkBytes: Uint8Array): ExternalSigner {
+ *   const sk = new SigningKey(pkBytes)
+ *   return {
+ *     address: computeAddress(sk.publicKey) as `0x${string}`,
+ *     signHash: async (hash) => sk.sign(hash).serialized as `0x${string}`,
+ *   }
+ * }
+ * const signer = fromPrivateKeyBytes(bytes)
+ * try { userOp.signature = await safe.signUserOp(op, [signer], chainId) }
+ * finally { bytes.fill(0) }  // zero the buffer on dispose
+ * ```
+ *
+ * @example HSM / hardware-wallet / MPC: key never exists in JS memory:
+ * ```ts
+ * const hsmSigner: ExternalSigner = {
+ *   address: deviceAddress,
+ *   signHash: async (hash) => await hsm.signHash(hash),     // RPC to device
+ *   signTypedData: async (td) => await hsm.signTypedData(td),
+ * }
+ * ```
+ */
+export type Signer = SignerBase &
+	(
+		| { signHash: SignHashFn; signTypedData?: SignTypedDataFn }
+		| { signHash?: SignHashFn; signTypedData: SignTypedDataFn }
+	);

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -1,3 +1,5 @@
+import { BaseUserOperation } from "../types";
+
 /**
  * Narrow EIP-712 typed data payload. All hex fields are typed as
  * `` `0x${string}` `` so callers don't need casts when handing this straight
@@ -20,6 +22,43 @@ export interface TypedData {
 /** Signing schemes accounts may accept and signers may provide. */
 export type SigningScheme = "hash" | "typedData";
 
+/**
+ * Context the SDK passes to a signer on every account's
+ * `signUserOperationWithSigner(s)` (the single-op path — 99% of usage).
+ * All fields are required; IDE autocomplete shows them directly without a
+ * type guard. Default for {@link Signer}, {@link SignHashFn},
+ * {@link SignTypedDataFn}.
+ *
+ * For the multi-op Merkle path
+ * (`SafeMultiChainSigAccountV1.signUserOperationsWithSigners`), see
+ * {@link MultiOpSignContext}.
+ */
+export interface SignContext<T extends BaseUserOperation = BaseUserOperation> {
+	readonly userOperation: T;
+	readonly chainId: bigint;
+	readonly entryPoint: string;
+}
+
+/**
+ * Context for the multi-op Merkle signing path
+ * (`SafeMultiChainSigAccountV1.signUserOperationsWithSigners`). The signer
+ * sees the full bundle so you can show "you're
+ * authorizing N ops across these chains" instead of an opaque root.
+ *
+ * Type your multi-op signer as `ExternalSigner<MultiOpSignContext>` for
+ * full autocomplete on `userOperations`. Pre-built adapters
+ * (`fromPrivateKey`, `fromViem`, `fromEthersWallet`,
+ * `fromViemWalletClient`) return a universal `Signer<unknown>` and work in
+ * either path without retyping.
+ */
+export interface MultiOpSignContext<T extends BaseUserOperation = BaseUserOperation> {
+	readonly userOperations: ReadonlyArray<{
+		readonly userOperation: T;
+		readonly chainId: bigint;
+	}>;
+	readonly entryPoint: string;
+}
+
 /** Common fields every Signer exposes. */
 interface SignerBase {
 	/** Address that will recover from signatures this signer produces. */
@@ -28,19 +67,28 @@ interface SignerBase {
 
 /**
  * Sign a 32-byte hash raw (no EIP-191 prefix). Required for Simple7702 /
- * Calibur; acceptable fallback for Safe. Typical implementations:
- * `wallet.signingKey.sign(hash).serialized` (ethers) or
- * `account.sign({ hash })` (viem Local Account).
+ * Calibur; acceptable fallback for Safe.
+ *
+ * Generic over the context type the SDK will pass. Defaults to
+ * {@link SignContext} (single-op) — set explicitly to
+ * {@link MultiOpSignContext} for multi-op signers, or to `unknown` for
+ * universal/context-agnostic signers like the built-in adapters.
  */
-export type SignHashFn = (hash: `0x${string}`) => Promise<`0x${string}`>;
+export type SignHashFn<C = SignContext> = (
+	hash: `0x${string}`,
+	context: C,
+) => Promise<`0x${string}`>;
 
 /**
  * Sign an EIP-712 typed data payload. Preferred for Safe because wallets
- * can display structured fields instead of a hex blob. Typical
- * implementations: `wallet.signTypedData(domain, types, message)` (ethers)
- * or `account.signTypedData({...})` (viem).
+ * can display structured fields instead of a hex blob.
+ *
+ * Generic over context — see {@link SignHashFn}.
  */
-export type SignTypedDataFn = (data: TypedData) => Promise<`0x${string}`>;
+export type SignTypedDataFn<C = SignContext> = (
+	data: TypedData,
+	context: C,
+) => Promise<`0x${string}`>;
 
 /**
  * A capability-oriented signer. Must declare at least one of `signHash` or
@@ -93,8 +141,8 @@ export type SignTypedDataFn = (data: TypedData) => Promise<`0x${string}`>;
  * }
  * ```
  */
-export type Signer = SignerBase &
+export type Signer<C = SignContext> = SignerBase &
 	(
-		| { signHash: SignHashFn; signTypedData?: SignTypedDataFn }
-		| { signHash?: SignHashFn; signTypedData: SignTypedDataFn }
+		| { signHash: SignHashFn<C>; signTypedData?: SignTypedDataFn<C> }
+		| { signHash?: SignHashFn<C>; signTypedData: SignTypedDataFn<C> }
 	);

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -47,9 +47,11 @@ export interface SignContext<T extends BaseUserOperation = BaseUserOperation> {
  *
  * Type your multi-op signer as `ExternalSigner<MultiOpSignContext>` for
  * full autocomplete on `userOperations`. Pre-built adapters
- * (`fromPrivateKey`, `fromViem`, `fromEthersWallet`,
- * `fromViemWalletClient`) return a universal `Signer<unknown>` and work in
- * either path without retyping.
+ * `fromPrivateKey`, `fromViem`, and `fromEthersWallet` return a universal
+ * `Signer<unknown>` and work on either single-op or multi-op paths
+ * without retyping. `fromViemWalletClient` only exposes `signTypedData`,
+ * so it's usable on single-op paths only — the multi-op Merkle root is
+ * opaque, has no typed-data display, and requires raw-hash signing.
  */
 export interface MultiOpSignContext<T extends BaseUserOperation = BaseUserOperation> {
 	readonly userOperations: ReadonlyArray<{
@@ -128,7 +130,7 @@ export type SignTypedDataFn<C = SignContext> = (
  *   }
  * }
  * const signer = fromPrivateKeyBytes(bytes)
- * try { userOp.signature = await safe.signUserOp(op, [signer], chainId) }
+ * try { userOp.signature = await safe.signUserOperationWithSigners(op, [signer], chainId) }
  * finally { bytes.fill(0) }  // zero the buffer on dispose
  * ```
  *

--- a/test/calibur/calibur7702Account.test.js
+++ b/test/calibur/calibur7702Account.test.js
@@ -680,59 +680,9 @@ describe('Calibur7702Account', () => {
         expect(hash).toBe(expected);
     });
 
-    // ─── signUserOperationWithSigner ────────────────────────────────────
-
-    test('signUserOperationWithSigner produces same result as signUserOperation', async () => {
-
-        const account = new ak.Calibur7702Account("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-        const wallet = new Wallet(signingKey);
-
-        const userOp = {
-            sender: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-            nonce: 0n, callData: "0x", callGasLimit: 100000n,
-            verificationGasLimit: 100000n, preVerificationGas: 50000n,
-            maxFeePerGas: 1000000000n, maxPriorityFeePerGas: 1000000000n,
-            signature: "0x",
-            factory: null, factoryData: null,
-            paymaster: null, paymasterVerificationGasLimit: null,
-            paymasterPostOpGasLimit: null, paymasterData: null,
-            eip7702Auth: null,
-        };
-
-        const signerFn = async (hash) => {
-            return wallet.signingKey.sign(hash).serialized;
-        };
-
-        const sigFromSigner = await account.signUserOperationWithSigner(userOp, signerFn, 11155111n);
-        const sigFromKey = account.signUserOperation(userOp, signingKey, 11155111n);
-
-        expect(sigFromSigner).toBe(sigFromKey);
-    });
-
-    test('signUserOperationWithSigner with keyHash produces same result as signUserOperation with keyHash', async () => {
-
-        const account = new ak.Calibur7702Account("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-        const wallet = new Wallet(signingKey);
-        const keyHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-
-        const userOp = {
-            sender: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-            nonce: 0n, callData: "0x", callGasLimit: 0n,
-            verificationGasLimit: 0n, preVerificationGas: 0n,
-            maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x",
-            factory: null, factoryData: null,
-            paymaster: null, paymasterVerificationGasLimit: null,
-            paymasterPostOpGasLimit: null, paymasterData: null,
-            eip7702Auth: null,
-        };
-
-        const signerFn = async (hash) => wallet.signingKey.sign(hash).serialized;
-
-        const sigFromSigner = await account.signUserOperationWithSigner(userOp, signerFn, 11155111n, { keyHash });
-        const sigFromKey = account.signUserOperation(userOp, signingKey, 11155111n, { keyHash });
-
-        expect(sigFromSigner).toBe(sigFromKey);
-    });
+    // Equivalence tests for the new signUserOperationWithSigner API live in
+    // test/signer/signer.test.js; they verify against a reference signature
+    // computed from ethers primitives.
 
     // ─── createAndSignEip7702DelegationAuthorization callback ────────────
 

--- a/test/calibur/calibur7702Account.test.js
+++ b/test/calibur/calibur7702Account.test.js
@@ -707,13 +707,13 @@ describe('Calibur7702Account', () => {
         expect(authFromCallback.s).toBe(authFromKey.s);
     });
 
-    // ─── SignerFunction export ──────────────────────────────────────────
+    // ─── ExternalSigner adapter exports ─────────────────────────────────
 
-    test('SignerFunction type is exported (runtime check via typeof)', () => {
-        // SignerFunction is a type alias, so it doesn't exist at runtime.
-        // We verify the pattern works by creating one and using it.
-        const fn = async (hash) => "0x" + "00".repeat(65);
-        expect(typeof fn).toBe('function');
+    test('ExternalSigner adapters are exported at runtime', () => {
+        expect(typeof ak.fromPrivateKey).toBe('function');
+        expect(typeof ak.fromViem).toBe('function');
+        expect(typeof ak.fromEthersWallet).toBe('function');
+        expect(typeof ak.fromViemWalletClient).toBe('function');
     });
 
     // ─── CaliburKeySettingsResult ────────────────────────────────────────

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -1,0 +1,419 @@
+// Unit tests for the Signer-interface design. All tests are offline.
+//
+// Public API:
+//   Safe accounts (multi-signer):    signUserOperationWithSigners(op, signers[], chainId)
+//   Simple7702 / Calibur (single):   signUserOperationWithSigner(op, signer, chainId)
+//
+// Equivalence strategy: each test compares the new method's output to a
+// signature computed via the legacy sync path or via ethers primitives.
+
+const ak = require('../../dist/index.cjs');
+const { Wallet, SigningKey, computeAddress, getBytes } = require('ethers');
+
+const PK1 = '0x' + '11'.repeat(32);
+const PK2 = '0x' + '22'.repeat(32);
+const CHAIN_ID = 11155111n;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
+
+function buildSafeV3Op(safe) {
+    return {
+        sender: safe.accountAddress, nonce: 0n,
+        factory: safe.factoryAddress, factoryData: safe.factoryData,
+        callData: '0x', callGasLimit: 100000n, verificationGasLimit: 500000n,
+        preVerificationGas: 60000n, maxFeePerGas: 10000000n, maxPriorityFeePerGas: 1000000n,
+        paymaster: null, paymasterVerificationGasLimit: null, paymasterPostOpGasLimit: null,
+        paymasterData: null, signature: '0x',
+    };
+}
+
+function buildSafeV2Op(safe) {
+    return {
+        sender: safe.accountAddress, nonce: 0n,
+        initCode: safe.factoryAddress + safe.factoryData.slice(2),
+        callData: '0x', callGasLimit: 100000n, verificationGasLimit: 500000n,
+        preVerificationGas: 60000n, maxFeePerGas: 10000000n, maxPriorityFeePerGas: 1000000n,
+        paymasterAndData: '0x', signature: '0x',
+    };
+}
+
+function buildSafeMultiChainOp(safe) {
+    return {
+        sender: safe.accountAddress, nonce: 0n,
+        factory: safe.factoryAddress, factoryData: safe.factoryData,
+        callData: '0x', callGasLimit: 100000n, verificationGasLimit: 500000n,
+        preVerificationGas: 60000n, maxFeePerGas: 10000000n, maxPriorityFeePerGas: 1000000n,
+        paymaster: null, paymasterVerificationGasLimit: null, paymasterPostOpGasLimit: null,
+        paymasterData: null, signature: '0x', eip7702Auth: null,
+    };
+}
+
+function buildSimpleOp(owner) {
+    return {
+        sender: owner, nonce: 0n, factory: null, factoryData: null,
+        callData: '0x', callGasLimit: 100000n, verificationGasLimit: 100000n,
+        preVerificationGas: 50000n, maxFeePerGas: 10000000n, maxPriorityFeePerGas: 1000000n,
+        paymaster: null, paymasterVerificationGasLimit: null, paymasterPostOpGasLimit: null,
+        paymasterData: null, signature: '0x', eip7702Auth: null,
+    };
+}
+
+// ─── Adapter tests ───────────────────────────────────────────────────────
+
+describe('fromPrivateKey adapter', () => {
+    test('produces a Signer with both signHash and signTypedData', () => {
+        const signer = ak.fromPrivateKey(PK1);
+        expect(signer.address).toBe(computeAddress(PK1));
+        expect(typeof signer.signHash).toBe('function');
+        expect(typeof signer.signTypedData).toBe('function');
+    });
+
+    test('signHash produces same bytes as ethers signingKey.sign', async () => {
+        const signer = ak.fromPrivateKey(PK1);
+        const wallet = new Wallet(PK1);
+        const hash = '0x' + 'ab'.repeat(32);
+        const sigA = await signer.signHash(hash);
+        const sigB = wallet.signingKey.sign(hash).serialized;
+        expect(sigA).toBe(sigB);
+    });
+});
+
+describe('fromEthersWallet adapter', () => {
+    test('wraps an ethers Wallet and passes through to signingKey.sign', async () => {
+        const wallet = new Wallet(PK1);
+        const signer = ak.fromEthersWallet(wallet);
+        const hash = '0x' + 'cd'.repeat(32);
+        expect(await signer.signHash(hash))
+            .toBe(wallet.signingKey.sign(hash).serialized);
+    });
+});
+
+// ─── Safe accounts (multi-signer, plural method name) ───────────────────
+
+describe('SafeAccountV0_3_0 signUserOperationWithSigners', () => {
+    const owner = computeAddress(PK1);
+    const safe = ak.SafeAccountV0_3_0.initializeNewAccount([owner]);
+    const op = buildSafeV3Op(safe);
+
+    test('with fromPrivateKey matches legacy sync signUserOperation', async () => {
+        const pkSig = safe.signUserOperation(op, [PK1], CHAIN_ID);
+        const signerSig = await safe.signUserOperationWithSigners(
+            op, [ak.fromPrivateKey(PK1)], CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('sorts multi-signer by address regardless of input order', async () => {
+        const owner2 = computeAddress(PK2);
+        const multi = ak.SafeAccountV0_3_0.initializeNewAccount([owner, owner2]);
+        const mop = buildSafeV3Op(multi);
+        const expected = multi.signUserOperation(mop, [PK1, PK2], CHAIN_ID);
+        const forward = await multi.signUserOperationWithSigners(
+            mop, [ak.fromPrivateKey(PK1), ak.fromPrivateKey(PK2)], CHAIN_ID,
+        );
+        const reverse = await multi.signUserOperationWithSigners(
+            mop, [ak.fromPrivateKey(PK2), ak.fromPrivateKey(PK1)], CHAIN_ID,
+        );
+        expect(forward).toBe(expected);
+        expect(reverse).toBe(expected);
+    });
+
+    test('custom hash-only Signer matches PK path', async () => {
+        const wallet = new Wallet(PK1);
+        const custom = {
+            address: wallet.address,
+            signHash: async (h) => wallet.signingKey.sign(h).serialized,
+        };
+        const pkSig = safe.signUserOperation(op, [PK1], CHAIN_ID);
+        const customSig = await safe.signUserOperationWithSigners(op, [custom], CHAIN_ID);
+        expect(customSig).toBe(pkSig);
+    });
+
+    test('signTypedData-only Signer works (typedData scheme)', async () => {
+        const wallet = new Wallet(PK1);
+        const tdOnly = {
+            address: wallet.address,
+            signTypedData: async (td) =>
+                wallet.signTypedData(td.domain, td.types, td.message),
+        };
+        const pkSig = safe.signUserOperation(op, [PK1], CHAIN_ID);
+        const tdSig = await safe.signUserOperationWithSigners(op, [tdOnly], CHAIN_ID);
+        expect(tdSig).toBe(pkSig);
+    });
+
+    test('throws with actionable message on capability mismatch', async () => {
+        const empty = { address: '0x' + '0'.repeat(40) };
+        await expect(
+            safe.signUserOperationWithSigners(op, [empty], CHAIN_ID),
+        ).rejects.toThrow(
+            /No compatible signing scheme.*Signer must implement at least one of/s,
+        );
+    });
+
+    test('does NOT accept raw private-key strings (type-level only)', async () => {
+        // At runtime the call still throws a meaningful error — strings lack
+        // the required .address / sign methods. Type system enforces Signer-
+        // only arguments; this test documents the runtime fallback.
+        await expect(
+            safe.signUserOperationWithSigners(op, [PK1], CHAIN_ID),
+        ).rejects.toThrow();
+    });
+});
+
+describe('SafeAccountV0_2_0 signUserOperationWithSigners', () => {
+    const owner = computeAddress(PK1);
+    const safe = ak.SafeAccountV0_2_0.initializeNewAccount([owner]);
+    const op = buildSafeV2Op(safe);
+
+    test('matches legacy sync signUserOperation', async () => {
+        const pkSig = safe.signUserOperation(op, [PK1], CHAIN_ID);
+        const signerSig = await safe.signUserOperationWithSigners(
+            op, [ak.fromPrivateKey(PK1)], CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+});
+
+describe('SafeMultiChainSigAccountV1 signUserOperationWithSigners', () => {
+    const owner = computeAddress(PK1);
+    const safe = ak.SafeMultiChainSigAccountV1.initializeNewAccount([owner]);
+    const op = buildSafeMultiChainOp(safe);
+
+    test('single-op: matches legacy sync path with isMultiChainSignature set', async () => {
+        const pkSig = safe.signUserOperation(op, [PK1], CHAIN_ID);
+        const signerSig = await safe.signUserOperationWithSigners(
+            op, [ak.fromPrivateKey(PK1)], CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('signUserOperationsWithSigners with single op delegates correctly', async () => {
+        const [sig] = await safe.signUserOperationsWithSigners(
+            [{ userOperation: op, chainId: CHAIN_ID, validAfter: 0n, validUntil: 0n }],
+            [ak.fromPrivateKey(PK1)],
+        );
+        const ref = safe.signUserOperation(op, [PK1], CHAIN_ID);
+        expect(sig).toBe(ref);
+    });
+
+    test('signUserOperationsWithSigners with multi ops emits distinct signatures', async () => {
+        const op2 = { ...op, nonce: 1n };
+        const [s1, s2] = await safe.signUserOperationsWithSigners(
+            [
+                { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
+                { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
+            ],
+            [ak.fromPrivateKey(PK1)],
+        );
+        expect(s1).toMatch(/^0x/);
+        expect(s2).toMatch(/^0x/);
+        expect(s1).not.toBe(s2);
+    });
+
+    test('signUserOperationsWithSigners matches legacy signUserOperations for multi', async () => {
+        const op2 = { ...op, nonce: 1n };
+        const opsToSign = [
+            { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
+            { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
+        ];
+        const legacySigs = safe.signUserOperations(opsToSign, [PK1]);
+        const newSigs = await safe.signUserOperationsWithSigners(
+            opsToSign, [ak.fromPrivateKey(PK1)],
+        );
+        expect(newSigs).toEqual(legacySigs);
+    });
+});
+
+// ─── Single-signer accounts (singular method name) ──────────────────────
+
+describe('Simple7702Account signUserOperationWithSigner', () => {
+    const owner = computeAddress(PK1);
+    const simple = new ak.Simple7702Account(owner);
+    const op = buildSimpleOp(owner);
+
+    test('matches legacy sync signUserOperation(pk)', async () => {
+        const pkSig = simple.signUserOperation(op, PK1, CHAIN_ID);
+        const signerSig = await simple.signUserOperationWithSigner(
+            op, ak.fromPrivateKey(PK1), CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('fromViem-shaped signer via fromEthersWallet matches PK path', async () => {
+        const wallet = new Wallet(PK1);
+        const pkSig = simple.signUserOperation(op, PK1, CHAIN_ID);
+        const signerSig = await simple.signUserOperationWithSigner(
+            op, ak.fromEthersWallet(wallet), CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('rejects signTypedData-only signer with actionable error', async () => {
+        const tdOnly = {
+            address: owner,
+            signTypedData: async () => '0x',
+        };
+        await expect(
+            simple.signUserOperationWithSigner(op, tdOnly, CHAIN_ID),
+        ).rejects.toThrow(/accepts: \[hash\]; signer provides: \[typedData\]/);
+    });
+});
+
+describe('Simple7702AccountV09 signUserOperationWithSigner', () => {
+    const owner = computeAddress(PK1);
+    const simple = new ak.Simple7702AccountV09(owner);
+    const op = buildSimpleOp(owner);
+
+    test('matches legacy sync signUserOperation(pk)', async () => {
+        const pkSig = simple.signUserOperation(op, PK1, CHAIN_ID);
+        const signerSig = await simple.signUserOperationWithSigner(
+            op, ak.fromPrivateKey(PK1), CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+});
+
+describe('Calibur7702Account signUserOperationWithSigner', () => {
+    const owner = computeAddress(PK1);
+    const calibur = new ak.Calibur7702Account(owner);
+    const op = buildSimpleOp(owner);
+
+    test('matches legacy sync signUserOperation(pk)', async () => {
+        const pkSig = calibur.signUserOperation(op, PK1, CHAIN_ID);
+        const signerSig = await calibur.signUserOperationWithSigner(
+            op, ak.fromPrivateKey(PK1), CHAIN_ID,
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('keyHash override flows through to wrapped signature', async () => {
+        const keyHash = '0x' + 'ee'.repeat(32);
+        const pkSig = calibur.signUserOperation(op, PK1, CHAIN_ID, { keyHash });
+        const signerSig = await calibur.signUserOperationWithSigner(
+            op, ak.fromPrivateKey(PK1), CHAIN_ID, { keyHash },
+        );
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('rejects signTypedData-only signer', async () => {
+        const tdOnly = {
+            address: owner,
+            signTypedData: async () => '0x',
+        };
+        await expect(
+            calibur.signUserOperationWithSigner(op, tdOnly, CHAIN_ID),
+        ).rejects.toThrow(/accepts: \[hash\]/);
+    });
+});
+
+// ─── Uint8Array / HSM / secure-dispose ──────────────────────────────────
+
+describe('Uint8Array-only / secure-dispose signers', () => {
+    function fromPrivateKeyBytes(pkBytes) {
+        if (!(pkBytes instanceof Uint8Array) || pkBytes.length !== 32) {
+            throw new Error('expected 32-byte Uint8Array');
+        }
+        const signingKey = new SigningKey(pkBytes);
+        const address = computeAddress(signingKey.publicKey);
+        let disposed = false;
+        return {
+            address,
+            signHash: async (hash) => {
+                if (disposed) throw new Error('signer disposed');
+                return signingKey.sign(hash).serialized;
+            },
+            dispose() {
+                pkBytes.fill(0);
+                disposed = true;
+            },
+        };
+    }
+
+    test('Uint8Array-held Signer produces same signature as legacy PK path', async () => {
+        const hexPk = '0x' + '33'.repeat(32);
+        const bytes = getBytes(hexPk);
+        const signer = fromPrivateKeyBytes(bytes);
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([signer.address]);
+        const op = buildSafeV3Op(safe);
+
+        const pkSig = safe.signUserOperation(op, [hexPk], CHAIN_ID);
+        const signerSig = await safe.signUserOperationWithSigners(op, [signer], CHAIN_ID);
+        expect(signerSig).toBe(pkSig);
+    });
+
+    test('dispose() zeros the buffer and blocks subsequent signing', async () => {
+        const hexPk = '0x' + '44'.repeat(32);
+        const bytes = getBytes(hexPk);
+        const signer = fromPrivateKeyBytes(bytes);
+
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([signer.address]);
+        const op = buildSafeV3Op(safe);
+        await expect(safe.signUserOperationWithSigners(op, [signer], CHAIN_ID))
+            .resolves.toMatch(/^0x/);
+        expect(Array.from(bytes).some((b) => b !== 0)).toBe(true);
+        signer.dispose();
+        expect(Array.from(bytes).every((b) => b === 0)).toBe(true);
+        await expect(safe.signUserOperationWithSigners(op, [signer], CHAIN_ID))
+            .rejects.toThrow(/signer disposed/);
+    });
+
+    test('works on Simple7702 / Calibur (hash-only accounts)', async () => {
+        const hexPk = '0x' + '55'.repeat(32);
+        const bytes = getBytes(hexPk);
+        const signer = fromPrivateKeyBytes(bytes);
+        const owner = signer.address;
+
+        const simple = new ak.Simple7702Account(owner);
+        const calibur = new ak.Calibur7702Account(owner);
+        const op = buildSimpleOp(owner);
+
+        const simplePk = simple.signUserOperation(op, hexPk, CHAIN_ID);
+        expect(await simple.signUserOperationWithSigner(op, signer, CHAIN_ID)).toBe(simplePk);
+
+        const caliburPk = calibur.signUserOperation(op, hexPk, CHAIN_ID);
+        expect(await calibur.signUserOperationWithSigner(op, signer, CHAIN_ID)).toBe(caliburPk);
+    });
+
+    test('async HSM-style signer (no key material in memory)', async () => {
+        const hexPk = '0x' + '66'.repeat(32);
+        const refWallet = new Wallet(hexPk);
+        let hsmCallCount = 0;
+        const hsmSigner = {
+            address: refWallet.address,
+            signHash: async (hash) => {
+                hsmCallCount++;
+                return refWallet.signingKey.sign(hash).serialized;
+            },
+        };
+
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([refWallet.address]);
+        const op = buildSafeV3Op(safe);
+        const pkSig = safe.signUserOperation(op, [hexPk], CHAIN_ID);
+        expect(await safe.signUserOperationWithSigners(op, [hsmSigner], CHAIN_ID)).toBe(pkSig);
+        expect(hsmCallCount).toBe(1);
+    });
+
+    test('using-pattern helper guarantees dispose even on error', async () => {
+        async function withSecureSigner(pkBytes, fn) {
+            const signer = fromPrivateKeyBytes(pkBytes);
+            try { return await fn(signer); }
+            finally { signer.dispose(); }
+        }
+
+        const hexPk = '0x' + '77'.repeat(32);
+        const bytes = getBytes(hexPk);
+
+        const result = await withSecureSigner(bytes, async (signer) => {
+            const safe = ak.SafeAccountV0_3_0.initializeNewAccount([signer.address]);
+            return safe.signUserOperationWithSigners(buildSafeV3Op(safe), [signer], CHAIN_ID);
+        });
+        expect(result).toMatch(/^0x/);
+        expect(Array.from(bytes).every((b) => b === 0)).toBe(true);
+
+        const bytes2 = getBytes('0x' + '88'.repeat(32));
+        await expect(withSecureSigner(bytes2, async () => {
+            throw new Error('something went wrong');
+        })).rejects.toThrow(/something went wrong/);
+        expect(Array.from(bytes2).every((b) => b === 0)).toBe(true);
+    });
+});

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -88,6 +88,137 @@ describe('fromEthersWallet adapter', () => {
     });
 });
 
+// ─── SignContext delivery ────────────────────────────────────────────────
+
+describe('SignContext is forwarded to signers', () => {
+    const owner = computeAddress(PK1);
+
+    test('single-op accounts pass { userOperation, chainId, entryPoint }', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([owner]);
+        const op = buildSafeV3Op(safe);
+        const wallet = new Wallet(PK1);
+        let captured = null;
+        const inspecting = {
+            address: wallet.address,
+            signHash: async (h, ctx) => {
+                captured = ctx;
+                return wallet.signingKey.sign(h).serialized;
+            },
+        };
+        await safe.signUserOperationWithSigners(op, [inspecting], CHAIN_ID);
+        expect(captured).not.toBeNull();
+        expect('userOperation' in captured).toBe(true);
+        expect(captured.userOperation.sender).toBe(op.sender);
+        expect(captured.chainId).toBe(CHAIN_ID);
+        expect(captured.entryPoint).toBe(safe.entrypointAddress);
+    });
+
+    test('Simple7702 / Calibur forward the same single-op shape', async () => {
+        const wallet = new Wallet(PK1);
+
+        // Simple7702
+        const simple = new ak.Simple7702Account(owner);
+        const simpleOp = buildSimpleOp(owner);
+        let simpleCtx = null;
+        await simple.signUserOperationWithSigner(simpleOp, {
+            address: wallet.address,
+            signHash: async (h, ctx) => {
+                simpleCtx = ctx;
+                return wallet.signingKey.sign(h).serialized;
+            },
+        }, CHAIN_ID);
+        expect('userOperation' in simpleCtx).toBe(true);
+        expect(simpleCtx.userOperation.nonce).toBe(simpleOp.nonce);
+        expect(simpleCtx.chainId).toBe(CHAIN_ID);
+        expect(simpleCtx.entryPoint).toBe(simple.entrypointAddress);
+
+        // Calibur
+        const calibur = new ak.Calibur7702Account(owner);
+        const caliburOp = buildSimpleOp(owner);
+        let caliburCtx = null;
+        await calibur.signUserOperationWithSigner(caliburOp, {
+            address: wallet.address,
+            signHash: async (h, ctx) => {
+                caliburCtx = ctx;
+                return wallet.signingKey.sign(h).serialized;
+            },
+        }, CHAIN_ID);
+        expect('userOperation' in caliburCtx).toBe(true);
+        expect(caliburCtx.userOperation.nonce).toBe(caliburOp.nonce);
+        expect(caliburCtx.chainId).toBe(CHAIN_ID);
+        expect(caliburCtx.entryPoint).toBe(calibur.entrypointAddress);
+    });
+
+    test('multi-op Merkle path passes { userOperations[], entryPoint }', async () => {
+        const safe = ak.SafeMultiChainSigAccountV1.initializeNewAccount([owner]);
+        const op = buildSafeMultiChainOp(safe);
+        const op2 = { ...op, nonce: 1n };
+        const wallet = new Wallet(PK1);
+        let captured = null;
+        await safe.signUserOperationsWithSigners(
+            [
+                { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
+                { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
+            ],
+            [{
+                address: wallet.address,
+                signHash: async (h, ctx) => {
+                    captured = ctx;
+                    return wallet.signingKey.sign(h).serialized;
+                },
+            }],
+        );
+        expect('userOperations' in captured).toBe(true);
+        expect(captured.userOperations).toHaveLength(2);
+        expect(captured.userOperations[0].chainId).toBe(1n);
+        expect(captured.userOperations[1].chainId).toBe(10n);
+        expect(captured.userOperations[1].userOperation.nonce).toBe(1n);
+        expect(captured.entryPoint).toBe(safe.entrypointAddress);
+    });
+
+    test('signUserOperationsWithSigners with length=1 still passes multi-op context', async () => {
+        // Regression: previously the length=1 path delegated to the single-op
+        // method which built single-op context, so a multi-op-typed signer
+        // would see `userOperations` undefined at runtime. Now the plural
+        // method always passes multi-op context regardless of bundle length.
+        const safe = ak.SafeMultiChainSigAccountV1.initializeNewAccount([owner]);
+        const op = buildSafeMultiChainOp(safe);
+        const wallet = new Wallet(PK1);
+        let captured = null;
+        await safe.signUserOperationsWithSigners(
+            [{ userOperation: op, chainId: CHAIN_ID, validAfter: 0n, validUntil: 0n }],
+            [{
+                address: wallet.address,
+                signHash: async (h, ctx) => {
+                    captured = ctx;
+                    return wallet.signingKey.sign(h).serialized;
+                },
+            }],
+        );
+        expect('userOperations' in captured).toBe(true);
+        expect(captured.userOperations).toHaveLength(1);
+        expect(captured.userOperations[0].chainId).toBe(CHAIN_ID);
+        expect(captured.userOperations[0].userOperation.sender).toBe(op.sender);
+        expect('userOperation' in captured).toBe(false);
+    });
+
+    test('signTypedData receives the same context shape', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([owner]);
+        const op = buildSafeV3Op(safe);
+        const wallet = new Wallet(PK1);
+        let captured = null;
+        await safe.signUserOperationWithSigners(op, [{
+            address: wallet.address,
+            signTypedData: async (td, ctx) => {
+                captured = ctx;
+                return wallet.signTypedData(td.domain, td.types, td.message);
+            },
+        }], CHAIN_ID);
+        expect('userOperation' in captured).toBe(true);
+        expect(captured.chainId).toBe(CHAIN_ID);
+    });
+});
+
 // ─── Safe accounts (multi-signer, plural method name) ───────────────────
 
 describe('SafeAccountV0_3_0 signUserOperationWithSigners', () => {


### PR DESCRIPTION
Alternative design to #107 for integrating external signers (viem, ethers, hardware wallets, HSMs, MPC, WebAuthn, Uint8Array-only) without passing raw private keys. Opened as a separate PR so both can be compared side-by-side.

## TL;DR differences from #107

| | #107 (callback API) | This PR (capability API) |
|---|---|---|
| Input shape | callback function `async ({userOpHash, typedData}) => ({signerAddress, signature})` | value `{ address, signHash?, signTypedData? }` |
| Caller boilerplate per signer | ~15 lines, 2-3 type casts, null-check on `typedData`, manual `EIP712Domain` strip | one line via `fromViem` / `fromEthersWallet` / `fromPrivateKey` adapter |
| Capability mismatch | bundler rejects with opaque 500 | offline `AbstractionKitError` with actionable fix |
| `v+4` foot-gun (`personal_sign` on Safe) | possible | impossible by design (EIP-191 never exposed) |
| `any` in public types | 4 | 0 |
| Uint8Array-only / HSM posture | works with awkward callback shape | native fit via custom `ExternalSigner` |

## What's in this PR

- `ExternalSigner` interface + `TypedData` / `SigningScheme` / `SignHashFn` / `SignTypedDataFn` types
- Structural adapters: `fromPrivateKey`, `fromViem`, `fromEthersWallet`, `fromViemWalletClient` (zero runtime dep on viem / ethers for the adapters themselves)
- `signUserOperationWithSigner(s)` on every account class (Safe V0_2 / V0_3 / V1_5_0_M_0_3_0 / MultiChainSig, Simple7702 V8 / V09, Calibur). Plural/singular mirrors parameter arity.
- `SafeMultiChainSigAccountV1.signUserOperationsWithSigners` multi-op variant (Merkle root signing for cross-chain bundles)
- Existing sync `signUserOperation(op, pk[] | pk, chainId)` **untouched** — zero migration cost for current callers
- 26 offline tests in `test/signer/signer.test.js` covering every account + adapter + Uint8Array/HSM/secure-dispose postures

## Live-tested on Sepolia (14 txs)
- Safe V0_3_0: 5 paths (`fromPrivateKey`, `fromViem`, `fromEthersWallet`, `fromViemWalletClient`, custom hash-only)
- Simple7702 V8: 3 paths
- Simple7702 V09: 3 paths (two-phase paymaster flow)
- Calibur: 3 paths
- SafeMultiChainSigAccountV1: add-owner across 2 chains with one signature

Example scripts in [abstractionkit-examples](https://github.com/candidelabs/abstractionkit-examples) (not yet pushed): `sponsor-gas/sponsor-gas-v2-signer.ts`, `eip-7702/simple-account/06-signer-api.ts`, `eip-7702/simple-account/07-signer-api-v09.ts`, `eip-7702/calibur-account/04-signer-api.ts`, `chain-abstraction/add-owner-with-signers.ts`.

## BREAKING CHANGE

The prior `Calibur7702Account.signUserOperationWithSigner` callback API is removed. The method name is reused for the new capability API with a different parameter shape. Migration snippet in the commit body and `CHANGELOG.md`.

## Test plan
- [x] `npm run build` clean
- [x] `npx jest test/signer/signer.test.js` — 26/26 passing
- [x] Live Sepolia smoke — 14/14 transactions included, all successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External signer support for user operations across accounts, including multi-signer Safe flows and multi-chain bundled signing.
  * Adapter constructors to wrap private keys and common wallet clients into the external-signer interface.
  * New exported signing types/interfaces for clearer signer contracts and context propagation.

* **Breaking Changes**
  * Removed callback-based signing API; migrate to the new external-signer model.
  * Internal helper visibilities and legacy exported type aliases were removed/changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->