### PR TITLE
chore(release): 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 0.3.2
 
 ### New Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.1   | :white_check_mark: |
+| 0.3.2   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3355,7 +3355,7 @@ function generateOnChainIdentifier(
     project: string,
     platform: "Web" | "Mobile" | "Safe App" | "Widget" = "Web",
     tool: string = "abstractionkit",
-    toolVersion: string = "0.3.0"
+    toolVersion: string = "0.3.2"
 ): string {
     const identifierPrefix = '5afe'; // Safe identifier prefix
     const identifierVersion = '00'; // First version


### PR DESCRIPTION
Release 0.3.2 off `dev`. Promotes the `[Unreleased]` section of the CHANGELOG to a versioned `## 0.3.2` heading and bumps every place the library tracks its own version.

## Version-bump checklist

- `package.json` version: 0.3.1 → 0.3.2
- `CHANGELOG.md`: `## [Unreleased]` → `## 0.3.2`
- `SECURITY.md`: Supported Versions table 0.3.1 → 0.3.2
- `generateOnChainIdentifier` default `toolVersion` in `src/account/Safe/SafeAccount.ts`: 0.3.0 → 0.3.2 (embedded in the Safe on-chain identifier)

## What's in 0.3.2

Promoted from `[Unreleased]`; primary content is #109 (capability-oriented signing API). See `CHANGELOG.md` for full details and migration snippets. Highlights:

### New
- `signUserOperationWithSigner(s)` + `ExternalSigner` on every account class (Safe V0_2 / V0_3 / V1_5_0_M_0_3_0 / MultiChainSig, Simple7702 V8 / V09, Calibur). Signers-only; no pk-string auto-wrap in the new methods.
- `ExternalSigner` discriminated-union interface — compile-time at-least-one-capability check.
- Adapters: `fromPrivateKey`, `fromViem`, `fromEthersWallet`, `fromViemWalletClient`. Structural types, zero runtime dep on viem / ethers.
- `SafeMultiChainSigAccountV1.signUserOperationsWithSigners` — async Merkle-rooted multi-op.
- `SignContext` / `MultiOpSignContext` forwarded to signers as a typed second arg on `signHash` / `signTypedData`.

### Breaking
- Callback signing API (`SignerFunction`, `AddressedSignerFunction`, `SignerInput`, `SignerResult`, `SignerTypedData`) removed.
- `SafeAccount.baseSignSingleUserOperation` now `protected static` (was `public static`).
- `ViemLocalAccountLike` / `ViemWalletClientLike` / `EthersWalletLike` no longer exported (internal structural shapes).

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/signer/signer.test.js` — 31/31 passing
- [ ] CI green on this PR
- [ ] Squash-merge into `dev`, then open `dev → main` promotion PR (merge commit, 1 approval)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.2

* **Documentation**
  * Updated changelog for 0.3.2 release
  * Updated security support documentation to reflect 0.3.2 as the supported version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->