### PR TITLE
feat(account): add skipGasEstimation flag to createUserOperation and populate dummy signature

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,19 @@
 **/.env
 *.log
 .worktrees/
+
+# IDEs / editors
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.project
+.classpath
+.settings/
+*.sublime-project
+*.sublime-workspace
+
+# OS
+.DS_Store
+Thumbs.db

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -468,10 +468,13 @@ export class Calibur7702Account
 		let verificationGasLimit = BaseUserOperationDummyValues.verificationGasLimit;
 		let callGasLimit = BaseUserOperationDummyValues.callGasLimit;
 
+		const skipGasEstimation = overrides.skipGasEstimation ?? false;
+
 		if (
-			overrides.preVerificationGas == null ||
-			overrides.verificationGasLimit == null ||
-			overrides.callGasLimit == null
+			!skipGasEstimation &&
+			(overrides.preVerificationGas == null ||
+				overrides.verificationGasLimit == null ||
+				overrides.callGasLimit == null)
 		) {
 			if (bundlerRpc != null) {
 				userOperation.callGasLimit = 0n;

--- a/src/account/Calibur/types.ts
+++ b/src/account/Calibur/types.ts
@@ -108,6 +108,14 @@ export interface CaliburCreateUserOperationOverrides {
 	/** State overrides for gas estimation */
 	state_override_set?: StateOverrideSet;
 
+	/**
+	 * Skip calling the bundler's gas estimation entirely. When true, the returned
+	 * UserOperation still gets a dummy signature, but its gas limits come from the
+	 * provided overrides (or stay at 0n). Useful when estimation is run separately
+	 * — for example, by a paymaster sponsorship call that returns its own limits.
+	 */
+	skipGasEstimation?: boolean;
+
 	/** Override the dummy signature used during gas estimation */
 	dummySignature?: string;
 

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1560,10 +1560,61 @@ export class SafeAccount extends SmartAccount {
 		let verificationGasLimit = BaseUserOperationDummyValues.verificationGasLimit;
 		let callGasLimit = BaseUserOperationDummyValues.callGasLimit;
 
+		// Build the dummy signature up-front and attach it to the user operation
+		// so the returned op always carries a valid placeholder signature
+		// whether gas estimation runs below or is skipped.
+		const validAfter = 0xffffffffffffn;
+		const validUntil = 0xffffffffffffn;
+
+		let dummySignerSignaturePairs: SignerSignaturePair[];
+		if (overrides.dummySignerSignaturePairs != null) {
+			if (overrides.expectedSigners != null) {
+				throw new RangeError(
+					"Can't use both dummySignerSignaturePairs and expectedSigners overrides.",
+				);
+			}
+			if (overrides.dummySignerSignaturePairs.length < 1) {
+				throw new RangeError("Number of dummySignerSignaturePairs can't be less than 1");
+			}
+			dummySignerSignaturePairs = overrides.dummySignerSignaturePairs;
+		} else {
+			if (overrides.expectedSigners == null) {
+				dummySignerSignaturePairs = [EOADummySignerSignaturePair];
+			} else {
+				const isInit = factoryAddress != null && factoryAddress !== "0x";
+				dummySignerSignaturePairs = SafeAccount.createDummySignerSignaturePairForExpectedSigners(
+					overrides.expectedSigners,
+					{
+						isInit,
+						webAuthnSharedSigner,
+						eip7212WebAuthnPrecompileVerifier,
+						eip7212WebAuthnContractVerifier,
+						webAuthnSignerFactory,
+						webAuthnSignerSingleton,
+						webAuthnSignerProxyCreationCode,
+						validAfter,
+						validUntil,
+					},
+				);
+			}
+		}
+		userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+			dummySignerSignaturePairs,
+			{
+				validAfter,
+				validUntil,
+				webAuthnSharedSigner,
+				isMultiChainSignature: overrides.isMultiChainSignature,
+			},
+		);
+
+		const skipGasEstimation = overrides.skipGasEstimation ?? false;
+
 		if (
-			overrides.preVerificationGas == null ||
-			overrides.verificationGasLimit == null ||
-			overrides.callGasLimit == null
+			!skipGasEstimation &&
+			(overrides.preVerificationGas == null ||
+				overrides.verificationGasLimit == null ||
+				overrides.callGasLimit == null)
 		) {
 			if (bundlerRpc != null) {
 				userOperation.callGasLimit = 0n;
@@ -1618,51 +1669,6 @@ export class SafeAccount extends SmartAccount {
 						userOperationToEstimate.paymasterData = parallelPaymasterInitValues.paymasterData;
 					}
 				}
-				const validAfter = 0xffffffffffffn;
-				const validUntil = 0xffffffffffffn;
-
-				let dummySignerSignaturePairs: SignerSignaturePair[];
-				if (overrides.dummySignerSignaturePairs != null) {
-					if (overrides.expectedSigners != null) {
-						throw new RangeError(
-							"Can't use both dummySignerSignaturePairs and expectedSigners overrides.",
-						);
-					}
-					if (overrides.dummySignerSignaturePairs.length < 1) {
-						throw new RangeError("Number of dummySignerSignaturePairs can't be less than 1");
-					}
-					dummySignerSignaturePairs = overrides.dummySignerSignaturePairs;
-				} else {
-					if (overrides.expectedSigners == null) {
-						dummySignerSignaturePairs = [EOADummySignerSignaturePair];
-					} else {
-						const isInit = factoryAddress != null && factoryAddress !== "0x";
-						dummySignerSignaturePairs =
-							SafeAccount.createDummySignerSignaturePairForExpectedSigners(
-								overrides.expectedSigners,
-								{
-									isInit,
-									webAuthnSharedSigner,
-									eip7212WebAuthnPrecompileVerifier,
-									eip7212WebAuthnContractVerifier,
-									webAuthnSignerFactory,
-									webAuthnSignerSingleton,
-									webAuthnSignerProxyCreationCode,
-									validAfter,
-									validUntil,
-								},
-							);
-					}
-				}
-				userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
-					dummySignerSignaturePairs,
-					{
-						validAfter,
-						validUntil,
-						webAuthnSharedSigner,
-						isMultiChainSignature: overrides.isMultiChainSignature,
-					},
-				);
 
 				[preVerificationGas, verificationGasLimit, callGasLimit] =
 					await this.baseEstimateUserOperationGas(userOperationToEstimate, bundlerRpc, {
@@ -3087,7 +3093,7 @@ function generateOnChainIdentifier(
 	project: string,
 	platform: "Web" | "Mobile" | "Safe App" | "Widget" = "Web",
 	tool: string = "abstractionkit",
-	toolVersion: string = "0.3.2"
+	toolVersion: string = "0.3.2",
 ): string {
 	const identifierPrefix = "5afe"; // Safe identifier prefix
 	const identifierVersion = "00"; // First version

--- a/src/account/Safe/types.ts
+++ b/src/account/Safe/types.ts
@@ -39,6 +39,14 @@ export interface CreateBaseUserOperationOverrides {
 	/** pass some state overrides for gas estimation */
 	state_override_set?: StateOverrideSet;
 
+	/**
+	 * Skip calling the bundler's gas estimation entirely. When true, the returned
+	 * UserOperation still gets a dummy signature, but its gas limits come from the
+	 * provided overrides (or stay at 0n). Useful when estimation is run separately
+	 * — for example, by a paymaster sponsorship call that returns its own limits.
+	 */
+	skipGasEstimation?: boolean;
+
 	dummySignerSignaturePairs?: SignerSignaturePair[];
 
 	webAuthnSharedSigner?: string;

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -79,6 +79,14 @@ export interface CreateUserOperationOverrides {
 	/** pass some state overrides for gas estimation */
 	state_override_set?: StateOverrideSet;
 
+	/**
+	 * Skip calling the bundler's gas estimation entirely. When true, the returned
+	 * UserOperation still gets a dummy signature, but its gas limits come from the
+	 * provided overrides (or stay at 0n). Useful when estimation is run separately
+	 * — for example, by a paymaster sponsorship call that returns its own limits.
+	 */
+	skipGasEstimation?: boolean;
+
 	/** Override the dummy signature used during gas estimation */
 	dummySignature?: string;
 
@@ -581,10 +589,18 @@ export class BaseSimple7702Account extends SmartAccount {
 		let verificationGasLimit = BaseUserOperationDummyValues.verificationGasLimit;
 		let callGasLimit = BaseUserOperationDummyValues.callGasLimit;
 
+		// Set the dummy signature on the user operation regardless of whether
+		// gas estimation runs below, so the returned op always has a valid
+		// placeholder signature (required by paymaster sponsorship calls).
+		userOperation.signature = overrides.dummySignature ?? BaseSimple7702Account.dummySignature;
+
+		const skipGasEstimation = overrides.skipGasEstimation ?? false;
+
 		if (
-			overrides.preVerificationGas == null ||
-			overrides.verificationGasLimit == null ||
-			overrides.callGasLimit == null
+			!skipGasEstimation &&
+			(overrides.preVerificationGas == null ||
+				overrides.verificationGasLimit == null ||
+				overrides.callGasLimit == null)
 		) {
 			const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
 			if (parallelPaymasterInitValues != null) {
@@ -609,7 +625,6 @@ export class BaseSimple7702Account extends SmartAccount {
 
 				const userOperationToEstimate = { ...userOperation };
 
-				userOperation.signature = overrides.dummySignature ?? BaseSimple7702Account.dummySignature;
 				[preVerificationGas, verificationGasLimit, callGasLimit] =
 					await this.baseEstimateUserOperationGas(userOperationToEstimate, bundlerRpc, {
 						stateOverrideSet: overrides.state_override_set,


### PR DESCRIPTION
## Summary
  - Add `skipGasEstimation?: boolean` to `CreateBaseUserOperationOverrides` (Safe family),
  `CreateUserOperationOverrides` (Simple7702), and `CaliburCreateUserOperationOverrides`. When true, the bundler's
  `eth_estimateUserOperationGas` call is skipped; gas limits fall back to overrides or `0n`.
  - Always fill the dummy signature on the returned UserOperation, regardless of whether estimation ran. Previously the
  signature stayed `"0x"` when all three gas fields were overridden, which broke downstream paymaster sponsorship calls
  that require a valid placeholder signature.

  ## Affected account classes
  - `SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0`, `SafeMultiChainSigAccount` (via
  `SafeAccount.createBaseUserOperationAndFactoryAddressAndFactoryData`)
  - `Simple7702Account`, `Simple7702AccountV09` (via `BaseSimple7702Account.baseCreateUserOperation`)
  - `Calibur7702Account.createUserOperation`

  ## Test plan
  - [x] `yarn build` passes
  - [x] Existing integration tests still pass with no overrides (estimation path unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `skipGasEstimation` override option across account types, enabling users to bypass bundler gas estimation and proceed with custom or default gas values for faster operation creation.

* **Chores**
  * Standardized line-ending handling for all files using LF normalization.
  * Expanded project configuration to exclude common IDE and editor artifacts, temporary files, and OS-generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->