### PR TITLE
refactor(paymaster): move CandidePaymasterContext back to a dedicated parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ npm install abstractionkit
 
 ### Upgrading to v0.3.0
 
-v0.3.0 is a major release. Two API changes are likely to break existing paymaster code:
+v0.3.0 is a major release. The following API change is likely to break existing paymaster code:
 
-- `CandidePaymaster.createSponsorPaymasterUserOperation(...)` now takes `smartAccount` as the **first** argument: `(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId?, overrides?)`.
-- `CandidePaymasterContext` is no longer a separate argument. Pass it via `overrides.context` on `GasPaymasterUserOperationOverrides`.
+- `CandidePaymaster.createSponsorPaymasterUserOperation(...)` now takes `smartAccount` as the **first** argument: `(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId?, context?, overrides?)`.
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full list of new features, renames, type export changes, and fixes.
 
@@ -187,7 +186,7 @@ const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
 
 ### Pass paymaster context (sponsorship policy, parallel signing)
 
-As of v0.3.0, `CandidePaymasterContext` is passed via the `overrides.context` field on `GasPaymasterUserOperationOverrides`. Previously it was a separate top level argument.
+`CandidePaymasterContext` is passed as its own argument, separate from gas overrides.
 
 ```typescript
 const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
@@ -196,11 +195,11 @@ const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
   bundlerRpc,
   sponsorshipPolicyId,
   {
-    context: {
-      // For EntryPoint v0.9 parallel signing flows:
-      // signingPhase: "commit" | "finalize",
-    },
-    // gas overrides also live here:
+    // For EntryPoint v0.9 parallel signing flows:
+    // signingPhase: "commit" | "finalize",
+  },
+  {
+    // gas overrides:
     callGasLimitPercentageMultiplier: 110,
   },
 );

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ npm install abstractionkit
 
 ### Upgrading to v0.3.0
 
-v0.3.0 is a major release. The following API change is likely to break existing paymaster code:
+v0.3.0 is a major release. The following API changes are likely to break existing paymaster code:
 
 - `CandidePaymaster.createSponsorPaymasterUserOperation(...)` now takes `smartAccount` as the **first** argument: `(smartAccount, userOp, bundlerRpc, sponsorshipPolicyId?, context?, overrides?)`.
+- `CandidePaymaster.createTokenPaymasterUserOperation(...)` adds a dedicated `context?` argument before `overrides?`: `(smartAccount, userOp, tokenAddress, bundlerRpc, context?, overrides?)`. Callers that previously passed `overrides` positionally at argument 5 must insert `undefined` (or an explicit context) so `overrides` shifts to argument 6.
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full list of new features, renames, type export changes, and fixes.
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
   userOp,
   bundlerRpc,
   sponsorshipPolicyId,
-  // overrides (optional, includes context for parallel signing)
+  // context (optional — e.g. { signingPhase: "commit" } for EP v0.9 parallel signing)
+  // overrides (optional — gas limits and multipliers)
 );
 
 // Sign and send as usual
@@ -178,7 +179,8 @@ const tokenOp = await paymaster.createTokenPaymasterUserOperation(
   userOp,
   gasTokenAddress,
   bundlerRpc,
-  // overrides (optional)
+  // context (optional)
+  // overrides (optional — gas limits, multipliers, resetApproval)
 );
 
 tokenOp.signature = smartAccount.signUserOperation(tokenOp, [ownerPrivateKey], chainId);

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -506,7 +506,8 @@ export class CandidePaymaster extends Paymaster {
 	 * @param userOperation - The UserOperation to sponsor
 	 * @param bundlerRpc - Bundler RPC URL for gas estimation
 	 * @param sponsorshipPolicyId - Optional sponsorship policy ID
-	 * @param overrides - Override gas limits, multipliers, and optional context
+	 * @param context - Optional additional context to pass to the paymaster RPC
+	 * @param overrides - Override gas limits and multipliers
 	 * @returns A tuple of [UserOperation, SponsorMetadata | undefined]
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if sponsorship fails
 	 */
@@ -515,10 +516,11 @@ export class CandidePaymaster extends Paymaster {
 		userOperation: T,
 		bundlerRpc: string,
 		sponsorshipPolicyId?: string,
+		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
 		const userOp = { ...userOperation } as T;
-		const context: CandidePaymasterContext = { sponsorshipPolicyId, ...(overrides?.context || {}) };
+		context = { ...(context || {}), sponsorshipPolicyId };
 		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 		await this.ensureInitialized(entrypoint);
 		const epData = this.getEntrypointData(entrypoint);
@@ -541,7 +543,8 @@ export class CandidePaymaster extends Paymaster {
 	 * @param userOperation - The UserOperation to modify for token payment
 	 * @param tokenAddress - The ERC-20 token contract address to pay gas with
 	 * @param bundlerRpc - Bundler RPC URL for gas estimation
-	 * @param overrides - Override gas limits, multipliers, and optional context
+	 * @param context - Optional additional context to pass to the paymaster RPC
+	 * @param overrides - Override gas limits and multipliers
 	 * @returns The UserOperation with token approval prepended and paymaster fields set
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if the token is not supported
 	 */
@@ -550,13 +553,14 @@ export class CandidePaymaster extends Paymaster {
 		userOperation: T,
 		tokenAddress: string,
 		bundlerRpc: string,
+		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<SameUserOp<T>> {
 		try {
 			const userOp = { ...userOperation } as T;
-			const context: CandidePaymasterContext = {
+			context = {
+				...(context || {}),
 				token: tokenAddress,
-				...(overrides?.context || {}),
 			};
 			if (!context.token || context.token.trim().length === 0 || !isAddress(context.token)) {
 				throw new RangeError(`Invalid token ${context.token ?? "undefined"}`);

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -520,7 +520,10 @@ export class CandidePaymaster extends Paymaster {
 		overrides?: GasPaymasterUserOperationOverrides,
 	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
 		const userOp = { ...userOperation } as T;
-		context = { ...(context || {}), sponsorshipPolicyId };
+		context = {
+			...(context || {}),
+			...(sponsorshipPolicyId !== undefined ? { sponsorshipPolicyId } : {}),
+		};
 		const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 		await this.ensureInitialized(entrypoint);
 		const epData = this.getEntrypointData(entrypoint);

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -180,6 +180,4 @@ export interface GasPaymasterUserOperationOverrides extends BasePaymasterUserOpe
 
 	/** pass some state overrides for gas estimation */
 	state_override_set?: StateOverrideSet;
-
-	context?: CandidePaymasterContext;
 }

--- a/test/calibur/caliburPaymasterV9.test.js
+++ b/test/calibur/caliburPaymasterV9.test.js
@@ -132,7 +132,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
-            userOp, bundlerRpc, undefined, PM_V9,
+            account, userOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         // Verify paymaster fields
@@ -169,7 +169,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const [sponsoredOp2] = await paymaster.createSponsorPaymasterUserOperation(
-            userOp2, bundlerRpc, undefined, PM_V9,
+            account, userOp2, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         sponsoredOp2.signature = account.signUserOperation(sponsoredOp2, eoa.privateKey, chainId);
@@ -194,7 +194,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
-            userOp, bundlerRpc, undefined, PM_V9,
+            account, userOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         sponsoredOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
@@ -224,7 +224,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
-            delegateOp, bundlerRpc, undefined, PM_V9,
+            account, delegateOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         sponsoredDelegateOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
@@ -251,7 +251,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
 
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
         const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
-            regOp, bundlerRpc, undefined, PM_V9,
+            account, regOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         sponsoredRegOp.signature = account.signUserOperation(sponsoredRegOp, eoa.privateKey, chainId);
@@ -271,7 +271,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const [sponsoredPasskeyOp] = await paymaster.createSponsorPaymasterUserOperation(
-            passkeyOp, bundlerRpc, undefined, PM_V9,
+            account, passkeyOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         const userOpHash = account.getUserOperationHash(sponsoredPasskeyOp, chainId);
@@ -297,7 +297,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             { eip7702Auth: { chainId } },
         );
         const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
-            delegateOp, bundlerRpc, undefined, PM_V9,
+            account, delegateOp, bundlerRpc, undefined, undefined, PM_V9,
         );
         sponsoredDelegateOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
             BigInt(sponsoredDelegateOp.eip7702Auth.chainId),
@@ -320,7 +320,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         });
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
         const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
-            regOp, bundlerRpc, undefined, PM_V9,
+            account, regOp, bundlerRpc, undefined, undefined, PM_V9,
         );
         sponsoredRegOp.signature = account.signUserOperation(sponsoredRegOp, eoa.privateKey, chainId);
         await sendAndWait(account, sponsoredRegOp, bundlerRpc);
@@ -331,7 +331,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         const revokeTx = ak.Calibur7702Account.createRevokeKeyMetaTransaction(keyHash);
         const revokeOp = await account.createUserOperation([revokeTx], providerRpc, bundlerRpc);
         const [sponsoredRevokeOp] = await paymaster.createSponsorPaymasterUserOperation(
-            revokeOp, bundlerRpc, undefined, PM_V9,
+            account, revokeOp, bundlerRpc, undefined, undefined, PM_V9,
         );
         sponsoredRevokeOp.signature = account.signUserOperation(
             sponsoredRevokeOp, eoa.privateKey, chainId,
@@ -356,7 +356,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const [sponsoredOp, sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-            userOp, bundlerRpc, undefined, PM_V9,
+            account, userOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
         expect(sponsoredOp.paymaster).toBeTruthy();
@@ -401,7 +401,7 @@ describe('Calibur7702Account Token Paymaster (v0.9 / EntryPoint v9)', () => {
                 { eip7702Auth: { chainId } },
             );
             const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
-                delegateOp, bundlerRpc, undefined, PM_V9,
+                account, delegateOp, bundlerRpc, undefined, undefined, PM_V9,
             );
             sponsoredOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
                 BigInt(sponsoredOp.eip7702Auth.chainId),
@@ -444,7 +444,7 @@ describe('Calibur7702Account Token Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const tokenOp = await paymaster.createTokenPaymasterUserOperation(
-            account, userOp, erc20TokenAddress, bundlerRpc, PM_V9,
+            account, userOp, erc20TokenAddress, bundlerRpc, undefined, PM_V9,
         );
 
         // Verify paymaster fields
@@ -481,7 +481,7 @@ describe('Calibur7702Account Token Paymaster (v0.9 / EntryPoint v9)', () => {
         );
 
         const tokenOp = await paymaster.createTokenPaymasterUserOperation(
-            account, userOp, erc20TokenAddress, bundlerRpc, PM_V9,
+            account, userOp, erc20TokenAddress, bundlerRpc, undefined, PM_V9,
         );
 
         // Should have 3 calls: approve + 2 original


### PR DESCRIPTION
## Summary
  - Revert the API from #95: `CandidePaymasterContext` is no longer read from `overrides.context`; it's passed as its
  own argument again on `createSponsorPaymasterUserOperation` (position 5) and `createTokenPaymasterUserOperation`
  (position 5), each before `overrides`.
  - Remove the `context` field from `GasPaymasterUserOperationOverrides`.
  - Update README: fix the v0.3.0 migration note and the "Pass paymaster context" example.

  ## Breaking change
  Callers that adopted the v0.3.0 `overrides.context` shape must move `context` back to its own argument:

  ```ts
  // Before
  await paymaster.createSponsorPaymasterUserOperation(
    account, op, bundlerRpc, policyId,
    { context: { signingPhase: "commit" }, callGasLimitPercentageMultiplier: 110 },
  );

  // After
  await paymaster.createSponsorPaymasterUserOperation(
    account, op, bundlerRpc, policyId,
    { signingPhase: "commit" },
    { callGasLimitPercentageMultiplier: 110 },
  );
```

  Named parameters (sponsorshipPolicyId, tokenAddress) take precedence over the same keys inside context.

  Test plan

  - yarn build && yarn test — existing paymaster tests (none pass explicit context today, so this should be green).
  - Manually exercise a sponsored UserOp with a signingPhase: "commit" context on EP v0.9.
  - Manually exercise a token-paid UserOp and confirm tokenAddress still reaches the paymaster RPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Paymaster context is now passed as a dedicated argument to paymaster calls; overrides no longer accept a context and now control only gas-related settings.

* **Documentation**
  * Updated upgrade notes and TypeScript examples to show the new parameter order/shape and instruct positional callers to insert a placeholder (e.g., undefined) so overrides shift one position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->