### PR TITLE
fix(paymaster): parse sponsor info per ERC-7677 in CandidePaymaster

### DIFF
--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -133,6 +133,7 @@ export type {
 	JsonRpcResult,
 	MetaTransaction,
 	ParallelPaymasterInitValues,
+	SponsorInfo,
 	SponsorMetadata,
 	StateOverrideSet,
 	UserOperationByHashResult,

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -466,7 +466,18 @@ export class CandidePaymaster extends Paymaster {
 			userOp.paymasterData = v7Result.paymasterData;
 		}
 
-		return result.sponsorMetadata ?? undefined;
+		// ERC-7677 returns sponsor info under `sponsor: { name, icon? }` (singular `icon`).
+		// Normalize into the public `SponsorMetadata` shape.
+		if (result.sponsor?.name != null) {
+			const { name, icon } = result.sponsor;
+			return {
+				name,
+				description: "",
+				url: "",
+				icons: icon ? [icon] : [],
+			};
+		}
+		return undefined;
 	}
 
 	// ── Core paymaster method (private) ──────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,18 @@ export type SponsorMetadata = {
 	icons: string[];
 };
 
+/**
+ * Raw sponsor info shape returned by `pm_getPaymasterData` per ERC-7677
+ * (singular `icon`). Normalized into {@link SponsorMetadata} by
+ * `applyPaymasterResult`.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-7677
+ */
+export type SponsorInfo = {
+	name: string;
+	icon?: string;
+};
+
 /** Paymaster fields returned by pm_getPaymasterData for EntryPoint v0.7+. */
 export type PmUserOperationV7Result = {
 	/** Paymaster contract address */
@@ -243,8 +255,8 @@ export type PmUserOperationV7Result = {
 	maxFeePerGas?: bigint;
 	/** Overridden max priority fee per gas (if provided by paymaster) */
 	maxPriorityFeePerGas?: bigint;
-	/** Metadata about the sponsor */
-	sponsorMetadata?: SponsorMetadata;
+	/** Raw sponsor info per ERC-7677 (normalized into {@link SponsorMetadata}) */
+	sponsor?: SponsorInfo;
 };
 
 /** Paymaster fields returned by pm_getPaymasterData for EntryPoint v0.8 (identical shape to v0.7). */
@@ -264,8 +276,8 @@ export type PmUserOperationV6Result = {
 	maxFeePerGas?: bigint;
 	/** Overridden max priority fee per gas (if provided by paymaster) */
 	maxPriorityFeePerGas?: bigint;
-	/** Metadata about the sponsor */
-	sponsorMetadata?: SponsorMetadata;
+	/** Raw sponsor info per ERC-7677 (normalized into {@link SponsorMetadata}) */
+	sponsor?: SponsorInfo;
 };
 
 /**


### PR DESCRIPTION
## Summary

- `CandidePaymaster#applyPaymasterResult` was reading `result.sponsorMetadata`, a proprietary field the backend never returns on `pm_getPaymasterData`. Per ERC-7677, sponsor info lives under `result.sponsor: { name, icon? }`. Net effect: `createSponsorPaymasterUserOperation` always returned `sponsorMetadata: undefined` since the 0.3.0 switch from `pm_sponsorUserOperation` to `pm_getPaymasterData` — consumers that displayed the sponsor logo got a broken `<img>`.
- Normalize the ERC-7677 `sponsor` shape into the public `SponsorMetadata` shape (`icons = [icon]`, `description` / `url` blank).
- Drop the unused `sponsorMetadata?` field from `PmUserOperationV7Result` / `PmUserOperationV6Result` and the fallback branch in `applyPaymasterResult` — no provider we talk to returns that field.
- Export the new `SponsorInfo` raw-shape type.

Spec reference: https://eips.ethereum.org/EIPS/eip-7677

## Test plan

- [ ] `yarn build` — passes locally (verified)
- [ ] Wire a downstream app against `file:./abstractionkit` and confirm the sponsor's `name` / `icons[0]` populate after `createSponsorPaymasterUserOperation` (verified against safe-passkeys-react-example)
- [ ] CI

## Notes

- Server-side, the paymaster currently returns `icon` as an `https://` URL. ERC-7677 requires a data URI — worth a follow-up on the paymaster service, not blocking here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sponsor information structure in paymaster results. Sponsor data is now derived from ERC-7677 format and normalized into a consistent metadata format with name, description, URL, and icon fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->