### PR TITLE
feat(paymaster)!: return object with tokenQuote/sponsorMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- **`TokenQuote` type** exported from the package root: `{ token: string; exchangeRate: bigint; tokenCost: bigint }`. Surfaces the exchange rate and maximum token cost the paymaster applied when paying gas with an ERC-20 token, so consumers can display the cost to users or log/meter it without a second RPC round-trip.
+- **`CandidePaymaster.createTokenPaymasterUserOperation` and `Erc7677Paymaster.createPaymasterUserOperation` now return `tokenQuote`** alongside the UserOperation. Populated on the token-payment flow; absent on sponsored flows and on Candide's `signingPhase: "finalize"` path (no gas estimation → no cost computation).
+
+### Breaking Changes
+
+- **Three paymaster methods changed return shape** from a raw UserOperation / tuple to a named-field object. All now return `{ userOperation, tokenQuote? | sponsorMetadata? }`:
+  - `CandidePaymaster.createTokenPaymasterUserOperation` — returns `{ userOperation, tokenQuote? }` (was `SameUserOp<T>`).
+  - `CandidePaymaster.createSponsorPaymasterUserOperation` — returns `{ userOperation, sponsorMetadata? }` (was `[SameUserOp<T>, SponsorMetadata | undefined]`).
+  - `Erc7677Paymaster.createPaymasterUserOperation` — returns `{ userOperation, tokenQuote? }` (was `SameUserOp<T>`).
+
+  Migration:
+  ```ts
+  // Before
+  const [sponsoredOp, sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(...);
+  const tokenOp = await paymaster.createTokenPaymasterUserOperation(...);
+  const userOp = await erc7677.createPaymasterUserOperation(...);
+
+  // After
+  const { userOperation: sponsoredOp, sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(...);
+  const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(...);
+  const { userOperation, tokenQuote } = await erc7677.createPaymasterUserOperation(...);
+  ```
+
 ## 0.3.2
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ const userOp = await smartAccount.createUserOperation(
 
 // Sponsor it. Sets paymaster fields and re-estimates gas.
 // Note: as of v0.3.0, smartAccount is the first argument.
-const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+const { userOperation: sponsoredOp, sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(
   smartAccount,
   userOp,
   bundlerRpc,
@@ -174,7 +174,8 @@ const userOp = await smartAccount.createUserOperation(
 // Automatically prepends token approval + sets paymaster fields.
 // For tokens like USDT that require resetting allowance to 0 first, pass
 // { resetApproval: true } in the overrides.
-const tokenOp = await paymaster.createTokenPaymasterUserOperation(
+// `tokenQuote` carries the exchange rate and max token cost used for the approval.
+const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
   smartAccount,
   userOp,
   gasTokenAddress,
@@ -192,7 +193,7 @@ const response = await smartAccount.sendUserOperation(tokenOp, bundlerRpc);
 `CandidePaymasterContext` is passed as its own argument, separate from gas overrides.
 
 ```typescript
-const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
   smartAccount,
   userOp,
   bundlerRpc,

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -12,6 +12,7 @@ import type {
 	SponsorMetadata,
 	SupportedERC20TokensAndMetadata,
 	SupportedERC20TokensAndMetadataWithExchangeRate,
+	TokenQuote,
 } from "../types";
 import { calculateUserOperationMaxGasCost, sendJsonRpcRequest } from "../utils";
 import { Paymaster } from "./Paymaster";
@@ -55,7 +56,7 @@ const TOKENS_REQUIRING_ALLOWANCE_RESET: string[] = [
  *
  * @example
  * const paymaster = new CandidePaymaster("https://api.candide.dev/public/v3/11155111");
- * const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(userOp, bundlerRpcUrl);
+ * const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(userOp, bundlerRpcUrl);
  */
 export class CandidePaymaster extends Paymaster {
 	/** The paymaster JSON-RPC endpoint URL */
@@ -487,7 +488,7 @@ export class CandidePaymaster extends Paymaster {
 		userOperation: T,
 		context: CandidePaymasterContext = {},
 		overrides: GasPaymasterUserOperationOverrides = {},
-	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
+	): Promise<{ userOperation: SameUserOp<T>; sponsorMetadata?: SponsorMetadata }> {
 		try {
 			const entrypoint =
 				overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOperation);
@@ -499,7 +500,10 @@ export class CandidePaymaster extends Paymaster {
 				context,
 			]);
 			const sponsorMetadata = this.applyPaymasterResult(userOperation, jsonRpcResult);
-			return [userOperation as unknown as SameUserOp<T>, sponsorMetadata];
+			return {
+				userOperation: userOperation as unknown as SameUserOp<T>,
+				sponsorMetadata,
+			};
 		} catch (err) {
 			const error = ensureError(err);
 			throw new AbstractionKitError("PAYMASTER_ERROR", "pm_getPaymasterData failed", {
@@ -519,7 +523,7 @@ export class CandidePaymaster extends Paymaster {
 	 * @param sponsorshipPolicyId - Optional sponsorship policy ID
 	 * @param context - Optional additional context to pass to the paymaster RPC
 	 * @param overrides - Override gas limits and multipliers
-	 * @returns A tuple of [UserOperation, SponsorMetadata | undefined]
+	 * @returns An object `{ userOperation, sponsorMetadata? }`
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if sponsorship fails
 	 */
 	async createSponsorPaymasterUserOperation<T extends AnyUserOperation>(
@@ -529,7 +533,7 @@ export class CandidePaymaster extends Paymaster {
 		sponsorshipPolicyId?: string,
 		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
-	): Promise<[SameUserOp<T>, SponsorMetadata | undefined]> {
+	): Promise<{ userOperation: SameUserOp<T>; sponsorMetadata?: SponsorMetadata }> {
 		const userOp = { ...userOperation } as T;
 		context = {
 			...(context || {}),
@@ -559,7 +563,8 @@ export class CandidePaymaster extends Paymaster {
 	 * @param bundlerRpc - Bundler RPC URL for gas estimation
 	 * @param context - Optional additional context to pass to the paymaster RPC
 	 * @param overrides - Override gas limits and multipliers
-	 * @returns The UserOperation with token approval prepended and paymaster fields set
+	 * @returns An object `{ userOperation, tokenQuote? }`. `tokenQuote` is absent
+	 *   when called under the `finalize` signing phase (no cost recomputation).
 	 * @throws AbstractionKitError with code "PAYMASTER_ERROR" if the token is not supported
 	 */
 	async createTokenPaymasterUserOperation<T extends AnyUserOperation>(
@@ -569,7 +574,7 @@ export class CandidePaymaster extends Paymaster {
 		bundlerRpc: string,
 		context?: CandidePaymasterContext,
 		overrides?: GasPaymasterUserOperationOverrides,
-	): Promise<SameUserOp<T>> {
+	): Promise<{ userOperation: SameUserOp<T>; tokenQuote?: TokenQuote }> {
 		try {
 			const userOp = { ...userOperation } as T;
 			context = {
@@ -581,6 +586,7 @@ export class CandidePaymaster extends Paymaster {
 			}
 			const entrypoint = overrides?.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
 			await this.ensureInitialized(entrypoint);
+			let tokenQuote: TokenQuote | undefined;
 			if (context.signingPhase !== "finalize") {
 				const epData = this.getEntrypointData(entrypoint);
 				if (epData == null) {
@@ -611,12 +617,11 @@ export class CandidePaymaster extends Paymaster {
 
 				await this.estimateAndApplyGasLimits(userOp, bundlerRpc, entrypoint, overrides ?? {});
 
-				const maxErc20Cost = await this.calculateUserOperationErc20TokenMaxGasCost(
-					smartAccount,
-					userOp,
-					context.token,
-				);
-				const approveAmount = maxErc20Cost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
+				const exchangeRate = await this.fetchTokenPaymasterExchangeRate(context.token, entrypoint);
+				const gasCostWei = calculateUserOperationMaxGasCost(userOp);
+				const tokenCost = (exchangeRate * gasCostWei) / 10n ** 18n;
+				tokenQuote = { token: context.token, exchangeRate, tokenCost };
+				const approveAmount = tokenCost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
 				callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
 					oldCallData,
 					context.token,
@@ -634,13 +639,13 @@ export class CandidePaymaster extends Paymaster {
 				userOp.callData = callDataWithApprove;
 			}
 			const _overrides = { ...(overrides || {}), entrypoint: entrypoint };
-			const [resultUserOp] = await this.createPaymasterUserOperation(
+			const { userOperation: resultUserOp } = await this.createPaymasterUserOperation(
 				smartAccount,
 				userOp,
 				context,
 				_overrides,
 			);
-			return resultUserOp;
+			return { userOperation: resultUserOp, tokenQuote };
 		} catch (err) {
 			const error = ensureError(err);
 

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -1,7 +1,7 @@
 import { Bundler } from "../Bundler";
 import { ENTRYPOINT_V6, ENTRYPOINT_V7, ENTRYPOINT_V8, ENTRYPOINT_V9 } from "../constants";
 import { AbstractionKitError, ensureError } from "../errors";
-import type { StateOverrideSet } from "../types";
+import type { StateOverrideSet, TokenQuote } from "../types";
 import { calculateUserOperationMaxGasCost, sendJsonRpcRequest } from "../utils";
 import { Paymaster } from "./Paymaster";
 import type {
@@ -124,7 +124,7 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * @example Sponsored UserOperation (Candide)
  * ```ts
  * const paymaster = new Erc7677Paymaster(candideUrl);
- * const sponsoredOp = await paymaster.createPaymasterUserOperation(
+ * const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
  *   smartAccount,
  *   userOp,
  *   bundlerRpc,
@@ -137,7 +137,7 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * @example Token paymaster (Candide — automatic, provider auto-detected)
  * ```ts
  * const paymaster = new Erc7677Paymaster(candideUrl);
- * const tokenOp = await paymaster.createPaymasterUserOperation(
+ * const { userOperation: tokenOp, tokenQuote } = await paymaster.createPaymasterUserOperation(
  *   smartAccount,
  *   userOp,
  *   bundlerRpc,
@@ -148,7 +148,7 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  * @example Token paymaster (unknown provider, exchangeRate supplied)
  * ```ts
  * const paymaster = new Erc7677Paymaster(customUrl);
- * const tokenOp = await paymaster.createPaymasterUserOperation(
+ * const { userOperation: tokenOp, tokenQuote } = await paymaster.createPaymasterUserOperation(
  *   smartAccount,
  *   userOp,
  *   bundlerRpc,
@@ -345,7 +345,8 @@ export class Erc7677Paymaster extends Paymaster {
 	 *   (e.g. `{ sponsorshipPolicyId }` or `{ token }`).
 	 * @param overrides - Gas estimation overrides and state-override set.
 	 *
-	 * @returns The UserOperation with paymaster + gas fields populated.
+	 * @returns An object `{ userOperation, tokenQuote? }`. `tokenQuote` is only
+	 *   populated when the token-payment flow is taken (`context.token` set).
 	 */
 	async createPaymasterUserOperation<T extends AnyUserOperation>(
 		smartAccount: SmartAccountWithEntrypoint,
@@ -353,7 +354,7 @@ export class Erc7677Paymaster extends Paymaster {
 		bundlerRpc: string,
 		context: Erc7677Context = {},
 		overrides: GasPaymasterUserOperationOverrides = {},
-	): Promise<SameUserOp<T>> {
+	): Promise<{ userOperation: SameUserOp<T>; tokenQuote?: TokenQuote }> {
 		try {
 			const userOp = { ...userOperation } as T;
 			const entrypoint = overrides.entrypoint ?? this.resolveEntrypoint(smartAccount, userOp);
@@ -698,7 +699,7 @@ export class Erc7677Paymaster extends Paymaster {
 		chainIdHex: string,
 		context: Erc7677Context,
 		overrides: GasPaymasterUserOperationOverrides,
-	): Promise<SameUserOp<T>> {
+	): Promise<{ userOperation: SameUserOp<T>; tokenQuote?: TokenQuote }> {
 		// Step 1 — resolve exchange rate + paymaster address.
 		let exchangeRate: bigint;
 		let paymasterAddress: string | null = null;
@@ -786,6 +787,7 @@ export class Erc7677Paymaster extends Paymaster {
 		const maxGasCostWei = calculateUserOperationMaxGasCost(userOp);
 		const tokenCost = (exchangeRate * maxGasCostWei) / 10n ** 18n;
 		const approveAmount = tokenCost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
+		const tokenQuote: TokenQuote = { token: tokenAddress, exchangeRate, tokenCost };
 
 		// Step 6 — replace dummy approval with calculated amount on original callData.
 		callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
@@ -810,7 +812,7 @@ export class Erc7677Paymaster extends Paymaster {
 		const final = await this.getPaymasterData(userOp, entrypoint, chainIdHex, context);
 		this.applyPaymasterFields(userOp, final);
 
-		return userOp as unknown as SameUserOp<T>;
+		return { userOperation: userOp as unknown as SameUserOp<T>, tokenQuote };
 	}
 
 	/**
@@ -824,7 +826,7 @@ export class Erc7677Paymaster extends Paymaster {
 		chainIdHex: string,
 		context: Erc7677Context,
 		overrides: GasPaymasterUserOperationOverrides,
-	): Promise<SameUserOp<T>> {
+	): Promise<{ userOperation: SameUserOp<T> }> {
 		// Step 1 — stub paymaster data for gas estimation.
 		// Candide-hosted paymasters skip `pm_getPaymasterStubData` and use the
 		// cached `pm_supportedERC20Tokens` response instead.
@@ -836,13 +838,13 @@ export class Erc7677Paymaster extends Paymaster {
 
 		// Step 3 — if the stub was already final, we're done.
 		if (stub.isFinal === true) {
-			return userOp as unknown as SameUserOp<T>;
+			return { userOperation: userOp as unknown as SameUserOp<T> };
 		}
 
 		// Step 4 — final paymaster data (signature over the fully-populated userOp).
 		const final = await this.getPaymasterData(userOp, entrypoint, chainIdHex, context);
 		this.applyPaymasterFields(userOp, final);
 
-		return userOp as unknown as SameUserOp<T>;
+		return { userOperation: userOp as unknown as SameUserOp<T> };
 	}
 }

--- a/src/paymaster/types.ts
+++ b/src/paymaster/types.ts
@@ -35,7 +35,7 @@ export type SameUserOp<T extends AnyUserOperation> = T extends UserOperationV9
  *
  * @example Sponsored (gasless) UserOperation
  * ```ts
- * const [userOp, sponsorMeta] = await paymaster.createSponsorPaymasterUserOperation(
+ * const { userOperation, sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(
  *   smartAccount, userOp, bundlerRpc,
  *   "my-sponsorship-policy-id",
  * );
@@ -43,7 +43,7 @@ export type SameUserOp<T extends AnyUserOperation> = T extends UserOperationV9
  *
  * @example ERC-20 token gas payment
  * ```ts
- * const userOp = await paymaster.createTokenPaymasterUserOperation(
+ * const { userOperation, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
  *   smartAccount, userOp, USDC_ADDRESS, bundlerRpc,
  * );
  * ```
@@ -55,7 +55,7 @@ export type SameUserOp<T extends AnyUserOperation> = T extends UserOperationV9
  * // The paymaster returns gas limits and init paymasterData (ending with
  * // PAYMASTER_SIG_MAGIC) so owners can sign in parallel without waiting
  * // for the final paymaster signature.
- * const [commitOp] = await paymaster.createSponsorPaymasterUserOperation(
+ * const { userOperation: commitOp } = await paymaster.createSponsorPaymasterUserOperation(
  *   smartAccount, userOp, bundlerRpc,
  *   sponsorshipPolicyId,
  *   { signingPhase: "commit" },
@@ -72,7 +72,7 @@ export type SameUserOp<T extends AnyUserOperation> = T extends UserOperationV9
  * // Send the already-signed UserOperation back to the paymaster.
  * // The paymaster replaces the init paymasterData with the final
  * // paymaster signature. Gas estimation is skipped (already done in commit).
- * const [finalOp] = await paymaster.createSponsorPaymasterUserOperation(
+ * const { userOperation: finalOp } = await paymaster.createSponsorPaymasterUserOperation(
  *   smartAccount, commitOp, bundlerRpc,
  *   sponsorshipPolicyId,
  *   { signingPhase: "finalize" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,6 +224,19 @@ export type SponsorMetadata = {
 };
 
 /**
+ * Quote describing the ERC-20 token payment for a gas-sponsored UserOperation.
+ * Populated when a paymaster successfully applies a token-payment flow.
+ */
+export type TokenQuote = {
+	/** ERC-20 token contract address used to pay gas */
+	token: string;
+	/** Exchange rate scaled by 10^18 (1 ETH expressed in the token's smallest unit) */
+	exchangeRate: bigint;
+	/** Maximum token cost charged for this UserOperation (token's smallest unit) */
+	tokenCost: bigint;
+};
+
+/**
  * Raw sponsor info shape returned by `pm_getPaymasterData` per ERC-7677
  * (singular `icon`). Normalized into {@link SponsorMetadata} by
  * `applyPaymasterResult`.

--- a/test/calibur/caliburPaymaster.test.js
+++ b/test/calibur/caliburPaymaster.test.js
@@ -117,7 +117,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             userOp,
             bundlerRpc,
@@ -156,7 +156,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             bundlerRpc,
         );
 
-        const [sponsoredOp2] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp2 } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             userOp2,
             bundlerRpc,
@@ -183,7 +183,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             userOp,
             bundlerRpc,
@@ -215,7 +215,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredDelegateOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             delegateOp,
             bundlerRpc,
@@ -244,7 +244,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         });
 
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
-        const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredRegOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             regOp,
             bundlerRpc,
@@ -266,7 +266,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             { dummySignature: dummyWebAuthnSig },
         );
 
-        const [sponsoredPasskeyOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredPasskeyOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             passkeyOp,
             bundlerRpc,
@@ -294,7 +294,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             bundlerRpc,
             { eip7702Auth: { chainId } },
         );
-        const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredDelegateOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             delegateOp,
             bundlerRpc,
@@ -319,7 +319,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             expiration: Math.floor(Date.now() / 1000) + 86400 * 365,
         });
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
-        const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredRegOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             regOp,
             bundlerRpc,
@@ -332,7 +332,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
         // Revoke it
         const revokeTx = ak.Calibur7702Account.createRevokeKeyMetaTransaction(keyHash);
         const revokeOp = await account.createUserOperation([revokeTx], providerRpc, bundlerRpc);
-        const [sponsoredRevokeOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredRevokeOp } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             revokeOp,
             bundlerRpc,
@@ -359,7 +359,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.8 defaults)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredOp, sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp, sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(
             account,
             userOp,
             bundlerRpc,
@@ -407,7 +407,7 @@ describe('Calibur7702Account Token Paymaster (v0.8 defaults)', () => {
                 bundlerRpc,
                 { eip7702Auth: { chainId } },
             );
-            const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+            const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
                 account,
                 delegateOp,
                 bundlerRpc,
@@ -452,12 +452,18 @@ describe('Calibur7702Account Token Paymaster (v0.8 defaults)', () => {
             bundlerRpc,
         );
 
-        const tokenOp = await paymaster.createTokenPaymasterUserOperation(
+        const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
             account,
             userOp,
             erc20TokenAddress,
             bundlerRpc,
         );
+
+        // Verify tokenQuote
+        expect(tokenQuote).toBeDefined();
+        expect(tokenQuote.token.toLowerCase()).toBe(erc20TokenAddress.toLowerCase());
+        expect(tokenQuote.exchangeRate > 0n).toBe(true);
+        expect(tokenQuote.tokenCost > 0n).toBe(true);
 
         // Verify paymaster fields
         expect(tokenOp.paymaster).toBeTruthy();
@@ -492,7 +498,7 @@ describe('Calibur7702Account Token Paymaster (v0.8 defaults)', () => {
             bundlerRpc,
         );
 
-        const tokenOp = await paymaster.createTokenPaymasterUserOperation(
+        const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
             account,
             userOp,
             erc20TokenAddress,

--- a/test/calibur/caliburPaymasterV9.test.js
+++ b/test/calibur/caliburPaymasterV9.test.js
@@ -131,7 +131,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, userOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -168,7 +168,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             bundlerRpc,
         );
 
-        const [sponsoredOp2] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp2 } = await paymaster.createSponsorPaymasterUserOperation(
             account, userOp2, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -193,7 +193,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, userOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -223,7 +223,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredDelegateOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, delegateOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -250,7 +250,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         });
 
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
-        const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredRegOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, regOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -270,7 +270,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             { dummySignature: dummyWebAuthnSig },
         );
 
-        const [sponsoredPasskeyOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredPasskeyOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, passkeyOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -296,7 +296,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             bundlerRpc,
             { eip7702Auth: { chainId } },
         );
-        const [sponsoredDelegateOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredDelegateOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, delegateOp, bundlerRpc, undefined, undefined, PM_V9,
         );
         sponsoredDelegateOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
@@ -319,7 +319,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             expiration: Math.floor(Date.now() / 1000) + 86400 * 365,
         });
         const regOp = await account.createUserOperation(registerTxs, providerRpc, bundlerRpc);
-        const [sponsoredRegOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredRegOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, regOp, bundlerRpc, undefined, undefined, PM_V9,
         );
         sponsoredRegOp.signature = account.signUserOperation(sponsoredRegOp, eoa.privateKey, chainId);
@@ -330,7 +330,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
         // Revoke it
         const revokeTx = ak.Calibur7702Account.createRevokeKeyMetaTransaction(keyHash);
         const revokeOp = await account.createUserOperation([revokeTx], providerRpc, bundlerRpc);
-        const [sponsoredRevokeOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredRevokeOp } = await paymaster.createSponsorPaymasterUserOperation(
             account, revokeOp, bundlerRpc, undefined, undefined, PM_V9,
         );
         sponsoredRevokeOp.signature = account.signUserOperation(
@@ -355,7 +355,7 @@ describe('Calibur7702Account Sponsor Paymaster (v0.9 / EntryPoint v9)', () => {
             { eip7702Auth: { chainId } },
         );
 
-        const [sponsoredOp, sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp, sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(
             account, userOp, bundlerRpc, undefined, undefined, PM_V9,
         );
 
@@ -400,7 +400,7 @@ describe('Calibur7702Account Token Paymaster (v0.9 / EntryPoint v9)', () => {
                 bundlerRpc,
                 { eip7702Auth: { chainId } },
             );
-            const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+            const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
                 account, delegateOp, bundlerRpc, undefined, undefined, PM_V9,
             );
             sponsoredOp.eip7702Auth = ak.createAndSignEip7702DelegationAuthorization(
@@ -443,9 +443,15 @@ describe('Calibur7702Account Token Paymaster (v0.9 / EntryPoint v9)', () => {
             bundlerRpc,
         );
 
-        const tokenOp = await paymaster.createTokenPaymasterUserOperation(
+        const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
             account, userOp, erc20TokenAddress, bundlerRpc, undefined, PM_V9,
         );
+
+        // Verify tokenQuote
+        expect(tokenQuote).toBeDefined();
+        expect(tokenQuote.token.toLowerCase()).toBe(erc20TokenAddress.toLowerCase());
+        expect(tokenQuote.exchangeRate > 0n).toBe(true);
+        expect(tokenQuote.tokenCost > 0n).toBe(true);
 
         // Verify paymaster fields
         expect(tokenOp.paymaster).toBeTruthy();
@@ -480,7 +486,7 @@ describe('Calibur7702Account Token Paymaster (v0.9 / EntryPoint v9)', () => {
             bundlerRpc,
         );
 
-        const tokenOp = await paymaster.createTokenPaymasterUserOperation(
+        const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
             account, userOp, erc20TokenAddress, bundlerRpc, undefined, PM_V9,
         );
 

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -112,7 +112,7 @@ describe('Erc7677Paymaster', () => {
       const userOp = v7UserOp();
       const context = { sponsorshipPolicyId: 'sp_test' };
 
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -166,7 +166,7 @@ describe('Erc7677Paymaster', () => {
 
     try {
       const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         { entrypointAddress: ENTRYPOINT_V7 },
         v7UserOp(),
         server.url,
@@ -307,7 +307,7 @@ describe('Erc7677Paymaster', () => {
 
     try {
       const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID });
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         { entrypointAddress: ENTRYPOINT_V7 },
         v7UserOp(),
         server.url,
@@ -402,7 +402,7 @@ describe('Erc7677Paymaster', () => {
       const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
       const userOp = v7UserOp();
 
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out, tokenQuote } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -420,6 +420,12 @@ describe('Erc7677Paymaster', () => {
 
       // Final paymaster data applied.
       expect(out.paymasterData).toBe('0xfinaltoken');
+
+      // tokenQuote populated on the token flow.
+      expect(tokenQuote).toBeDefined();
+      expect(tokenQuote.token.toLowerCase()).toBe(TOKEN_ADDR.toLowerCase());
+      expect(tokenQuote.exchangeRate > 0n).toBe(true);
+      expect(tokenQuote.tokenCost > 0n).toBe(true);
 
       // prependTokenPaymasterApproveToCallData was called (first with MAX, then with calculated).
       expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
@@ -466,7 +472,7 @@ describe('Erc7677Paymaster', () => {
       const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
       const userOp = v7UserOp();
 
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -520,7 +526,7 @@ describe('Erc7677Paymaster', () => {
 
     try {
       const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         { entrypointAddress: ENTRYPOINT_V7 },
         v7UserOp(),
         server.url,
@@ -741,7 +747,7 @@ describe('Erc7677Paymaster', () => {
       const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
       const userOp = v7UserOp();
 
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -794,7 +800,7 @@ describe('Erc7677Paymaster', () => {
       const originalCallData = '0xoriginal';
       const userOp = v7UserOp({ callData: originalCallData });
 
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -849,7 +855,7 @@ describe('Erc7677Paymaster', () => {
       const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
       const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
 
-      const out = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         v7UserOp(),
         server.url,

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -753,7 +753,7 @@ describe('Erc7677Paymaster', () => {
       const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
       const userOp = v7UserOp();
 
-      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out, tokenQuote } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -771,6 +771,12 @@ describe('Erc7677Paymaster', () => {
       // Paymaster address from stub was used in approve calls.
       expect(smartAccount.calls[0].paymasterAddress).toBe(PAYMASTER_ADDR);
       expect(out.paymasterData).toBe('0xfinalrate');
+
+      // tokenQuote populated from context.exchangeRate.
+      expect(tokenQuote).toBeDefined();
+      expect(tokenQuote.token.toLowerCase()).toBe(TOKEN_ADDR.toLowerCase());
+      expect(tokenQuote.exchangeRate).toBe(0xde0b6b3a7640000n);
+      expect(tokenQuote.tokenCost > 0n).toBe(true);
     } finally {
       await server.close();
     }

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -472,7 +472,7 @@ describe('Erc7677Paymaster', () => {
       const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
       const userOp = v7UserOp();
 
-      const { userOperation: out } = await paymaster.createPaymasterUserOperation(
+      const { userOperation: out, tokenQuote } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOp,
         server.url,
@@ -490,6 +490,12 @@ describe('Erc7677Paymaster', () => {
 
       expect(out.paymasterData).toBe('0xfinalcandide');
       expect(smartAccount.calls.length).toBeGreaterThanOrEqual(2);
+
+      // tokenQuote populated on the token flow.
+      expect(tokenQuote).toBeDefined();
+      expect(tokenQuote.token.toLowerCase()).toBe(TOKEN_ADDR.toLowerCase());
+      expect(tokenQuote.exchangeRate > 0n).toBe(true);
+      expect(tokenQuote.tokenCost > 0n).toBe(true);
     } finally {
       await server.close();
     }

--- a/test/safe/migrateAccount.test.js
+++ b/test/safe/migrateAccount.test.js
@@ -33,7 +33,7 @@ describe('safe account migration', () => {
             paymasterRPC
         )
 
-        let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+        let { userOperation: paymasterUserOperation, sponsorMetadata: _sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(
             accountToMigrate,
             testUserOperation,
             bundlerUrl
@@ -63,7 +63,7 @@ describe('safe account migration', () => {
             bundlerUrl,
         )
         
-        const [paymasterUserOperation2, _sponsorMetadata2] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: paymasterUserOperation2, sponsorMetadata: _sponsorMetadata2 } = await paymaster.createSponsorPaymasterUserOperation(
             accountToMigrate,
             migrateUserOperation,
             bundlerUrl
@@ -103,7 +103,7 @@ describe('safe account migration', () => {
             bundlerUrl,
         )
         
-        const [paymasterUserOperation3, _sponsorMetadata3] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: paymasterUserOperation3, sponsorMetadata: _sponsorMetadata3 } = await paymaster.createSponsorPaymasterUserOperation(
             migratedAccount,
             afterMigrationUserOperation,
             bundlerUrl

--- a/test/simple/delegationLive.test.js
+++ b/test/simple/delegationLive.test.js
@@ -104,7 +104,7 @@ describe('EIP-7702 delegation lifecycle (live)', () => {
         );
 
         // Sponsor gas
-        const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
             smartAccount,
             userOperation,
             bundlerUrl
@@ -157,7 +157,7 @@ describe('EIP-7702 delegation lifecycle (live)', () => {
         expect(userOperation.factory).toBeNull();
 
         // Sponsor gas
-        const [sponsoredOp] = await paymaster.createSponsorPaymasterUserOperation(
+        const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
             smartAccount,
             userOperation,
             bundlerUrl


### PR DESCRIPTION
## Summary
  - Three paymaster methods now return `{ userOperation, tokenQuote? | sponsorMetadata? }` instead of raw UserOp /
  tuple:
    - `CandidePaymaster.createTokenPaymasterUserOperation` — returns `{ userOperation, tokenQuote? }`
    - `CandidePaymaster.createSponsorPaymasterUserOperation` — returns `{ userOperation, sponsorMetadata? }` (previously
   `[userOp, sponsorMetadata?]`)
    - `Erc7677Paymaster.createPaymasterUserOperation` — returns `{ userOperation, tokenQuote? }`
  - New `TokenQuote` type exported from the barrel: `{ token, exchangeRate, tokenCost }`. Populated on the token-payment
   flow; absent on sponsored flow and on Candide's `signingPhase: "finalize"` path.
  - Exchange rate and max token cost are now computed once per call and surfaced to the caller; previously they were
  computed internally and discarded, forcing consumers to re-fetch.

  ## BREAKING CHANGE
  All three method return shapes changed. Migration:
  ```ts
  // Before
  const [sponsoredOp, sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(...);
  const tokenOp = await paymaster.createTokenPaymasterUserOperation(...);
  const userOp = await erc7677.createPaymasterUserOperation(...);

  // After
  const { userOperation: sponsoredOp, sponsorMetadata } = await paymaster.createSponsorPaymasterUserOperation(...);
  const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(...);
  const { userOperation, tokenQuote } = await erc7677.createPaymasterUserOperation(...);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exported TokenQuote payload (token, exchange rate, token cost) for token-payment flows
  * Paymaster calls now return structured objects with the user operation plus optional tokenQuote or sponsorMetadata instead of tuples/unnamed returns

* **Documentation**
  * README and examples updated to destructure and consume the new object return shapes

* **Tests**
  * Tests updated to destructure results and assert tokenQuote presence and values in token-payment scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->