### PR TITLE
chore(release): 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(...);
   const { userOperation, tokenQuote } = await erc7677.createPaymasterUserOperation(...);
   ```
-- **`CandidePaymasterContext` moved back to a dedicated parameter** on `CandidePaymaster.createSponsorPaymasterUserOperation` and `createTokenPaymasterUserOperation`. The `context` field was removed from `GasPaymasterUserOperationOverrides`. Migration:
+- **`CandidePaymasterContext` moved back to a dedicated parameter** on `CandidePaymaster.createSponsorPaymasterUserOperation` and `createTokenPaymasterUserOperation`. The `context` field was removed from `GasPaymasterUserOperationOverrides`, and `context` is now the second-to-last argument (optional) on both methods, with `overrides` as the last argument. Migration:
   ```ts
   // Before (0.3.2): context nested inside overrides
   await paymaster.createSponsorPaymasterUserOperation(
@@ -37,7 +37,7 @@
   );
   await paymaster.createTokenPaymasterUserOperation(
     smartAccount, userOp, tokenAddress, bundlerRpc,
-    { context: { token: tokenAddress }, maxFeePerGasMultiplier: 110n },
+    { context: { signingPhase: "commit" }, maxFeePerGasMultiplier: 110n },
   );
 
   // After (0.3.3): context is a dedicated argument
@@ -46,6 +46,9 @@
     { signingPhase: "commit" },
     { maxFeePerGasMultiplier: 110n },
   );
+  // For createTokenPaymasterUserOperation, `context` is optional: the method
+  // always derives `context.token` from the `tokenAddress` argument, so pass
+  // `undefined` unless you need other context fields (e.g. `signingPhase`).
   await paymaster.createTokenPaymasterUserOperation(
     smartAccount, userOp, tokenAddress, bundlerRpc,
     undefined,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.3.3
 
 ### New Features
 
 - **`TokenQuote` type** exported from the package root: `{ token: string; exchangeRate: bigint; tokenCost: bigint }`. Surfaces the exchange rate and maximum token cost the paymaster applied when paying gas with an ERC-20 token, so consumers can display the cost to users or log/meter it without a second RPC round-trip.
 - **`CandidePaymaster.createTokenPaymasterUserOperation` and `Erc7677Paymaster.createPaymasterUserOperation` now return `tokenQuote`** alongside the UserOperation. Populated on the token-payment flow; absent on sponsored flows and on Candide's `signingPhase: "finalize"` path (no gas estimation → no cost computation).
+- **`skipGasEstimation` flag on `createUserOperation` overrides** for `SafeAccount`, `Calibur7702Account`, and `Simple7702Account`. When set, the UserOperation is returned with a dummy signature and zero (or override-provided) gas limits, skipping the bundler's `eth_estimateUserOperationGas` roundtrip. Useful when gas estimation is run separately, for example by a paymaster sponsorship call that returns its own gas limits.
+- **`SponsorInfo` type** exported from the package root. Represents the raw `{ name, icon? }` shape returned by paymasters per ERC-7677; `CandidePaymaster` normalizes it into the public `SponsorMetadata` shape.
 
 ### Breaking Changes
 
@@ -26,6 +28,34 @@
   const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(...);
   const { userOperation, tokenQuote } = await erc7677.createPaymasterUserOperation(...);
   ```
+- **`CandidePaymasterContext` moved back to a dedicated parameter** on `CandidePaymaster.createSponsorPaymasterUserOperation` and `createTokenPaymasterUserOperation`. The `context` field was removed from `GasPaymasterUserOperationOverrides`. Migration:
+  ```ts
+  // Before (0.3.2): context nested inside overrides
+  await paymaster.createSponsorPaymasterUserOperation(
+    smartAccount, userOp, bundlerRpc, sponsorshipPolicyId,
+    { context: { signingPhase: "commit" }, maxFeePerGasMultiplier: 110n },
+  );
+  await paymaster.createTokenPaymasterUserOperation(
+    smartAccount, userOp, tokenAddress, bundlerRpc,
+    { context: { token: tokenAddress }, maxFeePerGasMultiplier: 110n },
+  );
+
+  // After (0.3.3): context is a dedicated argument
+  await paymaster.createSponsorPaymasterUserOperation(
+    smartAccount, userOp, bundlerRpc, sponsorshipPolicyId,
+    { signingPhase: "commit" },
+    { maxFeePerGasMultiplier: 110n },
+  );
+  await paymaster.createTokenPaymasterUserOperation(
+    smartAccount, userOp, tokenAddress, bundlerRpc,
+    undefined,
+    { maxFeePerGasMultiplier: 110n },
+  );
+  ```
+
+### Bug Fixes
+
+- **`CandidePaymaster` now parses sponsor info per ERC-7677.** Paymasters return sponsor info under `sponsor: { name, icon? }` (singular `icon`); the previous code read a non-standard `sponsorMetadata` key and therefore always returned `undefined`. The raw response is now normalized into the public `SponsorMetadata` shape (`{ name, description, url, icons[] }`).
 
 ## 0.3.2
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.2   | :white_check_mark: |
+| 0.3.3   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3093,7 +3093,7 @@ function generateOnChainIdentifier(
 	project: string,
 	platform: "Web" | "Mobile" | "Safe App" | "Widget" = "Web",
 	tool: string = "abstractionkit",
-	toolVersion: string = "0.3.2",
+	toolVersion: string = "0.3.3",
 ): string {
 	const identifierPrefix = "5afe"; // Safe identifier prefix
 	const identifierVersion = "00"; // First version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `skipGasEstimation` override to skip gas estimation and return dummy signatures
  * Exported `SponsorInfo` type for ERC-7677 sponsor payloads

* **Breaking Changes**
  * `CandidePaymasterContext` is now a dedicated argument instead of inside overrides (migration guidance included)

* **Bug Fixes**
  * Sponsor info parsing now returns normalized sponsor metadata

* **Chores**
  * Package released as v0.3.3; default tool version for on-chain identifiers updated to 0.3.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->