### PR TITLE
fix(exports): re-export TokenQuote from package root

### DIFF
--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -136,6 +136,7 @@ export type {
 	SponsorInfo,
 	SponsorMetadata,
 	StateOverrideSet,
+	TokenQuote,
 	UserOperationByHashResult,
 	UserOperationReceipt,
 	UserOperationReceiptResult,


### PR DESCRIPTION
## Summary

\`TokenQuote\` is declared in \`src/types.ts\` and referenced in the return type of \`CandidePaymaster.createTokenPaymasterUserOperation\` and \`Erc7677Paymaster.createPaymasterUserOperation\` (both as \`{ userOperation, tokenQuote? }\`), but it was omitted from the barrel in \`src/abstractionkit.ts\`.

As a result, consumers that use the returned \`tokenQuote\` object can't import the type by name (e.g. to type a helper function), even though 0.3.3's CHANGELOG claims \`TokenQuote\` is exported from the package root.

## Change

Add \`TokenQuote\` to the alphabetical \`export type { ... } from "./types"\` block in \`src/abstractionkit.ts\`, between \`StateOverrideSet\` and \`UserOperationByHashResult\`.

## Test plan
- [ ] \`npm run build\` emits \`TokenQuote\` in the generated \`.d.ts\`
- [ ] \`import type { TokenQuote } from "abstractionkit"\` resolves from a consumer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Exposed additional type for external use

<!-- end of auto-generated comment: release notes by coderabbit.ai -->