### PR TITLE
fix(simple7702): preserve parallel paymaster placeholders when gas estimation is skipped

### DIFF
--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -596,24 +596,29 @@ export class BaseSimple7702Account extends SmartAccount {
 
 		const skipGasEstimation = overrides.skipGasEstimation ?? false;
 
+		// Apply v0.9 parallel paymaster placeholders unconditionally so the
+		// paymaster stub survives into signing/hashing regardless of whether
+		// gas estimation runs below. The UserOpHash must commit to these
+		// fields, so dropping them when skipGasEstimation is true or when
+		// gas limits are pre-specified would produce an invalid signature.
+		const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
+		if (parallelPaymasterInitValues != null) {
+			if (this.entrypointAddress !== ENTRYPOINT_V9) {
+				throw new RangeError("parallelPaymasterInitValues only works with ep v0.9");
+			}
+			userOperation.paymaster = parallelPaymasterInitValues.paymaster;
+			userOperation.paymasterVerificationGasLimit =
+				parallelPaymasterInitValues.paymasterVerificationGasLimit;
+			userOperation.paymasterPostOpGasLimit = parallelPaymasterInitValues.paymasterPostOpGasLimit;
+			userOperation.paymasterData = parallelPaymasterInitValues.paymasterData;
+		}
+
 		if (
 			!skipGasEstimation &&
 			(overrides.preVerificationGas == null ||
 				overrides.verificationGasLimit == null ||
 				overrides.callGasLimit == null)
 		) {
-			const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
-			if (parallelPaymasterInitValues != null) {
-				if (this.entrypointAddress !== ENTRYPOINT_V9) {
-					throw new RangeError("parallelPaymasterInitValues only works with ep v0.9");
-				}
-				userOperation.paymaster = parallelPaymasterInitValues.paymaster;
-				userOperation.paymasterVerificationGasLimit =
-					parallelPaymasterInitValues.paymasterVerificationGasLimit;
-				userOperation.paymasterPostOpGasLimit = parallelPaymasterInitValues.paymasterPostOpGasLimit;
-				userOperation.paymasterData = parallelPaymasterInitValues.paymasterData;
-			}
-
 			if (bundlerRpc != null) {
 				userOperation.callGasLimit = 0n;
 				userOperation.verificationGasLimit = 0n;


### PR DESCRIPTION
## Summary

\`BaseSimple7702Account.baseCreateUserOperation\` applied \`overrides.parallelPaymasterInitValues\` only inside the \`!skipGasEstimation && (gasLimits are missing)\` branch. That meant v0.9 UserOperations lost the paymaster stub whenever:

- \`skipGasEstimation\` was \`true\`, or
- \`preVerificationGas\`, \`verificationGasLimit\`, and \`callGasLimit\` were all pre-specified (so the branch was skipped)

The UserOpHash commits to \`paymaster\`, \`paymasterVerificationGasLimit\`, \`paymasterPostOpGasLimit\`, and \`paymasterData\`, so dropping them left the returned op with a signature that wouldn't validate.

## Change

Hoist the \`parallelPaymasterInitValues\` placeholder application above the gas-estimation branch so it runs whenever the override is provided. The existing \`ENTRYPOINT_V9\` guard is preserved.

## Test plan
- [ ] Call \`baseCreateUserOperation\` on a \`Simple7702AccountV09\` with \`{ skipGasEstimation: true, parallelPaymasterInitValues: { ... } }\` and assert the returned op has the paymaster fields populated
- [ ] Call it with all three gas overrides set and assert the same
- [ ] Existing path (estimation runs) still populates the fields correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed paymaster field initialization in user operations to ensure required paymaster parameters are properly included regardless of gas estimation settings or pre-specified gas limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->