### PR TITLE
ci(sync): auto-open main→dev sync PR after releases

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,64 @@
+name: Sync main to dev
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Skip if dev already contains main
+        id: check
+        run: |
+          git fetch origin dev
+          if git merge-base --is-ancestor HEAD origin/dev; then
+            echo "dev already contains main; nothing to sync"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sync branch
+        if: steps.check.outputs.needed == 'true'
+        id: branch
+        run: |
+          BRANCH="sync/main-to-dev-$(date -u +%Y%m%d-%H%M%S)"
+          git push origin "HEAD:refs/heads/$BRANCH"
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open sync PR
+        if: steps.check.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base dev \
+            --head "${{ steps.branch.outputs.name }}" \
+            --title "sync: main into dev" \
+            --body "$(cat <<'EOF'
+          Auto-opened after push to \`main\` (typically a release merge).
+
+          Brings \`main\`'s tip back into \`dev\` so the next release PR does not open with an "out-of-date with base" banner.
+
+          ## How to merge
+
+          **Must be merged with "Create a merge commit"** (NOT squash, NOT rebase).
+
+          Why: the point of this PR is to make \`main\`'s release merge commits ancestors of \`dev\` by SHA. Squash flattens to a single new commit with a different SHA; rebase rewrites commits with different SHAs. Only "Create a merge commit" preserves the ancestry.
+
+          ## Note on CI
+
+          This PR is opened by \`GITHUB_TOKEN\`. If your branch protection on \`dev\` requires status checks, CI may not trigger automatically on \`GITHUB_TOKEN\`-created PRs. If that happens, close and reopen the PR, or replace the token with a PAT stored in secrets.
+          EOF
+          )"

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    concurrency:
+      group: sync-main-to-dev
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,7 +36,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         id: branch
         run: |
-          BRANCH="sync/main-to-dev-$(date -u +%Y%m%d-%H%M%S)"
+          BRANCH="sync/main-to-dev-$(date -u +%Y%m%d-%H%M%S)-${GITHUB_RUN_ID}"
           git push origin "HEAD:refs/heads/$BRANCH"
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs on every push to \`main\` (typically a release merge) and automatically opens a PR bringing \`main\`'s new tip back into \`dev\`. This replaces the manual sync-PR step that previously had to be done before each \`dev → main\` release PR.

Background: because \`dev → main\` PRs are merged with "Create a merge commit", each release leaves \`main\` with a new merge commit that \`dev\` doesn't have. The next release PR then opens with an "out-of-date with base" block, requiring a separate sync PR (\`main → dev\`) to resolve. This happened during the 0.3.3 release — see #129 for the manual version of what this workflow automates.

## How it works

1. Triggers on every push to \`main\` (plus manual \`workflow_dispatch\` for testing).
2. Checks if \`dev\` already contains \`main\` as an ancestor — if so, exits silently (idempotent).
3. Creates \`sync/main-to-dev-YYYYMMDD-HHMMSS\` at \`main\`'s tip.
4. Opens a PR to \`dev\` with a body explaining the required merge strategy.

## ⚠️ Merge strategy for the auto-generated sync PRs

The sync PRs this workflow opens **must be merged with "Create a merge commit"**, NOT squash or rebase — otherwise \`main\`'s merge commits don't become ancestors of \`dev\` by SHA, and the problem recurs. The PR body loudly instructs reviewers.

## Caveats

- **CI trigger**: PRs opened by \`GITHUB_TOKEN\` don't trigger workflows by default (GitHub's recursion guard). If \`dev\` branch protection requires CI to pass, sync PRs will sit unchecked. Close/reopen fires CI, or swap \`GITHUB_TOKEN\` for a PAT in repo secrets. This is noted in the generated PR body.
- **Merge-strategy enforcement**: the workflow can't force the merge button — the merger clicks it. The body makes the requirement prominent.

## Test plan

- [ ] Manually trigger the workflow via \`workflow_dispatch\` once merged to verify it behaves correctly when \`dev\` is already up to date (should skip)
- [ ] Verify it opens a PR on the next \`main\` push (next release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented automated synchronization workflow to maintain consistency between development branches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->