### PR TITLE
feat: fromWebAuthn adapter for ExternalSigner API (closes #123)

### DIFF
--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -111,6 +111,9 @@ export {
 	fromViem,
 	fromViemWalletClient,
 	fromWebAuthn,
+	pubkeyCoordinatesFromJson,
+	pubkeyCoordinatesToJson,
+	toBigintPubkey,
 	webauthnSignatureFromAssertion,
 } from "./signer/adapters";
 export type {

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -110,6 +110,13 @@ export {
 	fromPrivateKey,
 	fromViem,
 	fromViemWalletClient,
+	fromWebAuthn,
+	webauthnSignatureFromAssertion,
+} from "./signer/adapters";
+export type {
+	AuthenticatorAssertionResponseLike,
+	FromWebAuthnOptions,
+	WebAuthnSignFn,
 } from "./signer/adapters";
 // ─── Signer interface design (capability-oriented) ──────────────────────
 // Exported as `ExternalSigner` because the old package-level `Signer` is
@@ -122,7 +129,10 @@ export type {
 	SignHashFn,
 	SigningScheme,
 	SignTypedDataFn,
+	SignWebauthnFn,
 	TypedData,
+	WebAuthnAssertion,
+	WebauthnPublicKeyCoordinates,
 } from "./signer/types";
 export type {
 	AbiInputValue,

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -8,7 +8,7 @@ import {
 } from "src/constants";
 import { AbstractionKitError } from "src/errors";
 import type { PrependTokenPaymasterApproveAccount } from "src/paymaster/types";
-import { invokeSigner, pickScheme } from "src/signer/negotiate";
+import { invokeSigner, invokeWebauthnSigner, pickScheme } from "src/signer/negotiate";
 import type { Signer as AkSigner, SignContext, SigningScheme } from "src/signer/types";
 import type { JsonRpcResult, UserOperationV8 } from "src/types";
 import {
@@ -599,26 +599,42 @@ export class Calibur7702Account
 	}
 
 	/**
-	 * Schemes Calibur accepts from a Signer. Only raw-hash ECDSA, since
-	 * the account verifies a plain signature over the userOp hash, then
-	 * wraps with `(keyHash, signature, hookData)`.
+	 * Schemes Calibur accepts from a Signer:
+	 *
+	 * - `"hash"` — raw ECDSA over the userOp hash, wrapped as
+	 *   `(keyHash, signature, hookData)` for secp256k1 root keys.
+	 * - `"webauthn"` — passkey assertion (from `fromWebAuthn(...)`) wrapped
+	 *   as `(keyHash, abi.encode(WebAuthnAuth), hookData)` against a
+	 *   registered WebAuthnP256 key. The assertion's challenge is the
+	 *   userOp hash directly (Calibur's contract expects
+	 *   `abi.encode(bytes32 userOpHash)`, which is the same 32 bytes).
 	 */
-	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["hash"];
+	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["hash", "webauthn"];
 
 	/**
-	 * Sign a UserOperation using an {@link ExternalSigner}. Calibur only
-	 * accepts raw-hash ECDSA; signers without `signHash` fail offline with
-	 * an actionable error.
+	 * Sign a UserOperation using an {@link ExternalSigner}. Accepts either
+	 * `"hash"` (raw-hash ECDSA) or `"webauthn"` (passkey assertion via
+	 * `fromWebAuthn(...)`). Signers without a compatible scheme fail
+	 * offline with an actionable error.
 	 *
 	 * For signing with a raw private-key string, use the sync
 	 * {@link signUserOperation} method, or wrap explicitly with
 	 * `fromPrivateKey(pk)`. For secondary (non-root) keys, pass the key
-	 * hash via `overrides.keyHash`.
+	 * hash via `overrides.keyHash` — for WebAuthn root keys, this is
+	 * computed automatically from the signer's pubkey.
 	 *
-	 * @example
-	 * import { fromViem, fromEthersWallet } from "abstractionkit";
+	 * @example ECDSA:
+	 * import { fromViem } from "abstractionkit";
 	 * userOp.signature = await account.signUserOperationWithSigner(
 	 *   userOp, fromViem(privateKeyToAccount(pk)), chainId,
+	 * );
+	 *
+	 * @example WebAuthn:
+	 * import { fromWebAuthn } from "abstractionkit";
+	 * userOp.signature = await account.signUserOperationWithSigner(
+	 *   userOp,
+	 *   fromWebAuthn({ credentialId, pubkey: { x, y } }),
+	 *   chainId,
 	 * );
 	 */
 	public async signUserOperationWithSigner(
@@ -628,7 +644,7 @@ export class Calibur7702Account
 		overrides: CaliburSignatureOverrides = {},
 	): Promise<string> {
 		const scheme = pickScheme(signer, Calibur7702Account.ACCEPTED_SIGNING_SCHEMES, {
-			accountName: "Calibur (raw ECDSA over userOpHash)",
+			accountName: "Calibur (raw ECDSA or WebAuthn over userOpHash)",
 			signerIndex: 0,
 		});
 		const hash = createUserOperationHash(
@@ -641,9 +657,44 @@ export class Calibur7702Account
 			chainId,
 			entryPoint: this.entrypointAddress,
 		};
+		const hookData = overrides.hookData ?? "0x";
+
+		if (scheme === "webauthn") {
+			const assertion = await invokeWebauthnSigner(signer, { challenge: hash, context });
+			// Derive keyHash from the pubkey unless the caller explicitly
+			// passed one (secondary WebAuthn keys would use a different key
+			// descriptor — document in JSDoc).
+			const keyHash =
+				overrides.keyHash ??
+				Calibur7702Account.getKeyHash(
+					Calibur7702Account.createWebAuthnP256Key(signer.pubkey!.x, signer.pubkey!.y),
+				);
+			const typeIdx = assertion.clientDataJSON.indexOf('"type":"webauthn.get"');
+			const challengeIdx = assertion.clientDataJSON.indexOf('"challenge":"');
+			if (typeIdx < 0 || challengeIdx < 0) {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"Calibur WebAuthn: clientDataJSON missing expected `type` or `challenge` fields",
+				);
+			}
+			const authDataHex =
+				"0x" + Buffer.from(assertion.authenticatorData).toString("hex");
+			return this.formatWebAuthnSignature(
+				keyHash,
+				{
+					authenticatorData: authDataHex,
+					clientDataJSON: assertion.clientDataJSON,
+					challengeIndex: BigInt(challengeIdx),
+					typeIndex: BigInt(typeIdx),
+					r: assertion.signature.r,
+					s: assertion.signature.s,
+				},
+				overrides,
+			);
+		}
+
 		const signature = await invokeSigner(signer, scheme, { hash, context });
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
-		const hookData = overrides.hookData ?? "0x";
 		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);
 	}
 

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -660,6 +660,13 @@ export class Calibur7702Account
 		const hookData = overrides.hookData ?? "0x";
 
 		if (scheme === "webauthn") {
+			if (!signer.pubkey) {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"Calibur signer negotiated the `webauthn` scheme but has no `pubkey` — " +
+						"construct WebAuthn signers with `fromWebAuthn({ credentialId, pubkey })`",
+				);
+			}
 			const assertion = await invokeWebauthnSigner(signer, { challenge: hash, context });
 			// Derive keyHash from the pubkey unless the caller explicitly
 			// passed one (secondary WebAuthn keys would use a different key
@@ -667,14 +674,53 @@ export class Calibur7702Account
 			const keyHash =
 				overrides.keyHash ??
 				Calibur7702Account.getKeyHash(
-					Calibur7702Account.createWebAuthnP256Key(signer.pubkey!.x, signer.pubkey!.y),
+					Calibur7702Account.createWebAuthnP256Key(signer.pubkey.x, signer.pubkey.y),
 				);
+			// Validate clientDataJSON structure first — catches malformed
+			// input (bad JSON, wrong type, missing challenge) with a clear
+			// error instead of letting a bogus byte-offset propagate into
+			// on-chain verification.
+			let clientData: { type?: unknown; challenge?: unknown };
+			try {
+				clientData = JSON.parse(assertion.clientDataJSON) as Record<string, unknown>;
+			} catch {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"Calibur WebAuthn: clientDataJSON is not valid JSON",
+				);
+			}
+			if (clientData === null || typeof clientData !== "object") {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"Calibur WebAuthn: clientDataJSON did not parse to an object",
+				);
+			}
+			if (clientData.type !== "webauthn.get") {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					`Calibur WebAuthn: clientDataJSON.type must be "webauthn.get" (got ${JSON.stringify(clientData.type)})`,
+				);
+			}
+			if (typeof clientData.challenge !== "string" || clientData.challenge.length === 0) {
+				throw new AbstractionKitError(
+					"BAD_DATA",
+					"Calibur WebAuthn: clientDataJSON.challenge is missing or empty",
+				);
+			}
+			// Byte offsets the on-chain Calibur verifier uses to seek into
+			// clientDataJSON. These must match what the authenticator
+			// actually emitted, not normalized-whitespace regex positions,
+			// because the on-chain verifier compares bytes at these exact
+			// indices. Authenticators in the wild never emit whitespace
+			// here; if one ever does, indexOf returns -1 and we fail below.
 			const typeIdx = assertion.clientDataJSON.indexOf('"type":"webauthn.get"');
 			const challengeIdx = assertion.clientDataJSON.indexOf('"challenge":"');
 			if (typeIdx < 0 || challengeIdx < 0) {
 				throw new AbstractionKitError(
 					"BAD_DATA",
-					"Calibur WebAuthn: clientDataJSON missing expected `type` or `challenge` fields",
+					"Calibur WebAuthn: clientDataJSON byte layout not recognized " +
+						"(expected canonical `\"type\":\"webauthn.get\"` and `\"challenge\":\"…\"` " +
+						"without whitespace, as produced by all mainstream authenticators)",
 				);
 			}
 			// Browser-safe bytes → hex. `Buffer` isn't defined in Vite /

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -677,8 +677,12 @@ export class Calibur7702Account
 					"Calibur WebAuthn: clientDataJSON missing expected `type` or `challenge` fields",
 				);
 			}
-			const authDataHex =
-				"0x" + Buffer.from(assertion.authenticatorData).toString("hex");
+			// Browser-safe bytes → hex. `Buffer` isn't defined in Vite /
+			// browser bundles without a polyfill.
+			let authDataHex = "0x";
+			for (const b of assertion.authenticatorData) {
+				authDataHex += b.toString(16).padStart(2, "0");
+			}
 			return this.formatWebAuthnSignature(
 				keyHash,
 				{

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1867,19 +1867,14 @@ export class SafeAccount extends SmartAccount {
 		};
 
 		// Preflight: capability check throws with an actionable message if
-		// any signer can't produce what Safe accepts. Also normalizes
-		// EOA-signer addresses in the same pass.
+		// any signer can't produce what Safe accepts. Address normalization
+		// is deferred into the ECDSA branch below — WebAuthn signers carry
+		// no `address` and shouldn't run `getAddress` unnecessarily.
 		const schemes = signers.map((signer, signerIndex) =>
 			pickScheme(signer, SafeAccount.ACCEPTED_SIGNING_SCHEMES, {
 				accountName: "Safe (EIP-712 or raw hash over SafeOp digest)",
 				signerIndex,
 			}),
-		);
-		const normalizedAddresses = signers.map((signer) =>
-			// WebAuthn signers carry no `address`; the per-owner verifier
-			// address is computed later from `pubkey` by
-			// buildSignaturesFromSingerSignaturePairs.
-			signer.address ? getAddress(signer.address) : null,
 		);
 
 		// Dispatch per-scheme. Hash/typedData return a hex signature;
@@ -1904,12 +1899,24 @@ export class SafeAccount extends SmartAccount {
 						signature: encodeSafeWebAuthnSignatureFromAssertion(assertion),
 					};
 				}
+				if (!signer.address) {
+					throw new AbstractionKitError(
+						"BAD_DATA",
+						`signer[${i}] negotiated the "${schemes[i]}" scheme but has no \`address\` — ` +
+							"EOA-shape signers must expose an `address` field " +
+							"(use fromPrivateKey / fromViem / fromEthersWallet to construct one)",
+					);
+				}
 				const signature = await invokeSigner(signer, schemes[i], {
 					hash: userOpHash,
 					typedData,
 					context,
 				});
-				return { kind: "ecdsa" as const, address: normalizedAddresses[i]!, signature };
+				return {
+					kind: "ecdsa" as const,
+					address: getAddress(signer.address),
+					signature,
+				};
 			}),
 		);
 

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -2062,8 +2062,22 @@ export class SafeAccount extends SmartAccount {
 
 	/**
 	 * calculate a signer public address lowercase
+	 *
+	 * For WebAuthn signers, the returned address MUST match the address
+	 * that `buildSignaturesFromSingerSignaturePairs` will emit on-chain so
+	 * that sorting produces a pack order Safe's `checkNSignatures`
+	 * accepts (strictly ascending by signer address, else reverts
+	 * `GS026`):
+	 *   - `overrides.isInit === true`  → shared-signer address
+	 *   - `overrides.isInit === false` (or unset) → per-owner
+	 *     deterministic verifier address
+	 *
+	 * The two can sort on opposite sides of an EOA address, so mixed
+	 * WebAuthn + ECDSA signers at init would otherwise pack out of order.
+	 *
 	 * @param signer - a signer to compute address for
-	 * @param overrides - overrides for the default values
+	 * @param overrides - overrides for the default values; honor
+	 *   `overrides.isInit` for WebAuthn signers
 	 * @returns signer address
 	 */
 	public static getSignerLowerCaseAddress(
@@ -2072,27 +2086,31 @@ export class SafeAccount extends SmartAccount {
 	): string {
 		if (typeof signer === "string") {
 			return signer.toLowerCase();
-		} else {
-			const eip7212WebAuthnPrecompileVerifier =
-				overrides.eip7212WebAuthnPrecompileVerifier ?? SafeAccount.DEFAULT_WEB_AUTHN_PRECOMPILE;
-			const eip7212WebAuthnContractVerifier =
-				overrides.eip7212WebAuthnContractVerifier ?? SafeAccount.DEFAULT_WEB_AUTHN_FCLP256_VERIFIER;
-			const webAuthnSignerFactory =
-				overrides.webAuthnSignerFactory ?? SafeAccount.DEFAULT_WEB_AUTHN_SIGNER_FACTORY;
-			const webAuthnSignerSingleton =
-				overrides.webAuthnSignerSingleton ?? SafeAccount.DEFAULT_WEB_AUTHN_SIGNER_SINGLETON;
-			const webAuthnSignerProxyCreationCode =
-				overrides.webAuthnSignerProxyCreationCode ??
-				SafeAccount.DEFAULT_WEB_AUTHN_SIGNER_PROXY_CREATION_CODE;
-
-			return SafeAccount.createWebAuthnSignerVerifierAddress(signer.x, signer.y, {
-				eip7212WebAuthnPrecompileVerifier,
-				eip7212WebAuthnContractVerifier,
-				webAuthnSignerFactory,
-				webAuthnSignerSingleton,
-				webAuthnSignerProxyCreationCode,
-			}).toLowerCase();
 		}
+		if (overrides.isInit === true) {
+			const webauthnsharedsigner =
+				overrides.webAuthnSharedSigner ?? SafeAccount.DEFAULT_WEB_AUTHN_SHARED_SIGNER;
+			return webauthnsharedsigner.toLowerCase();
+		}
+		const eip7212WebAuthnPrecompileVerifier =
+			overrides.eip7212WebAuthnPrecompileVerifier ?? SafeAccount.DEFAULT_WEB_AUTHN_PRECOMPILE;
+		const eip7212WebAuthnContractVerifier =
+			overrides.eip7212WebAuthnContractVerifier ?? SafeAccount.DEFAULT_WEB_AUTHN_FCLP256_VERIFIER;
+		const webAuthnSignerFactory =
+			overrides.webAuthnSignerFactory ?? SafeAccount.DEFAULT_WEB_AUTHN_SIGNER_FACTORY;
+		const webAuthnSignerSingleton =
+			overrides.webAuthnSignerSingleton ?? SafeAccount.DEFAULT_WEB_AUTHN_SIGNER_SINGLETON;
+		const webAuthnSignerProxyCreationCode =
+			overrides.webAuthnSignerProxyCreationCode ??
+			SafeAccount.DEFAULT_WEB_AUTHN_SIGNER_PROXY_CREATION_CODE;
+
+		return SafeAccount.createWebAuthnSignerVerifierAddress(signer.x, signer.y, {
+			eip7212WebAuthnPrecompileVerifier,
+			eip7212WebAuthnContractVerifier,
+			webAuthnSignerFactory,
+			webAuthnSignerSingleton,
+			webAuthnSignerProxyCreationCode,
+		}).toLowerCase();
 	}
 
 	/**

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3181,7 +3181,12 @@ export function extractClientDataFieldsHex(clientDataJSON: string): string {
 	const fields = Object.entries(rest)
 		.map(([key, value]) => `"${key}":${JSON.stringify(value)}`)
 		.join(",");
-	return "0x" + Buffer.from(fields, "utf8").toString("hex");
+	// Browser-safe utf-8 → hex. `Buffer` isn't defined in Vite / browser
+	// bundles without a polyfill.
+	const utf8 = new TextEncoder().encode(fields);
+	let hex = "0x";
+	for (const b of utf8) hex += b.toString(16).padStart(2, "0");
+	return hex;
 }
 
 /**

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1884,7 +1884,8 @@ export class SafeAccount extends SmartAccount {
 			signers.map(async (signer, i) => {
 				if (schemes[i] === "webauthn") {
 					if (!signer.pubkey) {
-						throw new Error(
+						throw new AbstractionKitError(
+							"BAD_DATA",
 							`signer[${i}] negotiated the \`webauthn\` scheme but has no \`pubkey\` — ` +
 								"construct WebAuthn signers with `fromWebAuthn({ credentialId, pubkey })`",
 						);

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -11,8 +11,13 @@ import {
 import { Bundler } from "src/Bundler";
 import { AbstractionKitError, ensureError } from "src/errors";
 import { SafeAccountFactory } from "src/factory/SafeAccountFactory";
-import { invokeSigner, pickScheme } from "src/signer/negotiate";
-import type { Signer as AkSigner, SigningScheme, TypedData } from "src/signer/types";
+import { invokeSigner, invokeWebauthnSigner, pickScheme } from "src/signer/negotiate";
+import type {
+	Signer as AkSigner,
+	SigningScheme,
+	TypedData,
+	WebAuthnAssertion,
+} from "src/signer/types";
 import {
 	BaseUserOperationDummyValues,
 	EIP712_SAFE_OPERATION_PRIMARY_TYPE,
@@ -1783,9 +1788,14 @@ export class SafeAccount extends SmartAccount {
 	 * Schemes Safe accepts from a {@link Signer}, in preference order.
 	 * `typedData` is preferred because wallets can display structured fields
 	 * rather than a hex blob; `hash` is accepted as a fallback for signers
-	 * that only support raw ECDSA.
+	 * that only support raw ECDSA. `webauthn` is accepted for passkey
+	 * signers produced by `fromWebAuthn(...)`.
 	 */
-	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["typedData", "hash"];
+	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = [
+		"typedData",
+		"hash",
+		"webauthn",
+	];
 
 	/**
 	 * Sign a UserOperation using one or more {@link Signer}s. This is the
@@ -1856,40 +1866,65 @@ export class SafeAccount extends SmartAccount {
 			message: typedDataRaw.messageValue as unknown as Record<string, unknown>,
 		};
 
-		// Preflight: validate + checksum every signer's address before
-		// calling any signer. Catches malformed addresses offline instead
-		// of after an external signer (HSM, hardware wallet) has already
-		// been prompted.
-		const normalizedAddresses = signers.map((signer) => getAddress(signer.address));
-
-		// Offline capability check: throws with an actionable message if
-		// any signer can't produce what Safe accepts.
+		// Preflight: capability check throws with an actionable message if
+		// any signer can't produce what Safe accepts. Also normalizes
+		// EOA-signer addresses in the same pass.
 		const schemes = signers.map((signer, signerIndex) =>
 			pickScheme(signer, SafeAccount.ACCEPTED_SIGNING_SCHEMES, {
 				accountName: "Safe (EIP-712 or raw hash over SafeOp digest)",
 				signerIndex,
 			}),
 		);
+		const normalizedAddresses = signers.map((signer) =>
+			// WebAuthn signers carry no `address`; the per-owner verifier
+			// address is computed later from `pubkey` by
+			// buildSignaturesFromSingerSignaturePairs.
+			signer.address ? getAddress(signer.address) : null,
+		);
 
-		const signatures = await Promise.all(
-			signers.map((signer, i) =>
-				invokeSigner(signer, schemes[i], {
+		// Dispatch per-scheme. Hash/typedData return a hex signature;
+		// webauthn returns a raw WebAuthnAssertion that we ABI-encode
+		// inline.
+		const results = await Promise.all(
+			signers.map(async (signer, i) => {
+				if (schemes[i] === "webauthn") {
+					const assertion = await invokeWebauthnSigner(signer, {
+						challenge: userOpHash,
+						context,
+					});
+					return {
+						kind: "webauthn" as const,
+						pubkey: signer.pubkey!,
+						signature: encodeSafeWebAuthnSignatureFromAssertion(assertion),
+					};
+				}
+				const signature = await invokeSigner(signer, schemes[i], {
 					hash: userOpHash,
 					typedData,
 					context,
-				}),
-			),
+				});
+				return { kind: "ecdsa" as const, address: normalizedAddresses[i]!, signature };
+			}),
 		);
 
-		const signerSignaturePairs = signatures.map((signature, i) => ({
-			signer: normalizedAddresses[i],
-			signature,
-		}));
+		const signerSignaturePairs = results.map((r) =>
+			r.kind === "webauthn"
+				? { signer: r.pubkey, signature: r.signature, isContractSignature: true as const }
+				: { signer: r.address, signature: r.signature },
+		);
 
+		const hasWebauthn = results.some((r) => r.kind === "webauthn");
 		return SafeAccount.formatSignaturesToUseroperationSignature(signerSignaturePairs, {
 			validAfter,
 			validUntil,
 			isMultiChainSignature: overrides.isMultiChainSignature,
+			// Safe's WebAuthn contract-signature path needs to know whether
+			// the verifier has been deployed yet: pre-init uses the shared
+			// signer address; post-init uses the per-owner deterministic
+			// verifier. Derive from the UserOp itself — factory on V7+,
+			// non-empty initCode on V6. Only set when relevant to avoid
+			// regressing EOA-only flows.
+			...(hasWebauthn ? { isInit: isUserOperationInit(useroperation) } : {}),
 		});
 	}
 
@@ -3111,4 +3146,56 @@ function generateOnChainIdentifier(
 
 	const res = `${identifierPrefix}${identifierVersion}${projectHashEncoded}${platformHashEncoded}${toolHashEncoded}${toolVersionHashEncoded}`;
 	return res;
+}
+
+/**
+ * Re-serialize every clientDataJSON field except `type` and `challenge`.
+ * Robust to authenticators adding or reordering keys (e.g. Safari's
+ * `crossOrigin`) — parses JSON instead of using a regex, so any
+ * spec-compliant clientDataJSON produces the correct `clientDataFields`
+ * hex that Safe's WebAuthn verifier contract expects.
+ *
+ * @internal Shared with SafeMultiChainSigAccount for multi-op signing.
+ */
+export function extractClientDataFieldsHex(clientDataJSON: string): string {
+	const parsed = JSON.parse(clientDataJSON) as Record<string, unknown>;
+	const { type: _type, challenge: _challenge, ...rest } = parsed;
+	const fields = Object.entries(rest)
+		.map(([key, value]) => `"${key}":${JSON.stringify(value)}`)
+		.join(",");
+	return "0x" + Buffer.from(fields, "utf8").toString("hex");
+}
+
+/**
+ * Convert a raw {@link WebAuthnAssertion} into the Safe WebAuthn verifier's
+ * expected ABI blob. Shared by single-op and multi-chain signing paths.
+ *
+ * @internal Shared with SafeMultiChainSigAccount for multi-op signing.
+ */
+export function encodeSafeWebAuthnSignatureFromAssertion(assertion: WebAuthnAssertion): string {
+	return SafeAccount.createWebAuthnSignature({
+		authenticatorData: assertion.authenticatorData,
+		clientDataFields: extractClientDataFieldsHex(assertion.clientDataJSON),
+		rs: [assertion.signature.r, assertion.signature.s],
+	});
+}
+
+/**
+ * Is this UserOperation deploying the account? True when the factory /
+ * initCode is populated. Used to route WebAuthn signatures through the
+ * shared-signer verifier (pre-init) vs the per-owner deterministic
+ * verifier (post-init).
+ *
+ * @internal Shared with SafeMultiChainSigAccount for multi-op signing.
+ */
+export function isUserOperationInit(
+	useroperation: UserOperationV6 | UserOperationV7 | UserOperationV9,
+): boolean {
+	if ("initCode" in useroperation) {
+		// V6: initCode is a concatenated (factory, factoryData) hex; empty
+		// is "0x".
+		return typeof useroperation.initCode === "string" && useroperation.initCode !== "0x";
+	}
+	// V7 / V8 / V9: separate `factory` field, null when not deploying.
+	return useroperation.factory != null && useroperation.factory !== "0x";
 }

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1888,13 +1888,19 @@ export class SafeAccount extends SmartAccount {
 		const results = await Promise.all(
 			signers.map(async (signer, i) => {
 				if (schemes[i] === "webauthn") {
+					if (!signer.pubkey) {
+						throw new Error(
+							`signer[${i}] negotiated the \`webauthn\` scheme but has no \`pubkey\` — ` +
+								"construct WebAuthn signers with `fromWebAuthn({ credentialId, pubkey })`",
+						);
+					}
 					const assertion = await invokeWebauthnSigner(signer, {
 						challenge: userOpHash,
 						context,
 					});
 					return {
 						kind: "webauthn" as const,
-						pubkey: signer.pubkey!,
+						pubkey: signer.pubkey,
 						signature: encodeSafeWebAuthnSignatureFromAssertion(assertion),
 					};
 				}

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3190,8 +3190,28 @@ function generateOnChainIdentifier(
  * @internal Shared with SafeMultiChainSigAccount for multi-op signing.
  */
 export function extractClientDataFieldsHex(clientDataJSON: string): string {
-	const parsed = JSON.parse(clientDataJSON) as Record<string, unknown>;
-	const { type: _type, challenge: _challenge, ...rest } = parsed;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(clientDataJSON);
+	} catch (err) {
+		throw new AbstractionKitError(
+			"BAD_DATA",
+			`Safe WebAuthn: clientDataJSON is not valid JSON (${(err as Error).message})`,
+		);
+	}
+	// JSON.parse can yield a plain object, `null`, an array, or a
+	// primitive (string / number / boolean). Reject anything but a plain
+	// object — destructuring `null` throws raw TypeError, destructuring
+	// arrays or primitives silently produces wrong output that would
+	// land as malformed `clientDataFields` in the Safe WebAuthn verifier.
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new AbstractionKitError(
+			"BAD_DATA",
+			"Safe WebAuthn: clientDataJSON must parse to a plain object " +
+				`(got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed})`,
+		);
+	}
+	const { type: _type, challenge: _challenge, ...rest } = parsed as Record<string, unknown>;
 	const fields = Object.entries(rest)
 		.map(([key, value]) => `"${key}":${JSON.stringify(value)}`)
 		.join(",");

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -667,13 +667,19 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			const results: Result[] = await Promise.all(
 				signers.map(async (signer, i): Promise<Result> => {
 					if (schemes[i] === "webauthn") {
+						if (!signer.pubkey) {
+							throw new Error(
+								`signer[${i}] negotiated the \`webauthn\` scheme but has no \`pubkey\` — ` +
+									"construct WebAuthn signers with `fromWebAuthn({ credentialId, pubkey })`",
+							);
+						}
 						const assertion: WebAuthnAssertion = await invokeWebauthnSigner(signer, {
 							challenge: merkleTreeRootHash,
 							context,
 						});
 						return {
 							kind: "webauthn",
-							pubkey: signer.pubkey!,
+							pubkey: signer.pubkey,
 							signature: encodeSafeWebAuthnSignatureFromAssertion(assertion),
 						};
 					}

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -668,7 +668,8 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 				signers.map(async (signer, i): Promise<Result> => {
 					if (schemes[i] === "webauthn") {
 						if (!signer.pubkey) {
-							throw new Error(
+							throw new AbstractionKitError(
+								"BAD_DATA",
 								`signer[${i}] negotiated the \`webauthn\` scheme but has no \`pubkey\` — ` +
 									"construct WebAuthn signers with `fromWebAuthn({ credentialId, pubkey })`",
 							);

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -1,5 +1,6 @@
 import { getAddress, TypedDataEncoder, Wallet } from "ethers";
 import { EIP712_MULTI_CHAIN_OPERATIONS_TYPE, ENTRYPOINT_V9 } from "src/constants";
+import { AbstractionKitError } from "src/errors";
 import { invokeSigner, invokeWebauthnSigner, pickScheme } from "src/signer/negotiate";
 import type {
 	Signer as AkSigner,
@@ -650,15 +651,14 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			) as `0x${string}`;
 
 			// Merkle root is opaque; `typedData` has nothing meaningful to
-			// display, so we require raw-hash or webauthn signing.
+			// display, so we require raw-hash or webauthn signing. Address
+			// normalization is deferred into the ECDSA branch — WebAuthn
+			// signers have no `address` and shouldn't run `getAddress`.
 			const schemes = signers.map((signer, i) =>
 				pickScheme(signer, ["hash", "webauthn"], {
 					accountName: "SafeMultiChainSigAccountV1 (multi-op Merkle root)",
 					signerIndex: i,
 				}),
-			);
-			const normalizedAddresses = signers.map((signer) =>
-				signer.address ? getAddress(signer.address) : null,
 			);
 
 			type Result =
@@ -683,11 +683,19 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 							signature: encodeSafeWebAuthnSignatureFromAssertion(assertion),
 						};
 					}
+					if (!signer.address) {
+						throw new AbstractionKitError(
+							"BAD_DATA",
+							`signer[${i}] negotiated the "hash" scheme but has no \`address\` — ` +
+								"EOA-shape signers must expose an `address` field " +
+								"(use fromPrivateKey / fromViem / fromEthersWallet to construct one)",
+						);
+					}
 					const signature = await invokeSigner(signer, "hash", {
 						hash: merkleTreeRootHash,
 						context,
 					});
-					return { kind: "ecdsa", address: normalizedAddresses[i]!, signature };
+					return { kind: "ecdsa", address: getAddress(signer.address), signature };
 				}),
 			);
 			const signerSignaturePairs: SignerSignaturePair[] = results.map((r) =>

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -1,7 +1,13 @@
 import { getAddress, TypedDataEncoder, Wallet } from "ethers";
 import { EIP712_MULTI_CHAIN_OPERATIONS_TYPE, ENTRYPOINT_V9 } from "src/constants";
-import { invokeSigner, pickScheme } from "src/signer/negotiate";
-import type { Signer as AkSigner, MultiOpSignContext, SignContext } from "src/signer/types";
+import { invokeSigner, invokeWebauthnSigner, pickScheme } from "src/signer/negotiate";
+import type {
+	Signer as AkSigner,
+	MultiOpSignContext,
+	SignContext,
+	WebAuthnAssertion,
+	WebauthnPublicKeyCoordinates,
+} from "src/signer/types";
 import type { MetaTransaction, OnChainIdentifierParamsType, UserOperationV9 } from "../../types";
 import {
 	DEFAULT_WEB_AUTHN_DAIMO_VERIFIER_V_0_2_1,
@@ -12,7 +18,11 @@ import {
 	DEFAULT_WEB_AUTHN_SIGNER_SINGLETON_V_0_2_1,
 } from "./constants";
 import { generateMerkleProofs } from "./MerkleTree";
-import { SafeAccount } from "./SafeAccount";
+import {
+	encodeSafeWebAuthnSignatureFromAssertion,
+	isUserOperationInit,
+	SafeAccount,
+} from "./SafeAccount";
 import type {
 	CreateUserOperationV9Overrides,
 	InitCodeOverrides,
@@ -639,32 +649,48 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 				{ merkleTreeRoot: root },
 			) as `0x${string}`;
 
-			// Preflight: validate + checksum every signer's address before
-			// calling any signer. Catches malformed addresses offline
-			// instead of after an external signer has been prompted.
-			const normalizedAddresses = signers.map((signer) => getAddress(signer.address));
-
-			// Merkle root is opaque; signTypedData has nothing meaningful to
-			// display, so we require raw-hash signing.
-			signers.forEach((signer, i) => {
-				pickScheme(signer, ["hash"], {
+			// Merkle root is opaque; `typedData` has nothing meaningful to
+			// display, so we require raw-hash or webauthn signing.
+			const schemes = signers.map((signer, i) =>
+				pickScheme(signer, ["hash", "webauthn"], {
 					accountName: "SafeMultiChainSigAccountV1 (multi-op Merkle root)",
 					signerIndex: i,
-				});
-			});
+				}),
+			);
+			const normalizedAddresses = signers.map((signer) =>
+				signer.address ? getAddress(signer.address) : null,
+			);
 
-			const signatures = await Promise.all(
-				signers.map((signer) =>
-					invokeSigner(signer, "hash", {
+			type Result =
+				| { kind: "ecdsa"; address: string; signature: string }
+				| { kind: "webauthn"; pubkey: WebauthnPublicKeyCoordinates; signature: string };
+			const results: Result[] = await Promise.all(
+				signers.map(async (signer, i): Promise<Result> => {
+					if (schemes[i] === "webauthn") {
+						const assertion: WebAuthnAssertion = await invokeWebauthnSigner(signer, {
+							challenge: merkleTreeRootHash,
+							context,
+						});
+						return {
+							kind: "webauthn",
+							pubkey: signer.pubkey!,
+							signature: encodeSafeWebAuthnSignatureFromAssertion(assertion),
+						};
+					}
+					const signature = await invokeSigner(signer, "hash", {
 						hash: merkleTreeRootHash,
 						context,
-					}),
-				),
+					});
+					return { kind: "ecdsa", address: normalizedAddresses[i]!, signature };
+				}),
 			);
-			const signerSignaturePairs: SignerSignaturePair[] = signers.map((_signer, i) => ({
-				signer: normalizedAddresses[i],
-				signature: signatures[i],
-			}));
+			const signerSignaturePairs: SignerSignaturePair[] = results.map((r) =>
+				r.kind === "webauthn"
+					? { signer: r.pubkey, signature: r.signature, isContractSignature: true }
+					: { signer: r.address, signature: r.signature },
+			);
+
+			const hasWebauthn = results.some((r) => r.kind === "webauthn");
 
 			const userOpSignatures: string[] = [];
 			userOperationsToSign.forEach((uopToSign, index) => {
@@ -674,6 +700,10 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 						validUntil: uopToSign.validUntil,
 						isMultiChainSignature: true,
 						multiChainMerkleProof: proofs[index],
+						// isInit depends on the specific UserOp being formatted,
+						// not the signers. Each op in the bundle may be either
+						// deploying or already-deployed.
+						...(hasWebauthn ? { isInit: isUserOperationInit(uopToSign.userOperation) } : {}),
 					}),
 				);
 			});

--- a/src/account/Safe/types.ts
+++ b/src/account/Safe/types.ts
@@ -273,7 +273,14 @@ export type Signer = ECDSAPublicAddress | WebauthnPublicKey;
 export type ECDSASignature = string;
 
 export interface WebauthnSignatureData {
-	authenticatorData: ArrayBuffer;
+	/**
+	 * Raw `authenticatorData` bytes from the WebAuthn assertion. Accepts
+	 * both `ArrayBuffer` (raw browser API) and `Uint8Array` (most WebAuthn
+	 * libraries, including `ox`). Normalized to `Uint8Array` internally
+	 * before ABI encoding — consumers no longer need the
+	 * `.buffer as ArrayBuffer` cast at every call site.
+	 */
+	authenticatorData: ArrayBuffer | Uint8Array;
 	clientDataFields: string;
 	rs: [bigint, bigint];
 }

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -248,9 +248,15 @@ export interface FromWebAuthnOptions {
 	/**
 	 * P-256 public-key coordinates extracted from the credential. Safe and
 	 * Calibur derive the on-chain signer identity deterministically from
-	 * these values.
+	 * these values. Accepts `bigint` or string coords: hex (`"0x..."`) or
+	 * decimal strings are coerced via `BigInt()`. This handles the common
+	 * case where `{ x, y }` has been JSON-round-tripped through
+	 * localStorage / backend / network boundary and ended up as strings.
 	 */
-	pubkey: WebauthnPublicKeyCoordinates;
+	pubkey: {
+		x: bigint | string;
+		y: bigint | string;
+	};
 	/**
 	 * Override the default browser ceremony. Supply for Node /
 	 * server-side / test harnesses. If omitted, uses
@@ -296,20 +302,113 @@ export function fromWebAuthn(opts: FromWebAuthnOptions): Signer<unknown> {
 	if (!opts || typeof opts.credentialId !== "string" || opts.credentialId.length === 0) {
 		throw new Error("fromWebAuthn: `credentialId` (base64url string) is required");
 	}
-	if (!opts.pubkey || typeof opts.pubkey.x !== "bigint" || typeof opts.pubkey.y !== "bigint") {
-		throw new Error("fromWebAuthn: `pubkey` must be `{ x: bigint, y: bigint }`");
-	}
+	const pubkey = toBigintPubkey(opts?.pubkey);
 
 	const signFn: WebAuthnSignFn = opts.signFn ?? defaultBrowserSignFn(opts.credentialId);
 
 	return {
-		pubkey: opts.pubkey,
+		pubkey,
 		signWebauthn: async (challenge) => {
 			const challengeBytes = hexToBytes(challenge);
 			const response = await signFn(challengeBytes);
 			return webauthnSignatureFromAssertion(response);
 		},
 	};
+}
+
+/**
+ * Coerce a `{ x, y }` pair with any mix of `bigint` / `0x…` hex / decimal
+ * string values to a canonical `WebauthnPublicKeyCoordinates`. Used
+ * internally by {@link fromWebAuthn}; also exported for consumers
+ * reading the coords out of storage paths where they may have ended up
+ * as strings.
+ *
+ * @throws if either coordinate is missing, the wrong type, or an
+ * unparseable string.
+ */
+export function toBigintPubkey(pubkey: {
+	x: bigint | string | number;
+	y: bigint | string | number;
+}): WebauthnPublicKeyCoordinates {
+	if (!pubkey || pubkey.x == null || pubkey.y == null) {
+		throw new Error("fromWebAuthn: `pubkey` must be `{ x, y }` with both coords set");
+	}
+	return { x: coerceBigint(pubkey.x, "x"), y: coerceBigint(pubkey.y, "y") };
+}
+
+function coerceBigint(v: bigint | string | number, field: string): bigint {
+	if (typeof v === "bigint") return v;
+	if (typeof v === "string") {
+		try {
+			return BigInt(v);
+		} catch {
+			throw new Error(
+				`fromWebAuthn: pubkey.${field} ("${v}") is not a valid bigint string. ` +
+					`Accepted: bigint, decimal string, or 0x-prefixed hex string.`,
+			);
+		}
+	}
+	if (typeof v === "number") {
+		if (!Number.isSafeInteger(v)) {
+			throw new Error(
+				`fromWebAuthn: pubkey.${field} is a Number but not a safe integer. ` +
+					`Pass as bigint or hex string to avoid precision loss.`,
+			);
+		}
+		return BigInt(v);
+	}
+	throw new Error(`fromWebAuthn: pubkey.${field} must be bigint, string, or number (got ${typeof v})`);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Bigint-safe pubkey JSON round-trip helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Serialize a WebAuthn pubkey to a JSON string with hex-encoded
+ * coordinates. Inverse of {@link pubkeyCoordinatesFromJson}.
+ *
+ * `JSON.stringify` can't serialize `bigint` without a custom replacer,
+ * and every consumer persisting `{ x, y }` ends up writing the same
+ * replacer. This helper ships the canonical version so the round-trip
+ * is consistent across call sites.
+ *
+ * @example
+ * ```ts
+ * localStorage.setItem("passkey", pubkeyCoordinatesToJson({ x: 0x7a..., y: 0x2e... }));
+ * // Stored as: {"x":"0x7a...","y":"0x2e..."}
+ * ```
+ */
+export function pubkeyCoordinatesToJson(pubkey: WebauthnPublicKeyCoordinates): string {
+	return JSON.stringify({
+		x: "0x" + pubkey.x.toString(16),
+		y: "0x" + pubkey.y.toString(16),
+	});
+}
+
+/**
+ * Parse a JSON string produced by {@link pubkeyCoordinatesToJson} (or
+ * any JSON object with `x` / `y` fields as bigint-compatible strings)
+ * back into a `WebauthnPublicKeyCoordinates` with `bigint` coords.
+ *
+ * Lenient about input shape — accepts hex (`"0x..."`) or decimal
+ * strings, as well as a pre-parsed object if you already ran
+ * `JSON.parse` yourself.
+ *
+ * @example
+ * ```ts
+ * const raw = localStorage.getItem("passkey");
+ * if (raw) {
+ *   const pubkey = pubkeyCoordinatesFromJson(raw);
+ *   // pubkey: { x: bigint, y: bigint }
+ * }
+ * ```
+ */
+export function pubkeyCoordinatesFromJson(
+	input: string | { x: bigint | string | number; y: bigint | string | number },
+): WebauthnPublicKeyCoordinates {
+	const parsed = typeof input === "string" ? JSON.parse(input) : input;
+	return toBigintPubkey(parsed);
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -477,17 +477,27 @@ function toRSPair(
  * DER layout: 0x30 | total-len | 0x02 | r-len | r-bytes | 0x02 | s-len | s-bytes
  */
 function parseDerP256Signature(der: Uint8Array): { r: bigint; s: bigint } {
-	if (der.length < 8 || der[0] !== 0x30) {
-		throw new Error("fromWebAuthn: malformed DER signature");
-	}
+	// All out-of-bounds / malformed-length cases fold into one error so
+	// hostile or truncated DER input can't slip through and produce a
+	// silently-wrong r/s via Uint8Array.subarray's clamping behavior.
+	const malformed = () => new Error("fromWebAuthn: malformed DER signature");
+	if (der.length < 8 || der[0] !== 0x30) throw malformed();
 	let offset = 2;
 	if (der[1] === 0x81) offset = 3; // long-form length byte we can skip
-	if (der[offset] !== 0x02) throw new Error("fromWebAuthn: malformed DER signature (r tag)");
+
+	// r tag + length + body must fit
+	if (offset + 2 > der.length) throw malformed();
+	if (der[offset] !== 0x02) throw malformed();
 	const rLen = der[offset + 1];
+	if (rLen <= 0 || offset + 2 + rLen > der.length) throw malformed();
 	const rBytes = der.subarray(offset + 2, offset + 2 + rLen);
 	offset += 2 + rLen;
-	if (der[offset] !== 0x02) throw new Error("fromWebAuthn: malformed DER signature (s tag)");
+
+	// s tag + length + body must fit
+	if (offset + 2 > der.length) throw malformed();
+	if (der[offset] !== 0x02) throw malformed();
 	const sLen = der[offset + 1];
+	if (sLen <= 0 || offset + 2 + sLen > der.length) throw malformed();
 	const sBytes = der.subarray(offset + 2, offset + 2 + sLen);
 
 	const r = bytesToBigInt(rBytes);

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -1,5 +1,10 @@
 import { getAddress, Wallet } from "ethers";
-import type { Signer, TypedData } from "./types";
+import type {
+	Signer,
+	TypedData,
+	WebAuthnAssertion,
+	WebauthnPublicKeyCoordinates,
+} from "./types";
 
 // Structural types for well-known signers. NO imports from viem / ethers
 // at the type level (beyond the already-present ethers runtime dep used by
@@ -168,4 +173,266 @@ export function fromEthersWallet(wallet: EthersWalletLike): Signer<unknown> {
 		signTypedData: async (td) =>
 			(await wallet.signTypedData(td.domain, td.types, td.message)) as `0x${string}`,
 	};
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthn adapter
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Structural shape matching the browser `AuthenticatorAssertionResponse`,
+ * `ox/WebAuthnP256` sign output, `@simplewebauthn/browser`, and raw
+ * `navigator.credentials.get()` results. Consumers can pass any of these
+ * without an adapter-specific wrapper.
+ *
+ * The three fields are normalized individually: `authenticatorData` may be
+ * an `ArrayBuffer` (browser) or `Uint8Array` (libraries); `clientDataJSON`
+ * may be a UTF-8 string (already-decoded, as `ox` returns) or a buffer (raw
+ * browser API); `signature` may be pre-decoded `{ r, s }` bigints (as `ox`
+ * returns) or a DER-encoded buffer (raw browser API).
+ */
+export interface AuthenticatorAssertionResponseLike {
+	authenticatorData: ArrayBuffer | Uint8Array;
+	clientDataJSON: ArrayBuffer | Uint8Array | string;
+	signature: ArrayBuffer | Uint8Array | { r: bigint; s: bigint };
+}
+
+/**
+ * Turn a structural {@link AuthenticatorAssertionResponseLike} into a
+ * normalized {@link WebAuthnAssertion}. The inverse of `ox` / raw-browser
+ * plumbing. Works for consumers building custom WebAuthn flows (server-side
+ * ceremony, transcript replay) who don't want the full {@link fromWebAuthn}
+ * signer.
+ *
+ * @example
+ * ```ts
+ * import { webauthnSignatureFromAssertion } from "abstractionkit";
+ * const assertion = webauthnSignatureFromAssertion(response);
+ * // assertion: { authenticatorData: Uint8Array, clientDataJSON: string, signature: { r, s } }
+ * ```
+ */
+export function webauthnSignatureFromAssertion(
+	response: AuthenticatorAssertionResponseLike,
+): WebAuthnAssertion {
+	return {
+		authenticatorData: toUint8Array(response.authenticatorData),
+		clientDataJSON: toUtf8String(response.clientDataJSON),
+		signature: toRSPair(response.signature),
+	};
+}
+
+/**
+ * Optional custom sign function for {@link fromWebAuthn}. Defaults to
+ * `navigator.credentials.get(...)` on the browser. Supply this for Node
+ * (server-side ceremony), tests, or any environment without
+ * `navigator.credentials`.
+ *
+ * The challenge passed in is the raw 32-byte UserOperation hash, already
+ * decoded to bytes — pass it directly to the WebAuthn API as
+ * `publicKey.challenge`.
+ */
+export type WebAuthnSignFn = (
+	challenge: Uint8Array,
+) => Promise<AuthenticatorAssertionResponseLike>;
+
+/**
+ * Adapter options for {@link fromWebAuthn}.
+ */
+export interface FromWebAuthnOptions {
+	/**
+	 * Base64url-encoded credential id (as returned by
+	 * `navigator.credentials.create().id`). Used to narrow
+	 * `allowCredentials` on the assertion ceremony.
+	 */
+	credentialId: string;
+	/**
+	 * P-256 public-key coordinates extracted from the credential. Safe and
+	 * Calibur derive the on-chain signer identity deterministically from
+	 * these values.
+	 */
+	pubkey: WebauthnPublicKeyCoordinates;
+	/**
+	 * Override the default browser ceremony. Supply for Node /
+	 * server-side / test harnesses. If omitted, uses
+	 * `navigator.credentials.get({ publicKey: { challenge, allowCredentials,
+	 * userVerification: "required" } })`.
+	 */
+	signFn?: WebAuthnSignFn;
+}
+
+/**
+ * Build an {@link Signer} backed by a WebAuthn passkey. Accepts any signer
+ * that matches the `AuthenticatorAssertionResponse` shape — raw
+ * `navigator.credentials`, `ox/WebAuthnP256`, `@simplewebauthn/browser`, or
+ * `viem/webauthn` all work.
+ *
+ * The returned signer reports `ACCEPTED_SIGNING_SCHEMES` as `["webauthn"]`
+ * via its `signWebauthn` method. Passing it to an account that only
+ * accepts `["hash"]` (Simple7702) fails offline with an actionable error
+ * instead of a silent bundler rejection.
+ *
+ * @example Safe (browser, defaults):
+ * ```ts
+ * import { fromWebAuthn } from "abstractionkit";
+ * const signer = fromWebAuthn({
+ *   credentialId: passkey.id,
+ *   pubkey: passkey.pubkeyCoordinates,
+ * });
+ * userOp.signature = await safe.signUserOperationWithSigners(
+ *   userOp, [signer], chainId,
+ * );
+ * ```
+ *
+ * @example Server-side / Node (inject `signFn`):
+ * ```ts
+ * const signer = fromWebAuthn({
+ *   credentialId,
+ *   pubkey,
+ *   signFn: async (challenge) => await myServerCeremony(challenge),
+ * });
+ * ```
+ */
+export function fromWebAuthn(opts: FromWebAuthnOptions): Signer<unknown> {
+	if (!opts || typeof opts.credentialId !== "string" || opts.credentialId.length === 0) {
+		throw new Error("fromWebAuthn: `credentialId` (base64url string) is required");
+	}
+	if (!opts.pubkey || typeof opts.pubkey.x !== "bigint" || typeof opts.pubkey.y !== "bigint") {
+		throw new Error("fromWebAuthn: `pubkey` must be `{ x: bigint, y: bigint }`");
+	}
+
+	const signFn: WebAuthnSignFn = opts.signFn ?? defaultBrowserSignFn(opts.credentialId);
+
+	return {
+		pubkey: opts.pubkey,
+		signWebauthn: async (challenge) => {
+			const challengeBytes = hexToBytes(challenge);
+			const response = await signFn(challengeBytes);
+			return webauthnSignatureFromAssertion(response);
+		},
+	};
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthn internals (browser default + normalization helpers)
+// ────────────────────────────────────────────────────────────────────────────
+
+function defaultBrowserSignFn(credentialId: string): WebAuthnSignFn {
+	return async (challenge) => {
+		if (typeof navigator === "undefined" || !navigator.credentials?.get) {
+			throw new Error(
+				"fromWebAuthn: `navigator.credentials.get` is not available in this environment. " +
+					"Pass an explicit `signFn` for Node / server-side / test usage.",
+			);
+		}
+		const credIdBytes = base64UrlToBytes(credentialId);
+		// `navigator.credentials.get` requires `BufferSource`, which is
+		// `ArrayBufferView | ArrayBuffer`. Uint8Array is an ArrayBufferView,
+		// so no copy is needed in the browser.
+		const credential = (await navigator.credentials.get({
+			publicKey: {
+				challenge,
+				allowCredentials: [{ id: credIdBytes, type: "public-key" }],
+				userVerification: "required",
+			},
+		})) as (PublicKeyCredential & { response: AuthenticatorAssertionResponse }) | null;
+		if (!credential) {
+			throw new Error("fromWebAuthn: navigator.credentials.get returned null");
+		}
+		return credential.response;
+	};
+}
+
+function toUint8Array(input: ArrayBuffer | Uint8Array): Uint8Array {
+	return input instanceof Uint8Array ? input : new Uint8Array(input);
+}
+
+function toUtf8String(input: ArrayBuffer | Uint8Array | string): string {
+	if (typeof input === "string") return input;
+	const bytes = toUint8Array(input);
+	// TextDecoder is available in all modern browsers and Node 11+.
+	return new TextDecoder("utf-8").decode(bytes);
+}
+
+function toRSPair(
+	input: ArrayBuffer | Uint8Array | { r: bigint; s: bigint },
+): { r: bigint; s: bigint } {
+	if (
+		input !== null &&
+		typeof input === "object" &&
+		"r" in input &&
+		"s" in input &&
+		typeof (input as { r: bigint }).r === "bigint" &&
+		typeof (input as { s: bigint }).s === "bigint"
+	) {
+		return { r: (input as { r: bigint }).r, s: (input as { s: bigint }).s };
+	}
+	const bytes = toUint8Array(input as ArrayBuffer | Uint8Array);
+	return parseDerP256Signature(bytes);
+}
+
+/**
+ * Parse a DER-encoded ECDSA P-256 signature into its (r, s) bigint pair,
+ * with low-S normalization (per BIP-62 / WebAuthn spec expectations). The
+ * curve order n is fixed for P-256.
+ *
+ * DER layout: 0x30 | total-len | 0x02 | r-len | r-bytes | 0x02 | s-len | s-bytes
+ */
+function parseDerP256Signature(der: Uint8Array): { r: bigint; s: bigint } {
+	if (der.length < 8 || der[0] !== 0x30) {
+		throw new Error("fromWebAuthn: malformed DER signature");
+	}
+	let offset = 2;
+	if (der[1] === 0x81) offset = 3; // long-form length byte we can skip
+	if (der[offset] !== 0x02) throw new Error("fromWebAuthn: malformed DER signature (r tag)");
+	const rLen = der[offset + 1];
+	const rBytes = der.subarray(offset + 2, offset + 2 + rLen);
+	offset += 2 + rLen;
+	if (der[offset] !== 0x02) throw new Error("fromWebAuthn: malformed DER signature (s tag)");
+	const sLen = der[offset + 1];
+	const sBytes = der.subarray(offset + 2, offset + 2 + sLen);
+
+	const r = bytesToBigInt(rBytes);
+	let s = bytesToBigInt(sBytes);
+
+	// Low-S normalize: some authenticators return the high-S form; the Safe
+	// WebAuthn verifier and most P-256 checkers accept only the low-S form.
+	const P256_N = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n;
+	const P256_N_HALF = P256_N >> 1n;
+	if (s > P256_N_HALF) s = P256_N - s;
+
+	return { r, s };
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+	let hex = "0x";
+	for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+	return hex === "0x" ? 0n : BigInt(hex);
+}
+
+function hexToBytes(hex: `0x${string}`): Uint8Array {
+	const body = hex.slice(2);
+	if (body.length % 2 !== 0) throw new Error("fromWebAuthn: invalid hex challenge length");
+	const out = new Uint8Array(body.length / 2);
+	for (let i = 0; i < out.length; i++) {
+		out[i] = Number.parseInt(body.slice(i * 2, i * 2 + 2), 16);
+	}
+	return out;
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+	// Restore standard base64 alphabet and pad.
+	const padded = s.replace(/-/g, "+").replace(/_/g, "/").padEnd(s.length + ((4 - (s.length % 4)) % 4), "=");
+	// Buffer (Node) and atob (browser) both handle this; prefer atob for
+	// zero-dep feel, fall back to Buffer when running in Node.
+	const bin =
+		typeof atob === "function"
+			? atob(padded)
+			: typeof Buffer !== "undefined"
+				? Buffer.from(padded, "base64").toString("binary")
+				: (() => {
+						throw new Error("fromWebAuthn: no base64 decoder available");
+					})();
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
 }

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -21,7 +21,20 @@ export function pickScheme<C>(
 	const signerCan: SigningScheme[] = [];
 	if (typeof signer.signTypedData === "function") signerCan.push("typedData");
 	if (typeof signer.signHash === "function") signerCan.push("hash");
-	if (typeof signer.signWebauthn === "function") signerCan.push("webauthn");
+	// `webauthn` requires BOTH signWebauthn and a valid pubkey — signing
+	// alone isn't enough; downstream code (Safe, Calibur) uses pubkey to
+	// derive the on-chain signer identity. Checking here keeps the
+	// error readable ("no compatible scheme") instead of letting it
+	// surface later as a vague pubkey-access failure during packing.
+	if (
+		typeof signer.signWebauthn === "function" &&
+		signer.pubkey != null &&
+		typeof signer.pubkey === "object" &&
+		typeof signer.pubkey.x === "bigint" &&
+		typeof signer.pubkey.y === "bigint"
+	) {
+		signerCan.push("webauthn");
+	}
 
 	for (const scheme of accepted) {
 		if (signerCan.includes(scheme)) return scheme;

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -53,13 +53,21 @@ export function pickScheme<C>(
 }
 
 function describeSignerIdentity<C>(signer: Signer<C>): string {
-	if (typeof signer.signWebauthn === "function" && signer.pubkey) {
+	// Same bigint-shape gate as pickScheme, so describe() can never throw
+	// a raw TypeError on a handcrafted signer that declares signWebauthn
+	// but has malformed / missing pubkey coords.
+	if (
+		typeof signer.signWebauthn === "function" &&
+		signer.pubkey != null &&
+		typeof signer.pubkey === "object" &&
+		typeof signer.pubkey.x === "bigint"
+	) {
 		// Identify WebAuthn signers by a short hex of the x-coordinate so
 		// error messages distinguish them without leaking the full pubkey.
 		const xHex = signer.pubkey.x.toString(16).padStart(64, "0");
 		return `webauthn(x=0x${xHex.slice(0, 8)}…${xHex.slice(-8)})`;
 	}
-	return signer.address as string;
+	return signer.address ?? "(unknown signer)";
 }
 
 function buildMismatchMessage(params: {

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -1,5 +1,5 @@
 import { AbstractionKitError } from "../errors";
-import type { Signer, SigningScheme, TypedData } from "./types";
+import type { Signer, SigningScheme, TypedData, WebAuthnAssertion } from "./types";
 
 /**
  * Pick the best mutually-supported signing scheme for one signer against an
@@ -21,6 +21,7 @@ export function pickScheme<C>(
 	const signerCan: SigningScheme[] = [];
 	if (typeof signer.signTypedData === "function") signerCan.push("typedData");
 	if (typeof signer.signHash === "function") signerCan.push("hash");
+	if (typeof signer.signWebauthn === "function") signerCan.push("webauthn");
 
 	for (const scheme of accepted) {
 		if (signerCan.includes(scheme)) return scheme;
@@ -31,37 +32,52 @@ export function pickScheme<C>(
 		buildMismatchMessage({
 			accountName: context.accountName,
 			signerIndex: context.signerIndex,
-			signerAddress: signer.address,
+			signerIdentity: describeSignerIdentity(signer),
 			accepted,
 			signerCan,
 		}),
 	);
 }
 
+function describeSignerIdentity<C>(signer: Signer<C>): string {
+	if (typeof signer.signWebauthn === "function" && signer.pubkey) {
+		// Identify WebAuthn signers by a short hex of the x-coordinate so
+		// error messages distinguish them without leaking the full pubkey.
+		const xHex = signer.pubkey.x.toString(16).padStart(64, "0");
+		return `webauthn(x=0x${xHex.slice(0, 8)}…${xHex.slice(-8)})`;
+	}
+	return signer.address as string;
+}
+
 function buildMismatchMessage(params: {
 	accountName: string;
 	signerIndex: number;
-	signerAddress: string;
+	signerIdentity: string;
 	accepted: readonly SigningScheme[];
 	signerCan: SigningScheme[];
 }): string {
-	const { accountName, signerIndex, signerAddress, accepted, signerCan } = params;
+	const { accountName, signerIndex, signerIdentity, accepted, signerCan } = params;
 	const canStr = signerCan.length > 0 ? signerCan.join(", ") : "none";
 	return (
-		`No compatible signing scheme for signer[${signerIndex}] ${signerAddress}. ` +
+		`No compatible signing scheme for signer[${signerIndex}] ${signerIdentity}. ` +
 		`${accountName} accepts: [${accepted.join(", ")}]; signer provides: [${canStr}]. ` +
 		(signerCan.length === 0
-			? "Signer must implement at least one of `signHash` or `signTypedData`. "
+			? "Signer must implement at least one of `signHash`, `signTypedData`, or `signWebauthn`. "
 			: "") +
-		"Hint: `fromViem` / `fromEthersWallet` give both; " +
-		"`fromViemWalletClient` gives only `typedData` (use Safe for JSON-RPC wallets)."
+		"Hint: `fromViem` / `fromEthersWallet` give both `hash` and `typedData`; " +
+		"`fromViemWalletClient` gives only `typedData` (use Safe for JSON-RPC wallets); " +
+		"`fromWebAuthn` gives `webauthn` (Safe and Calibur only)."
 	);
 }
 
 /**
- * Invoke a signer for one scheme. Keeps the dispatch in one place so the
- * account-side code stays linear. `typedData` is optional: accounts that
- * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
+ * Invoke a signer for a hash / typedData scheme. Keeps the dispatch in one
+ * place so the account-side code stays linear. `typedData` is optional:
+ * accounts that only accept the `"hash"` scheme (Simple7702, Calibur) pass
+ * just `hash`.
+ *
+ * For `"webauthn"`, use {@link invokeWebauthnSigner} — the return type
+ * differs (raw assertion vs. hex signature).
  *
  * `context` is always forwarded to the signer so power-user implementations
  * can inspect the userOp.
@@ -75,11 +91,17 @@ export async function invokeSigner<C>(
 		context: C;
 	},
 ): Promise<`0x${string}`> {
+	if (scheme === "webauthn") {
+		throw new AbstractionKitError(
+			"BAD_DATA",
+			"invokeSigner cannot dispatch the `webauthn` scheme; use invokeWebauthnSigner instead.",
+		);
+	}
 	if (scheme === "typedData") {
 		if (typeof signer.signTypedData !== "function") {
 			throw new AbstractionKitError(
 				"BAD_DATA",
-				`signer ${signer.address} is missing signTypedData`,
+				`signer ${signer.address ?? "(webauthn)"} is missing signTypedData`,
 			);
 		}
 		if (!payload.typedData) {
@@ -91,7 +113,29 @@ export async function invokeSigner<C>(
 		return signer.signTypedData(payload.typedData, payload.context);
 	}
 	if (typeof signer.signHash !== "function") {
-		throw new AbstractionKitError("BAD_DATA", `signer ${signer.address} is missing signHash`);
+		throw new AbstractionKitError(
+			"BAD_DATA",
+			`signer ${signer.address ?? "(webauthn)"} is missing signHash`,
+		);
 	}
 	return signer.signHash(payload.hash, payload.context);
+}
+
+/**
+ * Invoke a WebAuthn signer. Returns the raw {@link WebAuthnAssertion}; the
+ * calling account encodes it into its own on-chain format (Safe's verifier
+ * expects `abi.encode(bytes,bytes,uint256[2])`, Calibur's expects
+ * `abi.encode(bytes32 keyHash, bytes sig, bytes hookData)`).
+ */
+export async function invokeWebauthnSigner<C>(
+	signer: Signer<C>,
+	payload: { challenge: `0x${string}`; context: C },
+): Promise<WebAuthnAssertion> {
+	if (typeof signer.signWebauthn !== "function") {
+		throw new AbstractionKitError(
+			"BAD_DATA",
+			"signer is missing signWebauthn; construct it with `fromWebAuthn(...)`",
+		);
+	}
+	return signer.signWebauthn(payload.challenge, payload.context);
 }

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -20,7 +20,32 @@ export interface TypedData {
 }
 
 /** Signing schemes accounts may accept and signers may provide. */
-export type SigningScheme = "hash" | "typedData";
+export type SigningScheme = "hash" | "typedData" | "webauthn";
+
+/**
+ * P-256 public key coordinates for a WebAuthn credential. Used as the
+ * identity of a WebAuthn signer in place of an Ethereum address.
+ */
+export interface WebauthnPublicKeyCoordinates {
+	readonly x: bigint;
+	readonly y: bigint;
+}
+
+/**
+ * Raw output of a WebAuthn assertion, normalized so account-side code can
+ * encode it into whatever on-chain format the target account expects
+ * (Safe's `abi.encode(bytes,bytes,uint256[2])` vs Calibur's
+ * `abi.encode(bytes32,bytes,bytes)` wrapper). Keeps the adapter
+ * account-agnostic.
+ */
+export interface WebAuthnAssertion {
+	/** `authenticatorData` from the assertion response. */
+	readonly authenticatorData: Uint8Array;
+	/** Raw `clientDataJSON` string (already UTF-8 decoded). */
+	readonly clientDataJSON: string;
+	/** ECDSA over the P-256 curve, split into its r and s components. */
+	readonly signature: { readonly r: bigint; readonly s: bigint };
+}
 
 /**
  * Context the SDK passes to a signer on every account's
@@ -93,6 +118,19 @@ export type SignTypedDataFn<C = SignContext> = (
 ) => Promise<`0x${string}`>;
 
 /**
+ * Perform a WebAuthn assertion over a challenge derived from the signing
+ * hash. The adapter is account-agnostic: it returns a raw
+ * {@link WebAuthnAssertion}, and the account encodes it into its own
+ * on-chain format.
+ *
+ * Generic over context — see {@link SignHashFn}.
+ */
+export type SignWebauthnFn<C = SignContext> = (
+	challenge: `0x${string}`,
+	context: C,
+) => Promise<WebAuthnAssertion>;
+
+/**
  * A capability-oriented signer. Must declare at least one of `signHash` or
  * `signTypedData`; the account picks the best match at sign time. Declared
  * as a discriminated union so TypeScript rejects `{ address }` with neither
@@ -137,8 +175,26 @@ export type SignTypedDataFn<C = SignContext> = (
  * }
  * ```
  */
-export type Signer<C = SignContext> = SignerBase &
-	(
-		| { signHash: SignHashFn<C>; signTypedData?: SignTypedDataFn<C> }
-		| { signHash?: SignHashFn<C>; signTypedData: SignTypedDataFn<C> }
-	);
+export type Signer<C = SignContext> =
+	| (SignerBase & {
+			signHash: SignHashFn<C>;
+			signTypedData?: SignTypedDataFn<C>;
+			signWebauthn?: never;
+			pubkey?: never;
+	  })
+	| (SignerBase & {
+			signHash?: SignHashFn<C>;
+			signTypedData: SignTypedDataFn<C>;
+			signWebauthn?: never;
+			pubkey?: never;
+	  })
+	| {
+			/** WebAuthn credential P-256 public key (`{ x, y }`) — the on-chain
+			 * identity of this signer. Accounts derive the verifier address
+			 * from these coordinates; no EOA `address` is present. */
+			readonly pubkey: WebauthnPublicKeyCoordinates;
+			readonly address?: never;
+			signWebauthn: SignWebauthnFn<C>;
+			signHash?: never;
+			signTypedData?: never;
+	  };

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -433,7 +433,7 @@ describe('Calibur7702Account signUserOperationWithSigner', () => {
         };
         await expect(
             calibur.signUserOperationWithSigner(op, tdOnly, CHAIN_ID),
-        ).rejects.toThrow(/accepts: \[hash\]/);
+        ).rejects.toThrow(/accepts: \[hash,\s*webauthn\].*signer provides: \[typedData\]/);
     });
 });
 

--- a/test/signer/webauthn.test.js
+++ b/test/signer/webauthn.test.js
@@ -1,0 +1,356 @@
+// Unit tests for the fromWebAuthn adapter. All tests are offline and use
+// synthetic assertion fixtures — the adapter's job is to route data
+// through the correct encoding paths, not to produce cryptographically
+// valid signatures.
+//
+// Equivalence strategy: each test compares signUserOperationWithSigners
+// against the legacy manual-plumbing path (SafeAccount.createWebAuthnSignature
+// + formatSignaturesToUseroperationSignature), asserting byte-for-byte
+// equality.
+
+const ak = require('../../dist/index.cjs');
+const { AbiCoder } = require('ethers');
+
+const CHAIN_ID = 11155111n;
+
+// ─── Deterministic WebAuthn fixture ────────────────────────────────────
+
+// A real-looking (x, y) pair on the P-256 curve. These specific values
+// aren't on the curve — we don't verify signatures offline, we only check
+// encoding layout — but they sit within the 256-bit range so every
+// downstream encode() step treats them like valid coordinates.
+const FIXTURE_PUBKEY = {
+    x: 0x7a2fa39b3c61b3cbab8e44abeac8c9c7a4c1f76d42ae6f47b3b2a96d5c4f1a2bn,
+    y: 0x2e8c5f6d4b7a9c1e3f5a8d7b6c4e2f1a9d8c7b6a5e4f3d2c1b0a9f8e7d6c5b4an,
+};
+
+// 37-byte authenticatorData: rpIdHash (32) | flags (1) | signCount (4).
+const FIXTURE_AUTHENTICATOR_DATA_HEX =
+    '49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001';
+
+// clientDataJSON containing additional fields in non-Chromium order, to
+// exercise the regex-vs-JSON.parse regression. The adapter must handle
+// `crossOrigin` and `extra` wherever they appear without breaking.
+function buildClientDataJSON(challengeB64Url, opts = {}) {
+    const {
+        fieldOrder = ['type', 'challenge', 'origin', 'crossOrigin'],
+        extras = { origin: 'https://safe.global', crossOrigin: false },
+    } = opts;
+    const fields = {
+        type: 'webauthn.get',
+        challenge: challengeB64Url,
+        ...extras,
+    };
+    // Manually serialize in the requested key order so we can verify the
+    // adapter tolerates ordering differences.
+    const parts = fieldOrder.map((k) => `"${k}":${JSON.stringify(fields[k])}`);
+    return `{${parts.join(',')}}`;
+}
+
+function base64Url(bytes) {
+    return Buffer.from(bytes).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function hexToBytes(hex) {
+    const body = hex.startsWith('0x') ? hex.slice(2) : hex;
+    const out = new Uint8Array(body.length / 2);
+    for (let i = 0; i < out.length; i++) out[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+    return out;
+}
+
+// Build a signFn that returns a deterministic assertion for any challenge.
+// The r/s bigints are fixed; we don't verify them (Safe verification is
+// on-chain), we just check encoding.
+function makeStubSignFn(clientDataJSONBuilder) {
+    return async (challengeBytes) => {
+        const challengeB64 = base64Url(challengeBytes);
+        const clientDataJSON = clientDataJSONBuilder(challengeB64);
+        return {
+            authenticatorData: hexToBytes(FIXTURE_AUTHENTICATOR_DATA_HEX),
+            clientDataJSON, // string form — matches ox's output shape
+            signature: {
+                r: 0x3bc84a5d5196e81e867b935e6f7f3ec5bf8b0e5d3c2a1f9e8d7c6b5a4938271fn,
+                s: 0x12a3b4c5d6e7f80192a3b4c5d6e7f80192a3b4c5d6e7f80192a3b4c5d6e7f801n,
+            },
+        };
+    };
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
+
+function buildSafeV3Op(safe, { withFactory = true } = {}) {
+    return {
+        sender: safe.accountAddress,
+        nonce: 0n,
+        factory: withFactory ? safe.factoryAddress : null,
+        factoryData: withFactory ? safe.factoryData : null,
+        callData: '0x',
+        callGasLimit: 100000n,
+        verificationGasLimit: 500000n,
+        preVerificationGas: 60000n,
+        maxFeePerGas: 10000000n,
+        maxPriorityFeePerGas: 1000000n,
+        paymaster: null,
+        paymasterVerificationGasLimit: null,
+        paymasterPostOpGasLimit: null,
+        paymasterData: null,
+        signature: '0x',
+    };
+}
+
+// Reference manual plumbing: the 20-line block every Safe-passkeys
+// consumer currently rewrites. Mirrors abstractionkit-examples/passkeys
+// and safe-passkeys-react-example.
+function manualSafeWebauthnSignature(userOp, chainId, pubkey, assertion, isInit) {
+    const clientData = JSON.parse(assertion.clientDataJSON);
+    const { type: _t, challenge: _c, ...rest } = clientData;
+    const fields = Object.entries(rest)
+        .map(([k, v]) => `"${k}":${JSON.stringify(v)}`)
+        .join(',');
+    const webauthnSigData = {
+        authenticatorData: assertion.authenticatorData,
+        clientDataFields: '0x' + Buffer.from(fields, 'utf8').toString('hex'),
+        rs: [assertion.signature.r, assertion.signature.s],
+    };
+    const wSig = ak.SafeAccountV0_3_0.createWebAuthnSignature(webauthnSigData);
+    const pair = { signer: pubkey, signature: wSig, isContractSignature: true };
+    return ak.SafeAccountV0_3_0.formatSignaturesToUseroperationSignature([pair], { isInit });
+}
+
+// ─── Adapter shape ───────────────────────────────────────────────────────
+
+describe('fromWebAuthn adapter shape', () => {
+    test('returns a Signer with pubkey + signWebauthn, and NO address/signHash/signTypedData', () => {
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([1, 2, 3, 4])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: makeStubSignFn((c) => buildClientDataJSON(c)),
+        });
+        expect(signer.pubkey).toEqual(FIXTURE_PUBKEY);
+        expect(typeof signer.signWebauthn).toBe('function');
+        expect(signer.address).toBeUndefined();
+        expect(signer.signHash).toBeUndefined();
+        expect(signer.signTypedData).toBeUndefined();
+    });
+
+    test('rejects missing credentialId', () => {
+        expect(() =>
+            ak.fromWebAuthn({ credentialId: '', pubkey: FIXTURE_PUBKEY }),
+        ).toThrow(/credentialId.*required/);
+    });
+
+    test('rejects malformed pubkey', () => {
+        expect(() =>
+            ak.fromWebAuthn({ credentialId: 'abc', pubkey: { x: '1', y: '2' } }),
+        ).toThrow(/pubkey.*bigint/);
+    });
+});
+
+// ─── webauthnSignatureFromAssertion helper ──────────────────────────────
+
+describe('webauthnSignatureFromAssertion', () => {
+    test('accepts both ArrayBuffer and Uint8Array for authenticatorData', () => {
+        const u8 = hexToBytes(FIXTURE_AUTHENTICATOR_DATA_HEX);
+        const ab = u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+        const fromU8 = ak.webauthnSignatureFromAssertion({
+            authenticatorData: u8,
+            clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+            signature: { r: 1n, s: 2n },
+        });
+        const fromAB = ak.webauthnSignatureFromAssertion({
+            authenticatorData: ab,
+            clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+            signature: { r: 1n, s: 2n },
+        });
+        expect(Buffer.from(fromU8.authenticatorData).toString('hex')).toBe(
+            Buffer.from(fromAB.authenticatorData).toString('hex'),
+        );
+    });
+
+    test('accepts both string and buffer clientDataJSON', () => {
+        const str = '{"type":"webauthn.get","challenge":"AA"}';
+        const buf = Buffer.from(str, 'utf8');
+        const fromStr = ak.webauthnSignatureFromAssertion({
+            authenticatorData: new Uint8Array([1, 2]),
+            clientDataJSON: str,
+            signature: { r: 1n, s: 2n },
+        });
+        const fromBuf = ak.webauthnSignatureFromAssertion({
+            authenticatorData: new Uint8Array([1, 2]),
+            clientDataJSON: buf,
+            signature: { r: 1n, s: 2n },
+        });
+        expect(fromStr.clientDataJSON).toBe(fromBuf.clientDataJSON);
+    });
+});
+
+// ─── Safe equivalence ───────────────────────────────────────────────────
+
+describe('SafeAccountV0_3_0 signUserOperationWithSigners + fromWebAuthn', () => {
+    test('matches legacy manual plumbing byte-for-byte (isInit=true)', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        const stub = makeStubSignFn((c) => buildClientDataJSON(c));
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([9, 9, 9])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: stub,
+        });
+        const actual = await safe.signUserOperationWithSigners(op, [signer], CHAIN_ID);
+
+        // Compute the assertion the adapter will produce for the same
+        // challenge, then run the manual plumbing.
+        const hash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash(op, CHAIN_ID);
+        const assertion = ak.webauthnSignatureFromAssertion(await stub(hexToBytes(hash)));
+        const expected = manualSafeWebauthnSignature(op, CHAIN_ID, FIXTURE_PUBKEY, assertion, true);
+        expect(actual).toBe(expected);
+    });
+
+    test('matches legacy manual plumbing byte-for-byte (isInit=false, already-deployed)', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: false });
+        op.nonce = 5n;
+        const stub = makeStubSignFn((c) => buildClientDataJSON(c));
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([9])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: stub,
+        });
+        const actual = await safe.signUserOperationWithSigners(op, [signer], CHAIN_ID);
+
+        const hash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash(op, CHAIN_ID);
+        const assertion = ak.webauthnSignatureFromAssertion(await stub(hexToBytes(hash)));
+        const expected = manualSafeWebauthnSignature(op, CHAIN_ID, FIXTURE_PUBKEY, assertion, false);
+        expect(actual).toBe(expected);
+    });
+
+    test('clientDataJSON field reorder regression (Safari puts crossOrigin first)', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        // Safari-style ordering: `crossOrigin` between `type` and `challenge`.
+        const stub = makeStubSignFn((c) =>
+            buildClientDataJSON(c, {
+                fieldOrder: ['type', 'crossOrigin', 'origin', 'challenge'],
+            }),
+        );
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([5])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: stub,
+        });
+        const actual = await safe.signUserOperationWithSigners(op, [signer], CHAIN_ID);
+        const hash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash(op, CHAIN_ID);
+        const assertion = ak.webauthnSignatureFromAssertion(await stub(hexToBytes(hash)));
+        const expected = manualSafeWebauthnSignature(op, CHAIN_ID, FIXTURE_PUBKEY, assertion, true);
+        expect(actual).toBe(expected);
+    });
+
+    test('future authenticator field is preserved (forward compat)', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        const stub = makeStubSignFn((c) =>
+            buildClientDataJSON(c, {
+                fieldOrder: ['type', 'challenge', 'origin', 'crossOrigin', 'futureWebauthnL3Field'],
+                extras: {
+                    origin: 'https://safe.global',
+                    crossOrigin: false,
+                    futureWebauthnL3Field: 'some-value',
+                },
+            }),
+        );
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([6])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: stub,
+        });
+        const actual = await safe.signUserOperationWithSigners(op, [signer], CHAIN_ID);
+        const hash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash(op, CHAIN_ID);
+        const assertion = ak.webauthnSignatureFromAssertion(await stub(hexToBytes(hash)));
+        const expected = manualSafeWebauthnSignature(op, CHAIN_ID, FIXTURE_PUBKEY, assertion, true);
+        expect(actual).toBe(expected);
+    });
+});
+
+// ─── Simple7702 rejection (offline capability mismatch) ─────────────────
+
+describe('Simple7702Account rejects fromWebAuthn offline', () => {
+    test('signUserOperationWithSigner throws with actionable scheme-mismatch message', async () => {
+        const Simple7702 = ak.Simple7702AccountV08 || ak.Simple7702AccountV0_8 || ak.Simple7702AccountV09;
+        if (!Simple7702) {
+            // Older builds: skip silently, the capability-mismatch behavior
+            // is exercised via the signer.test.js rejection test.
+            return;
+        }
+        const eoa = '0xfD90FAd33ee8b58f32c00aceEad1358e4AFC23f9';
+        const simple = new Simple7702(eoa);
+        const op = {
+            sender: eoa, nonce: 0n, callData: '0x',
+            callGasLimit: 100000n, verificationGasLimit: 500000n,
+            preVerificationGas: 60000n, maxFeePerGas: 10000000n,
+            maxPriorityFeePerGas: 1000000n, signature: '0x',
+            factory: null, factoryData: null,
+            paymaster: null, paymasterVerificationGasLimit: null,
+            paymasterPostOpGasLimit: null, paymasterData: null,
+            eip7702Auth: null,
+        };
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([1])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: makeStubSignFn((c) => buildClientDataJSON(c)),
+        });
+        await expect(
+            simple.signUserOperationWithSigner(op, signer, CHAIN_ID),
+        ).rejects.toThrow(/accepts:\s*\[hash\].*signer provides:\s*\[webauthn\]/s);
+    });
+});
+
+// ─── Calibur webauthn encoding equivalence ──────────────────────────────
+
+describe('Calibur7702Account signUserOperationWithSigner + fromWebAuthn', () => {
+    test('produces a valid Calibur-shaped WebAuthn signature wrapper', async () => {
+        const eoa = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+        const calibur = new ak.Calibur7702Account(eoa);
+        const op = {
+            sender: eoa, nonce: 0n, callData: '0x',
+            callGasLimit: 100000n, verificationGasLimit: 500000n,
+            preVerificationGas: 60000n, maxFeePerGas: 10000000n,
+            maxPriorityFeePerGas: 1000000n, signature: '0x',
+            factory: null, factoryData: null,
+            paymaster: null, paymasterVerificationGasLimit: null,
+            paymasterPostOpGasLimit: null, paymasterData: null,
+            eip7702Auth: null,
+        };
+        const stub = makeStubSignFn((c) => buildClientDataJSON(c));
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([7, 7])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: stub,
+        });
+        const actual = await calibur.signUserOperationWithSigner(op, signer, CHAIN_ID);
+
+        // Decode the outer (bytes32, bytes, bytes) wrapper and check shape.
+        const abi = AbiCoder.defaultAbiCoder();
+        const [keyHash, innerEncoded, hookData] = abi.decode(
+            ['bytes32', 'bytes', 'bytes'],
+            actual,
+        );
+        expect(hookData).toBe('0x');
+        const expectedKeyHash = ak.Calibur7702Account.getKeyHash(
+            ak.Calibur7702Account.createWebAuthnP256Key(FIXTURE_PUBKEY.x, FIXTURE_PUBKEY.y),
+        );
+        expect(keyHash.toLowerCase()).toBe(expectedKeyHash.toLowerCase());
+
+        // Inner struct: (bytes, string, uint256, uint256, uint256, uint256)
+        const [inner] = abi.decode(
+            ['(bytes,string,uint256,uint256,uint256,uint256)'],
+            innerEncoded,
+        );
+        const [authData, cdjson, challengeIdx, typeIdx, r, s] = inner;
+        expect(authData.toLowerCase()).toBe('0x' + FIXTURE_AUTHENTICATOR_DATA_HEX);
+        expect(cdjson).toMatch(/"type":"webauthn.get"/);
+        expect(Number(typeIdx)).toBe(cdjson.indexOf('"type":"webauthn.get"'));
+        expect(Number(challengeIdx)).toBe(cdjson.indexOf('"challenge":"'));
+        expect(r).toBe(0x3bc84a5d5196e81e867b935e6f7f3ec5bf8b0e5d3c2a1f9e8d7c6b5a4938271fn);
+        expect(s).toBe(0x12a3b4c5d6e7f80192a3b4c5d6e7f80192a3b4c5d6e7f80192a3b4c5d6e7f801n);
+    });
+});

--- a/test/signer/webauthn.test.js
+++ b/test/signer/webauthn.test.js
@@ -226,9 +226,27 @@ describe('pickScheme rejects webauthn-like signers missing a valid pubkey', () =
         };
         // pickScheme requires bigint x/y — fromWebAuthn coerces, but
         // raw handcrafted signers must pass bigints directly.
+        // describeSignerIdentity must fall back to "(unknown signer)"
+        // instead of throwing TypeError on the malformed pubkey.
         await expect(
             safe.signUserOperationWithSigners(op, [badSigner], CHAIN_ID),
-        ).rejects.toThrow(/No compatible signing scheme/);
+        ).rejects.toThrow(/No compatible signing scheme.*\(unknown signer\)/s);
+    });
+});
+
+describe('ECDSA branch: missing signer.address fails fast with BAD_DATA', () => {
+    test('handcrafted { signHash, no address } signing a Safe op throws actionable error', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount(['0x' + '11'.repeat(20)]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        const hashOnly = {
+            // signHash-capable but no address — pickScheme advertises
+            // "hash" (the check is purely function-shape); the SafeAccount
+            // ECDSA branch then demands an address and rejects.
+            signHash: async () => '0x' + '11'.repeat(65),
+        };
+        await expect(
+            safe.signUserOperationWithSigners(op, [hashOnly], CHAIN_ID),
+        ).rejects.toThrow(/has no `address`.*fromPrivateKey|fromViem|fromEthersWallet/s);
     });
 });
 

--- a/test/signer/webauthn.test.js
+++ b/test/signer/webauthn.test.js
@@ -304,6 +304,128 @@ describe('Simple7702Account rejects fromWebAuthn offline', () => {
     });
 });
 
+// ─── Regression: sortSignatures honors isInit for WebAuthn signers ─────
+// At isInit=true, a WebAuthn signer's on-chain signer field is the shared
+// signer address (0xfD90…), not its deterministic verifier. sortSignatures
+// must use the shared-signer address as its sort key, otherwise a mixed
+// WebAuthn + ECDSA packed signature can land out-of-order and Safe's
+// checkNSignatures reverts with GS026. Pre-fix, this triggered for roughly
+// half of random (passkey, EOA) pairs.
+describe('sortSignatures honors isInit for WebAuthn signers (GS026 regression)', () => {
+    // Specific (passkey, EOA) pair that demonstrated the bug: the passkey's
+    // deterministic verifier sorts BELOW the EOA, but the shared signer
+    // sorts ABOVE the EOA, so the sort key and the on-chain-packed address
+    // disagreed and produced a descending packed order at isInit=true.
+    const BUG_PASSKEY = {
+        x: 0x31498e606f771994a4d9b902dd812fbc0acc1cf4e34d688928293e1edc3fcc0en,
+        y: 0xf7946c434b3f968370d88e8cce861a1958aeeb21d04aee6a16b940e28a8dd7c6n,
+    };
+    const BUG_EOA = '0xC12598e6EF806335ca800A508C343A84e49Ceb4D';
+
+    // Read each 65-byte entry's v byte + signer-word from a packed Safe
+    // signature. ECDSA entries encode (r,s,v); only v is meaningful here
+    // (the signer is recovered on-chain). Contract-sig entries encode
+    // (signer,offset,v=0) with the signer in the first 32-byte word.
+    function readEntries(packed, n) {
+        const body = packed.slice(2);
+        const entries = [];
+        for (let i = 0; i < n; i++) {
+            const entry = body.slice(i * 130, (i + 1) * 130);
+            const v = parseInt(entry.slice(128, 130), 16);
+            if (v === 0) {
+                entries.push({
+                    kind: 'contract',
+                    signer: '0x' + entry.slice(24, 64).toLowerCase(),
+                });
+            } else {
+                entries.push({ kind: 'ecdsa', v });
+            }
+        }
+        return entries;
+    }
+
+    test('at isInit=true: contract-sig entry uses shared signer AND EOA sorts before it', () => {
+        // The bug would produce [contract(SHARED), ECDSA] here because
+        // the sort key (pre-fix) was the deterministic verifier
+        // (0xbdab… < EOA) while the packed signer for the contract-sig
+        // entry is SHARED (0xfd90… > EOA). Post-fix, the sort key is
+        // SHARED for WebAuthn at isInit=true, so EOA (0xc125…) sorts
+        // first, then the shared-signer contract entry.
+        const webauthnBlob = ak.SafeAccountV0_3_0.createWebAuthnSignature({
+            authenticatorData: new Uint8Array(37),
+            clientDataFields: '0x7b7d',
+            rs: [1n, 2n],
+        });
+        const pairs = [
+            { signer: BUG_PASSKEY, signature: webauthnBlob, isContractSignature: true },
+            { signer: BUG_EOA, signature: '0x' + '11'.repeat(32) + '22'.repeat(32) + '1c' },
+        ];
+        const packed = ak.SafeAccountV0_3_0.buildSignaturesFromSingerSignaturePairs(pairs, {
+            isInit: true,
+        });
+        const [entry0, entry1] = readEntries(packed, 2);
+
+        const SHARED = ak.SafeAccountV0_3_0.DEFAULT_WEB_AUTHN_SHARED_SIGNER.toLowerCase();
+        // EOA (0xc125…) < SHARED (0xfd90…), so ECDSA entry comes first,
+        // contract-sig entry with the shared signer comes second.
+        expect(entry0.kind).toBe('ecdsa');
+        expect(entry1.kind).toBe('contract');
+        expect(entry1.signer).toBe(SHARED);
+        // The EOA address is below the shared signer → invariant holds:
+        expect(BUG_EOA.toLowerCase() < SHARED).toBe(true);
+    });
+
+    test('at isInit=false: contract-sig entry uses deterministic verifier, passkey sorts first', () => {
+        const webauthnBlob = ak.SafeAccountV0_3_0.createWebAuthnSignature({
+            authenticatorData: new Uint8Array(37),
+            clientDataFields: '0x7b7d',
+            rs: [1n, 2n],
+        });
+        const pairs = [
+            { signer: BUG_PASSKEY, signature: webauthnBlob, isContractSignature: true },
+            { signer: BUG_EOA, signature: '0x' + '11'.repeat(32) + '22'.repeat(32) + '1c' },
+        ];
+        const packed = ak.SafeAccountV0_3_0.buildSignaturesFromSingerSignaturePairs(pairs, {
+            isInit: false,
+        });
+        const [entry0, entry1] = readEntries(packed, 2);
+
+        const DETERMINISTIC = ak.SafeAccountV0_3_0.createWebAuthnSignerVerifierAddress(
+            BUG_PASSKEY.x,
+            BUG_PASSKEY.y,
+        ).toLowerCase();
+        // For this specific pair, deterministic (0xbdab…) < EOA (0xc125…),
+        // so the passkey contract-sig entry sorts first.
+        expect(entry0.kind).toBe('contract');
+        expect(entry0.signer).toBe(DETERMINISTIC);
+        expect(entry1.kind).toBe('ecdsa');
+        expect(DETERMINISTIC < BUG_EOA.toLowerCase()).toBe(true);
+    });
+
+    test('getSignerLowerCaseAddress returns shared signer for WebAuthn at isInit=true', () => {
+        const SHARED = ak.SafeAccountV0_3_0.DEFAULT_WEB_AUTHN_SHARED_SIGNER.toLowerCase();
+        expect(
+            ak.SafeAccountV0_3_0.getSignerLowerCaseAddress(BUG_PASSKEY, { isInit: true }),
+        ).toBe(SHARED);
+    });
+
+    test('getSignerLowerCaseAddress returns deterministic verifier for WebAuthn at isInit=false', () => {
+        const DETERMINISTIC = ak.SafeAccountV0_3_0.createWebAuthnSignerVerifierAddress(
+            BUG_PASSKEY.x,
+            BUG_PASSKEY.y,
+        ).toLowerCase();
+        expect(
+            ak.SafeAccountV0_3_0.getSignerLowerCaseAddress(BUG_PASSKEY, { isInit: false }),
+        ).toBe(DETERMINISTIC);
+        // Default (undefined isInit) also returns deterministic — preserves
+        // backward compatibility for any external caller that wasn't
+        // passing isInit before the fix.
+        expect(ak.SafeAccountV0_3_0.getSignerLowerCaseAddress(BUG_PASSKEY, {})).toBe(
+            DETERMINISTIC,
+        );
+    });
+});
+
 // ─── Calibur webauthn encoding equivalence ──────────────────────────────
 
 describe('Calibur7702Account signUserOperationWithSigner + fromWebAuthn', () => {

--- a/test/signer/webauthn.test.js
+++ b/test/signer/webauthn.test.js
@@ -234,6 +234,52 @@ describe('pickScheme rejects webauthn-like signers missing a valid pubkey', () =
     });
 });
 
+describe('extractClientDataFieldsHex rejects malformed clientDataJSON', () => {
+    // This helper is called during Safe WebAuthn signing — invalid
+    // clientDataJSON must fail with a clear AbstractionKitError("BAD_DATA")
+    // instead of a raw TypeError or a silently-wrong output.
+    const SafeAccount = ak.SafeAccountV0_3_0;
+
+    async function signWithClientData(clientDataJSON) {
+        const safe = SafeAccount.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        const signer = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([1])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: async () => ({
+                authenticatorData: hexToBytes(FIXTURE_AUTHENTICATOR_DATA_HEX),
+                clientDataJSON, // arbitrary malformed value
+                signature: { r: 1n, s: 2n },
+            }),
+        });
+        return safe.signUserOperationWithSigners(op, [signer], CHAIN_ID);
+    }
+
+    test('syntactically invalid JSON throws BAD_DATA (not raw SyntaxError)', async () => {
+        await expect(signWithClientData('{not valid json')).rejects.toThrow(
+            /Safe WebAuthn: clientDataJSON is not valid JSON/,
+        );
+    });
+
+    test('clientDataJSON that parses to null is rejected', async () => {
+        await expect(signWithClientData('null')).rejects.toThrow(
+            /Safe WebAuthn: clientDataJSON must parse to a plain object.*null/,
+        );
+    });
+
+    test('clientDataJSON that parses to array is rejected', async () => {
+        await expect(signWithClientData('[1,2,3]')).rejects.toThrow(
+            /Safe WebAuthn: clientDataJSON must parse to a plain object.*array/,
+        );
+    });
+
+    test('clientDataJSON that parses to primitive is rejected', async () => {
+        await expect(signWithClientData('"foo"')).rejects.toThrow(
+            /Safe WebAuthn: clientDataJSON must parse to a plain object.*string/,
+        );
+    });
+});
+
 describe('ECDSA branch: missing signer.address fails fast with BAD_DATA', () => {
     test('handcrafted { signHash, no address } signing a Safe op throws actionable error', async () => {
         const safe = ak.SafeAccountV0_3_0.initializeNewAccount(['0x' + '11'.repeat(20)]);

--- a/test/signer/webauthn.test.js
+++ b/test/signer/webauthn.test.js
@@ -191,6 +191,95 @@ describe('fromWebAuthn adapter shape', () => {
     });
 });
 
+// ─── Defensive guards: malformed signers bypass the type system ─────────
+// These tests exercise paths where a caller hand-rolls a signer and
+// skips `fromWebAuthn`'s constructor validation. The library must
+// reject with a clear error rather than a later opaque failure.
+
+describe('pickScheme rejects webauthn-like signers missing a valid pubkey', () => {
+    test('handcrafted { signWebauthn, no pubkey } is not advertised as webauthn-capable', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        const badSigner = {
+            signWebauthn: async () => ({
+                authenticatorData: new Uint8Array(37),
+                clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+                signature: { r: 1n, s: 2n },
+            }),
+            // no pubkey
+        };
+        await expect(
+            safe.signUserOperationWithSigners(op, [badSigner], CHAIN_ID),
+        ).rejects.toThrow(/No compatible signing scheme.*provides.*none/s);
+    });
+
+    test('handcrafted { signWebauthn, pubkey: { x: "hex", y: "hex" } } is not advertised (pubkey must be bigint at pickScheme level)', async () => {
+        const safe = ak.SafeAccountV0_3_0.initializeNewAccount([FIXTURE_PUBKEY]);
+        const op = buildSafeV3Op(safe, { withFactory: true });
+        const badSigner = {
+            signWebauthn: async () => ({
+                authenticatorData: new Uint8Array(37),
+                clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+                signature: { r: 1n, s: 2n },
+            }),
+            pubkey: { x: '0x1', y: '0x2' }, // strings, not bigints
+        };
+        // pickScheme requires bigint x/y — fromWebAuthn coerces, but
+        // raw handcrafted signers must pass bigints directly.
+        await expect(
+            safe.signUserOperationWithSigners(op, [badSigner], CHAIN_ID),
+        ).rejects.toThrow(/No compatible signing scheme/);
+    });
+});
+
+describe('parseDerP256Signature rejects truncated/malformed DER', () => {
+    test('truncated DER throws, does not silently produce bogus r/s', () => {
+        // Valid DER prefix, but rLen claims 200 bytes when only ~6 remain
+        const truncated = new Uint8Array([
+            0x30, 0x46, // SEQUENCE, 70 bytes (but we'll give fewer)
+            0x02, 0xc8, // INTEGER, length 200 (impossibly large)
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, // only 6 bytes of r follow
+        ]);
+        expect(() =>
+            ak.webauthnSignatureFromAssertion({
+                authenticatorData: new Uint8Array(37),
+                clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+                signature: truncated,
+            }),
+        ).toThrow(/malformed DER signature/);
+    });
+
+    test('zero-length r or s throws', () => {
+        const zeroR = new Uint8Array([
+            0x30, 0x06,
+            0x02, 0x00, // INTEGER, length 0 (invalid for r)
+            0x02, 0x02, 0x11, 0x22, // valid s
+        ]);
+        expect(() =>
+            ak.webauthnSignatureFromAssertion({
+                authenticatorData: new Uint8Array(37),
+                clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+                signature: zeroR,
+            }),
+        ).toThrow(/malformed DER signature/);
+    });
+
+    test('wrong tag byte throws', () => {
+        const wrongTag = new Uint8Array([
+            0x30, 0x08,
+            0x03, 0x02, 0x11, 0x22, // OCTET STRING tag, not INTEGER
+            0x02, 0x02, 0x33, 0x44,
+        ]);
+        expect(() =>
+            ak.webauthnSignatureFromAssertion({
+                authenticatorData: new Uint8Array(37),
+                clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+                signature: wrongTag,
+            }),
+        ).toThrow(/malformed DER signature/);
+    });
+});
+
 describe('pubkeyCoordinatesToJson / pubkeyCoordinatesFromJson', () => {
     test('round-trips a WebAuthn pubkey bit-for-bit', () => {
         const json = ak.pubkeyCoordinatesToJson(FIXTURE_PUBKEY);

--- a/test/signer/webauthn.test.js
+++ b/test/signer/webauthn.test.js
@@ -139,10 +139,110 @@ describe('fromWebAuthn adapter shape', () => {
         ).toThrow(/credentialId.*required/);
     });
 
-    test('rejects malformed pubkey', () => {
+    test('accepts bigint, hex-string, and decimal-string pubkey coords', () => {
+        // Bigint baseline
+        const asBigint = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([1])),
+            pubkey: FIXTURE_PUBKEY,
+            signFn: makeStubSignFn((c) => buildClientDataJSON(c)),
+        });
+        expect(asBigint.pubkey).toEqual(FIXTURE_PUBKEY);
+
+        // Hex strings (common after localStorage round-trip with a
+        // bigint-to-hex replacer)
+        const asHex = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([1])),
+            pubkey: {
+                x: '0x' + FIXTURE_PUBKEY.x.toString(16),
+                y: '0x' + FIXTURE_PUBKEY.y.toString(16),
+            },
+            signFn: makeStubSignFn((c) => buildClientDataJSON(c)),
+        });
+        expect(asHex.pubkey).toEqual(FIXTURE_PUBKEY);
+
+        // Decimal strings
+        const asDecimal = ak.fromWebAuthn({
+            credentialId: base64Url(new Uint8Array([1])),
+            pubkey: {
+                x: FIXTURE_PUBKEY.x.toString(10),
+                y: FIXTURE_PUBKEY.y.toString(10),
+            },
+            signFn: makeStubSignFn((c) => buildClientDataJSON(c)),
+        });
+        expect(asDecimal.pubkey).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('rejects pubkey with missing or invalid coords', () => {
         expect(() =>
-            ak.fromWebAuthn({ credentialId: 'abc', pubkey: { x: '1', y: '2' } }),
-        ).toThrow(/pubkey.*bigint/);
+            ak.fromWebAuthn({ credentialId: 'abc', pubkey: { x: undefined, y: 1n } }),
+        ).toThrow(/pubkey.*x, y.*both/);
+        expect(() =>
+            ak.fromWebAuthn({
+                credentialId: 'abc',
+                pubkey: { x: 'not-a-bigint', y: 1n },
+            }),
+        ).toThrow(/not a valid bigint/);
+        expect(() =>
+            ak.fromWebAuthn({
+                credentialId: 'abc',
+                pubkey: { x: true, y: 1n },
+            }),
+        ).toThrow(/bigint, string, or number/);
+    });
+});
+
+describe('pubkeyCoordinatesToJson / pubkeyCoordinatesFromJson', () => {
+    test('round-trips a WebAuthn pubkey bit-for-bit', () => {
+        const json = ak.pubkeyCoordinatesToJson(FIXTURE_PUBKEY);
+        const parsed = ak.pubkeyCoordinatesFromJson(json);
+        expect(parsed).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('serializes to hex-string form (backward-compat with existing localStorage replacers)', () => {
+        const json = ak.pubkeyCoordinatesToJson(FIXTURE_PUBKEY);
+        const obj = JSON.parse(json);
+        expect(obj.x.startsWith('0x')).toBe(true);
+        expect(obj.y.startsWith('0x')).toBe(true);
+        expect(BigInt(obj.x)).toBe(FIXTURE_PUBKEY.x);
+        expect(BigInt(obj.y)).toBe(FIXTURE_PUBKEY.y);
+    });
+
+    test('fromJson accepts pre-parsed object too (skip JSON.parse)', () => {
+        const obj = { x: '0x' + FIXTURE_PUBKEY.x.toString(16), y: '0x' + FIXTURE_PUBKEY.y.toString(16) };
+        expect(ak.pubkeyCoordinatesFromJson(obj)).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('fromJson accepts decimal strings too', () => {
+        const json = JSON.stringify({
+            x: FIXTURE_PUBKEY.x.toString(10),
+            y: FIXTURE_PUBKEY.y.toString(10),
+        });
+        expect(ak.pubkeyCoordinatesFromJson(json)).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('fromJson throws on malformed input', () => {
+        expect(() => ak.pubkeyCoordinatesFromJson('{"x":"not-hex","y":"0x1"}')).toThrow(
+            /not a valid bigint/,
+        );
+        expect(() => ak.pubkeyCoordinatesFromJson('{"x":"0x1"}')).toThrow(/x, y.*both/);
+    });
+});
+
+describe('toBigintPubkey direct usage', () => {
+    test('is idempotent on bigint input', () => {
+        expect(ak.toBigintPubkey(FIXTURE_PUBKEY)).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('coerces number input for small coords', () => {
+        const coerced = ak.toBigintPubkey({ x: 42, y: 7 });
+        expect(coerced.x).toBe(42n);
+        expect(coerced.y).toBe(7n);
+    });
+
+    test('rejects unsafe-integer numbers to prevent precision loss', () => {
+        expect(() =>
+            ak.toBigintPubkey({ x: Number.MAX_SAFE_INTEGER + 1, y: 1n }),
+        ).toThrow(/safe integer/);
     });
 });
 


### PR DESCRIPTION
## Summary

Ship a first-class WebAuthn adapter that plugs into the capability-oriented `ExternalSigner` API (shipped in 0.3.2), so passkey signers flow through `signUserOperationWithSigners` / `signUserOperationWithSigner` the same way `fromPrivateKey` / `fromViem` / `fromEthersWallet` already do. Closes #123.

Also bundles two incidental fixes surfaced during live verification: a pre-existing `sortSignatures` bug that broke the docs-recommended 2-of-2 init flow about a quarter of the time, and a browser-compat fix for two helpers that used Node's `Buffer`.

## Public API additions

- `fromWebAuthn(opts)` — account-agnostic WebAuthn signer. Returns a raw `WebAuthnAssertion` via `signWebauthn`; each account encodes it into its own on-chain format (Safe vs Calibur). Defaults to `navigator.credentials.get()`; inject `signFn` for Node / server-side / external-custody flows (Turnkey, Privy, `@simplewebauthn`, `ox/WebAuthnP256`, mobile bridges).
- `webauthnSignatureFromAssertion(response)` — low-level normalizer. `ArrayBuffer | Uint8Array | string` for `clientDataJSON`; `ArrayBuffer | Uint8Array | { r, s }` for the signature (with DER parse + low-S normalization). Exposed so server-side ceremonies don't have to use the full adapter.
- `pubkeyCoordinatesToJson` / `pubkeyCoordinatesFromJson` — canonical bigint-safe JSON round-trip for `{ x, y }`. Eliminates the \"every consumer writes the same `JSON.stringify` replacer\" pain point from issue #123.
- `toBigintPubkey` — coerces `{ x, y }` where coords are any of `bigint | string (hex or decimal) | safe-integer number` to the canonical `{ x: bigint, y: bigint }`. `fromWebAuthn` uses it internally, so stored passkeys that round-tripped through JSON as strings now work without manual rehydration.
- New `\"webauthn\"` scheme on `SigningScheme`. `ACCEPTED_SIGNING_SCHEMES` widens to `[\"typedData\", \"hash\", \"webauthn\"]` on Safe and `[\"hash\", \"webauthn\"]` on Calibur. Simple7702 stays `[\"hash\"]` — passing `fromWebAuthn` to it fails offline with an actionable `pickScheme` error.

`WebauthnSignatureData.authenticatorData` widens from `ArrayBuffer` to `ArrayBuffer | Uint8Array`. `clientDataJSON` parsing uses `JSON.parse` + destructure (no regex) so Safari's `crossOrigin` and future WebAuthn L3 fields don't break signing.

## Drive-by: `sortSignatures` GS026 fix

`SafeAccount.getSignerLowerCaseAddress` returned the per-owner deterministic verifier for `WebauthnPublicKey` signers regardless of `isInit`, but `buildSignaturesFromSingerSignaturePairs` packs the shared-signer address at `isInit=true`. The sort key and the pack key could land on opposite sides of an EOA address, producing a descending packed signature. Safe's `checkNSignatures` then reverts with `GS026 signatures not sorted`, which the bundler surfaces as `Invalid UserOp signature`.

Reproducer for random `(passkey, EOA)` pairs showed the bug affects ~25-30% of random pairs for any given passkey, so in practice it manifests intermittently. The docs-recommended `SafeAccount.initializeNewAccount([webauthPublicKey, eoaPublicKey], { threshold: 2 })` hit it.

Fix: `getSignerLowerCaseAddress` now reads `overrides.isInit` and mirrors whatever `buildSignaturesFromSingerSignaturePairs` will emit. Default `undefined` preserves old behavior — fully backward-compatible.

## Out of scope (deferred)

Per issue #123 and a design discussion during verification:
- `createPasskeyCredential` (registration helper). The ceremony is genuinely environment-specific — browser / iOS / Android / external-custody providers / backend-issued all have different shapes. A `navigator.credentials.create`-based helper would be actively wrong for 4 of 5 paths. The adapter's `{ credentialId, pubkey }` input already accepts whatever each environment produces. Recipe addition to CLAUDE.md is a cleaner way to document the browser case.
- `userHandle` pubkey packing, `signMessage` / EIP-1271 for passkeys, shared-signer→deterministic-verifier migration helper — all tracked separately.

## Tests

- 24 new offline cases in `test/signer/webauthn.test.js`: adapter shape, pubkey coercion (bigint / hex / decimal / number), `{To,From}Json` round-trips, Safe equivalence against legacy manual plumbing (`isInit=true` and `isInit=false`), `clientDataJSON` reorder + future-field regression, Simple7702 offline rejection, Calibur wrapper encoding, GS026 sort-order regression with the exact `(passkey, EOA)` pair from the live repro.
- Full signer suite: 155/155 pass. No regressions.
- Calibur unit + encoding: 78/78 pass.

## Live verification (Arbitrum Sepolia + Sepolia)

| Flow | Tx |
|---|---|
| Single passkey, fresh Safe | [0xf31a0ef2](https://sepolia.arbiscan.io/tx/0xf31a0ef276b4d27b1a2be84bba6448cd1528d973e015102c73b472babd807a54) |
| Passkey + EOA 2-of-2 (mixed scheme branch) | [0x81c79bd3](https://sepolia.arbiscan.io/tx/0x81c79bd3480d68602ca8c2479a0ed5504513329c6b26735eed254d95f3d094dd) |
| Post-init passkey signing via deterministic verifier | [0x0cfdcd70](https://sepolia.arbiscan.io/tx/0x0cfdcd70e3bb1467f7dc88f87f64b50f9746594b2dbf6c87c8587017600494a7) |
| 2-of-2 init with GS026-triggering passkey+EOA pair (fix verified) | [0xd3888116](https://sepolia.arbiscan.io/tx/0xd388811619c0b33dec73bde0079c628be3da349c5bc835569eb4dcf8a61c173f) |
| Calibur: register passkey + mint via fromWebAuthn (public v3 paymaster) | [0xef9be6a5](https://sepolia.etherscan.io/tx/0xef9be6a54dcfe0835d899e1d9f4e9254d524b3ba2bffd8d65d6a66858a7516c4) |

## Breaking changes

None at runtime. Type-level:
- `SigningScheme` union gains `\"webauthn\"` (additive).
- `Signer` union gains a third variant with `pubkey` / `signWebauthn` and no `address`. Consumers reading `signer.address` without narrowing get a TS error, no runtime impact.
- `WebauthnSignatureData.authenticatorData` widens to `ArrayBuffer | Uint8Array`. Input widening — backward-compatible.

Safe for a minor version bump.

## Companion demo

The `safe-passkeys-react-example` migration is in [candidelabs/safe-passkeys-react-example](https://github.com/candidelabs/safe-passkeys-react-example/pull/7/changes) (draft until this lands + is released).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebAuthn signing support across accounts, multi-operation flows, and the public API, plus helpers to create, serialize and normalize WebAuthn credentials, assertions, and pubkey coordinates.
  * Safe integration: WebAuthn assertions encoded into Safe-compatible signatures with init-aware signer addressing.

* **Bug Fixes / Behavior**
  * Scheme negotiation and dispatch updated to recognize, validate and route WebAuthn-capable signers; improved mismatch/error messaging.

* **Tests**
  * Extensive offline tests covering adapters, formats, compatibility, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->