### PR TITLE
feat(safe): add SafeAccount.isDeployed helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ const newAccount = SafeAccountV0_3_0.initializeNewAccount(["0xOwnerAddress"]);
 // First UserOp will deploy it automatically
 ```
 
+When you have a stored Safe address and need to pick between the two paths at runtime, use `isDeployed` to avoid emitting redundant factory data (and the `AA10 sender already constructed` error) on subsequent UserOps:
+
+```typescript
+import { SafeAccountV0_3_0 } from "abstractionkit";
+
+const smartAccount = (await SafeAccountV0_3_0.isDeployed(safeAddress, nodeRpc))
+  ? new SafeAccountV0_3_0(safeAddress)
+  : SafeAccountV0_3_0.initializeNewAccount(owners);
+```
+
+`isDeployed` only checks for bytecode at the address. It does not verify that the deployed code is a Safe or that its on-chain owners match a given set. If your owners may have changed, compare `createAccountAddress(owners)` against the stored address yourself before calling `initializeNewAccount`.
+
 ### Calibur 7702: delegate an EOA and send a transfer
 
 `Calibur7702Account` is Uniswap's EIP-7702 smart account. It upgrades a regular EOA in place so the same address becomes a programmable smart account on EntryPoint v0.8.

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -230,6 +230,38 @@ export class SafeAccount extends SmartAccount {
 	}
 
 	/**
+	 * Check whether a Safe account is already deployed at the given address.
+	 *
+	 * Use this to decide between connecting to an existing account
+	 * (`new SafeAccountV0_3_0(address)`) and initializing a new one
+	 * (`SafeAccountV0_3_0.initializeNewAccount(owners)`). Once an account is
+	 * deployed, the factory data carried by `initializeNewAccount` is no
+	 * longer needed and including it would waste gas.
+	 *
+	 * Note: this only checks whether bytecode exists at `accountAddress`, not
+	 * whether the deployed code is actually a Safe or whether its on-chain
+	 * configuration matches a given set of owners.
+	 *
+	 * @param accountAddress - the Safe account address to check
+	 * @param nodeRpcUrl - Ethereum JSON-RPC node URL
+	 * @returns `true` if bytecode is deployed at `accountAddress`, `false` otherwise
+	 *
+	 * @example
+	 * ```ts
+	 * const account = (await SafeAccountV0_3_0.isDeployed(addr, rpc))
+	 *   ? new SafeAccountV0_3_0(addr)
+	 *   : SafeAccountV0_3_0.initializeNewAccount(owners);
+	 * ```
+	 */
+	public static async isDeployed(
+		accountAddress: string,
+		nodeRpcUrl: string,
+	): Promise<boolean> {
+		const code = await sendEthGetCodeRequest(nodeRpcUrl, accountAddress, "latest");
+		return code.length > 2;
+	}
+
+	/**
 	 * encode calldata for a single MetaTransaction to be executed by Safe account
 	 * @param metaTransaction - metaTransaction to create calldata for
 	 * @param overrides - overrides for the default values

--- a/test/safe/isDeployed.test.js
+++ b/test/safe/isDeployed.test.js
@@ -1,0 +1,58 @@
+const { SafeAccountV0_3_0, SafeAccountV0_2_0 } = require('../../dist/index.cjs');
+
+describe('SafeAccount.isDeployed', () => {
+    const fakeRpc = 'https://rpc.example.invalid';
+    const address = '0x1111111111111111111111111111111111111111';
+
+    let originalFetch;
+    let lastRequest;
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        lastRequest = null;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    function mockFetchReturning(code) {
+        global.fetch = async (url, options) => {
+            lastRequest = { url, body: JSON.parse(options.body) };
+            return {
+                json: async () => ({ jsonrpc: '2.0', id: 1, result: code }),
+            };
+        };
+    }
+
+    test('returns true when bytecode is deployed (V0_3_0)', async () => {
+        mockFetchReturning('0x6080604052' + 'aa'.repeat(40));
+        const result = await SafeAccountV0_3_0.isDeployed(address, fakeRpc);
+        expect(result).toBe(true);
+        expect(lastRequest.body.method).toBe('eth_getCode');
+        expect(lastRequest.body.params).toEqual([address, 'latest']);
+    });
+
+    test('returns false when no bytecode is present (V0_3_0)', async () => {
+        mockFetchReturning('0x');
+        const result = await SafeAccountV0_3_0.isDeployed(address, fakeRpc);
+        expect(result).toBe(false);
+    });
+
+    test('inherits onto V0_2_0 with same behavior', async () => {
+        mockFetchReturning('0x');
+        expect(await SafeAccountV0_2_0.isDeployed(address, fakeRpc)).toBe(false);
+
+        mockFetchReturning('0xdeadbeef');
+        expect(await SafeAccountV0_2_0.isDeployed(address, fakeRpc)).toBe(true);
+    });
+
+    test('treats EIP-7702 delegation prefix as deployed', async () => {
+        // 0xef0100 + 20-byte delegatee. Not a Safe, but bytecode is present
+        // so isDeployed must return true. Callers that need to distinguish
+        // delegation from a real Safe must do that check separately.
+        mockFetchReturning('0xef0100' + '11'.repeat(20));
+        const result = await SafeAccountV0_3_0.isDeployed(address, fakeRpc);
+        expect(result).toBe(true);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to check if a Safe account is already deployed on-chain, enabling users to determine whether to connect to an existing account or initialize a new one.

* **Documentation**
  * Updated guide with instructions for connecting to an existing deployed account, including validation best practices and ownership verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->