### PR TITLE
feat(signer): WebAuthn pubkey JSON helpers + assertion normalizer

### DIFF
--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -109,7 +109,12 @@ export type {
 	FromSafeWebauthnParams,
 	WebauthnAssertionFetcher,
 } from "./account/Safe/adapters";
-export { fromSafeWebauthn } from "./account/Safe/adapters";
+export {
+	fromSafeWebauthn,
+	pubkeyCoordinatesFromJson,
+	pubkeyCoordinatesToJson,
+	webauthnSignatureFromAssertion,
+} from "./account/Safe/adapters";
 export {
 	fromEthersWallet,
 	fromPrivateKey,

--- a/src/account/Safe/adapters.ts
+++ b/src/account/Safe/adapters.ts
@@ -1,4 +1,4 @@
-import { getBytes } from "ethers";
+import { getBytes, hexlify } from "ethers";
 import type { Signer } from "src/signer/types";
 import { SafeAccount } from "./SafeAccount";
 import type { WebauthnPublicKey, WebauthnSignatureData } from "./types";
@@ -153,4 +153,305 @@ export function fromSafeWebauthn(params: FromSafeWebauthnParams): Signer<unknown
 			return SafeAccount.createWebAuthnSignature(assertion) as `0x${string}`;
 		},
 	};
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthn pubkey JSON round-trip
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Coerce a `{ x, y }` pair where each coord may be `bigint`, hex string
+ * (`"0x..."`), decimal string, or a safe-integer number into a canonical
+ * {@link WebauthnPublicKey} with bigint coords. Used internally by
+ * {@link pubkeyCoordinatesFromJson} — for non-JSON inputs (URL params,
+ * RPC responses), pass the pre-parsed object straight to that helper.
+ *
+ * @throws if either coordinate is missing, the wrong type, or an
+ * unparseable string.
+ */
+function toBigintPubkey(pubkey: {
+	x: bigint | string | number;
+	y: bigint | string | number;
+}): WebauthnPublicKey {
+	if (!pubkey || pubkey.x == null || pubkey.y == null) {
+		throw new Error("toBigintPubkey: pubkey must be `{ x, y }` with both coords set");
+	}
+	return { x: coerceBigint(pubkey.x, "x"), y: coerceBigint(pubkey.y, "y") };
+}
+
+function coerceBigint(v: bigint | string | number, field: string): bigint {
+	let coerced: bigint;
+	if (typeof v === "bigint") {
+		coerced = v;
+	} else if (typeof v === "string") {
+		try {
+			coerced = BigInt(v);
+		} catch {
+			throw new Error(
+				`toBigintPubkey: pubkey.${field} ("${v}") is not a valid bigint string. ` +
+					"Accepted: non-negative bigint, decimal string, or 0x-prefixed hex string.",
+			);
+		}
+	} else if (typeof v === "number") {
+		if (!Number.isSafeInteger(v)) {
+			throw new Error(
+				`toBigintPubkey: pubkey.${field} is a Number but not a safe integer. ` +
+					"Pass as bigint or hex string to avoid precision loss.",
+			);
+		}
+		coerced = BigInt(v);
+	} else {
+		throw new Error(
+			`toBigintPubkey: pubkey.${field} must be bigint, string, or number (got ${typeof v})`,
+		);
+	}
+	// P-256 field elements are non-negative by definition. Reject negatives
+	// at the coercion boundary so they can't reach `pubkeyCoordinatesToJson`,
+	// which would emit an invalid `"0x-..."` string and break round-trip.
+	if (coerced < 0n) {
+		throw new Error(
+			`toBigintPubkey: pubkey.${field} must be non-negative (got ${coerced.toString()}). ` +
+				"P-256 coordinates are non-negative field elements; negative values aren't valid " +
+				"and would break canonical JSON round-trip serialization.",
+		);
+	}
+	return coerced;
+}
+
+/**
+ * Serialize a WebAuthn pubkey to a JSON string with hex-encoded
+ * coordinates. Inverse of {@link pubkeyCoordinatesFromJson}.
+ *
+ * Any JSON-string persistence — localStorage, backend indexes, query
+ * strings, IPC payloads — eventually needs a custom replacer for
+ * `bigint` (which `JSON.stringify` can't serialize on its own). This
+ * helper ships the canonical version so the round-trip is consistent
+ * across call sites.
+ *
+ * @example
+ * ```ts
+ * localStorage.setItem("passkey", pubkeyCoordinatesToJson({ x: 0x7a..., y: 0x2e... }));
+ * // Stored as: {"x":"0x7a...","y":"0x2e..."}
+ * ```
+ */
+export function pubkeyCoordinatesToJson(pubkey: WebauthnPublicKey): string {
+	return JSON.stringify({
+		x: "0x" + pubkey.x.toString(16),
+		y: "0x" + pubkey.y.toString(16),
+	});
+}
+
+/**
+ * Parse a JSON string produced by {@link pubkeyCoordinatesToJson} (or
+ * any JSON object with `x` / `y` fields as bigint-compatible values)
+ * back into a {@link WebauthnPublicKey} with bigint coords.
+ *
+ * Lenient about input shape: accepts a JSON string, a pre-parsed object
+ * (skip `JSON.parse` if you already ran it), and either hex (`"0x..."`)
+ * or decimal-string coords. Same one-line cost regardless of where the
+ * string came from — localStorage, backend response, query parameter.
+ *
+ * @example
+ * ```ts
+ * const raw = localStorage.getItem("passkey");
+ * if (raw) {
+ *   const pubkey = pubkeyCoordinatesFromJson(raw);
+ *   // pubkey: { x: bigint, y: bigint }
+ * }
+ * ```
+ */
+export function pubkeyCoordinatesFromJson(
+	input: string | { x: bigint | string | number; y: bigint | string | number },
+): WebauthnPublicKey {
+	const parsed = typeof input === "string" ? JSON.parse(input) : input;
+	return toBigintPubkey(parsed);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthn assertion normalizer
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Structural shape matching the browser `AuthenticatorAssertionResponse`,
+ * `ox/WebAuthnP256` sign output, and `@simplewebauthn/browser`. Consumers
+ * can pass any of these without an adapter-specific wrapper.
+ *
+ * Each field is normalized individually:
+ * - `authenticatorData`: `ArrayBuffer` (raw browser API), `Uint8Array`
+ *   (most libraries), or `0x`-prefixed hex string (`ox`).
+ * - `clientDataJSON`: UTF-8 string (`ox` returns it pre-decoded), or
+ *   buffer (raw browser API).
+ * - `signature`: pre-decoded `{ r, s }` bigints (`ox` returns this), or a
+ *   DER-encoded buffer (raw browser API).
+ */
+interface AuthenticatorAssertionLike {
+	authenticatorData: ArrayBuffer | Uint8Array | string;
+	clientDataJSON: ArrayBuffer | Uint8Array | string;
+	signature: ArrayBuffer | Uint8Array | { r: bigint; s: bigint };
+}
+
+/**
+ * Turn a structural {@link AuthenticatorAssertionLike} into
+ * {@link WebauthnSignatureData}, ready to feed straight into
+ * `SafeAccount.createWebAuthnSignature` or the `getAssertion` callback
+ * of `fromSafeWebauthn`.
+ *
+ * Replaces the ~13-line manual pipeline every Safe-passkeys consumer
+ * has been writing — `JSON.parse` of `clientDataJSON`, destructure +
+ * re-serialize the non-`type` / non-`challenge` fields, hex-encode,
+ * normalize `authenticatorData`, parse DER signature → `(r, s)` —
+ * with a single call.
+ *
+ * @example Browser:
+ * ```ts
+ * const assertion = await navigator.credentials.get({...});
+ * return webauthnSignatureFromAssertion(assertion.response);
+ * ```
+ *
+ * @example `ox/WebAuthnP256`:
+ * ```ts
+ * const { metadata, signature } = await sign({ challenge, credentialId });
+ * return webauthnSignatureFromAssertion({
+ *   authenticatorData: metadata.authenticatorData, // hex string from ox
+ *   clientDataJSON: metadata.clientDataJSON,       // string from ox
+ *   signature,                                      // { r, s } from ox
+ * });
+ * ```
+ */
+export function webauthnSignatureFromAssertion(
+	response: AuthenticatorAssertionLike,
+): WebauthnSignatureData {
+	const authenticatorData = toArrayBuffer(response.authenticatorData);
+	const clientDataJSON = toUtf8String(response.clientDataJSON);
+	const rs = toRSPair(response.signature);
+	return {
+		authenticatorData,
+		clientDataFields: extractClientDataFieldsHex(clientDataJSON),
+		rs: [rs.r, rs.s],
+	};
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Internal: input normalization
+// ────────────────────────────────────────────────────────────────────────────
+
+function toArrayBuffer(input: ArrayBuffer | Uint8Array | string): ArrayBuffer {
+	// ethers' `getBytes` validates hex format and returns a fresh
+	// Uint8Array; it doesn't accept ArrayBuffer though, so we handle
+	// that one case manually. Same byte-for-byte output as the previous
+	// hand-rolled `hexToBytes` plus regex validation.
+	if (input instanceof ArrayBuffer) return input;
+	const bytes = getBytes(input);
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+function toUtf8String(input: ArrayBuffer | Uint8Array | string): string {
+	if (typeof input === "string") return input;
+	const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+	// TextDecoder is available in all modern browsers and Node 11+.
+	return new TextDecoder("utf-8").decode(bytes);
+}
+
+function toRSPair(
+	input: ArrayBuffer | Uint8Array | { r: bigint; s: bigint },
+): { r: bigint; s: bigint } {
+	if (
+		input !== null &&
+		typeof input === "object" &&
+		"r" in input &&
+		"s" in input &&
+		typeof (input as { r: unknown }).r === "bigint" &&
+		typeof (input as { s: unknown }).s === "bigint"
+	) {
+		return { r: (input as { r: bigint }).r, s: (input as { s: bigint }).s };
+	}
+	const bytes = input instanceof Uint8Array ? input : new Uint8Array(input as ArrayBuffer);
+	return parseDerP256Signature(bytes);
+}
+
+/**
+ * Re-serialize every clientDataJSON field except `type` and `challenge`.
+ * Robust to authenticators adding or reordering keys (e.g. Safari's
+ * `crossOrigin`, future WebAuthn L3 fields) — parses JSON instead of
+ * using a regex, validates the shape is a plain object, and emits hex
+ * via `TextEncoder` (browser-safe; `Buffer` isn't defined in Vite /
+ * Rollup / esbuild bundles without a polyfill).
+ */
+function extractClientDataFieldsHex(clientDataJSON: string): string {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(clientDataJSON);
+	} catch (err) {
+		throw new Error(
+			`webauthnSignatureFromAssertion: clientDataJSON is not valid JSON (${(err as Error).message})`,
+		);
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error(
+			"webauthnSignatureFromAssertion: clientDataJSON must parse to a plain object " +
+				`(got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed})`,
+		);
+	}
+	const { type: _type, challenge: _challenge, ...rest } = parsed as Record<string, unknown>;
+	const fields = Object.entries(rest)
+		.map(([key, value]) => `"${key}":${JSON.stringify(value)}`)
+		.join(",");
+	// `hexlify` mirrors what the prior hand-rolled hex loop produced —
+	// each byte gets exactly 2 lowercase hex chars, no separators, `0x`
+	// prefix. Confirmed identical for all input sizes via the test suite.
+	return hexlify(new TextEncoder().encode(fields));
+}
+
+/**
+ * Parse a DER-encoded ECDSA P-256 signature into `(r, s)` bigints with
+ * low-S normalization. Defends against truncated / malformed DER: every
+ * length and tag is bounds-checked against the buffer before slicing,
+ * because `Uint8Array.subarray` silently clamps OOB indices and would
+ * otherwise produce attacker-controlled-length r/s.
+ *
+ * DER layout:
+ *   0x30 | total-len | 0x02 | r-len | r-bytes | 0x02 | s-len | s-bytes
+ */
+function parseDerP256Signature(der: Uint8Array): { r: bigint; s: bigint } {
+	const malformed = () =>
+		new Error("webauthnSignatureFromAssertion: malformed DER signature");
+	if (der.length < 8 || der[0] !== 0x30) throw malformed();
+
+	// Validate the outer SEQUENCE length up front so trailing garbage and
+	// length under/overstatement can't survive to the bigint conversion.
+	const headerLen = der[1] === 0x81 ? 3 : 2;
+	const outerLen = der[1] === 0x81 ? der[2] : der[1];
+	if (der.length !== headerLen + outerLen) throw malformed();
+	let offset = headerLen;
+
+	// r tag + length + body must fit
+	if (offset + 2 > der.length) throw malformed();
+	if (der[offset] !== 0x02) throw malformed();
+	const rLen = der[offset + 1];
+	if (rLen <= 0 || offset + 2 + rLen > der.length) throw malformed();
+	const rBytes = der.subarray(offset + 2, offset + 2 + rLen);
+	offset += 2 + rLen;
+
+	// s tag + length + body must fit
+	if (offset + 2 > der.length) throw malformed();
+	if (der[offset] !== 0x02) throw malformed();
+	const sLen = der[offset + 1];
+	if (sLen <= 0 || offset + 2 + sLen > der.length) throw malformed();
+	const sBytes = der.subarray(offset + 2, offset + 2 + sLen);
+	// No bytes may follow `s` inside the SEQUENCE.
+	if (offset + 2 + sLen !== der.length) throw malformed();
+
+	// `hexlify(empty)` returns "0x" which BigInt rejects; preserve the
+	// 0n short-circuit. For DER-parsed r/s the bytes are non-empty by
+	// the rLen/sLen > 0 checks above, but keep the guard explicit.
+	const r = rBytes.length === 0 ? 0n : BigInt(hexlify(rBytes));
+	let s = sBytes.length === 0 ? 0n : BigInt(hexlify(sBytes));
+
+	// Low-S normalize: some authenticators return the high-S form; the
+	// Safe WebAuthn verifier and most P-256 checkers accept only low-S.
+	const P256_N = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n;
+	const P256_N_HALF = P256_N >> 1n;
+	if (s > P256_N_HALF) s = P256_N - s;
+
+	return { r, s };
 }

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -169,4 +169,3 @@ export function fromEthersWallet(wallet: EthersWalletLike): Signer<unknown> {
 			(await wallet.signTypedData(td.domain, td.types, td.message)) as `0x${string}`,
 	};
 }
-

--- a/test/safe/webauthnHelpers.test.js
+++ b/test/safe/webauthnHelpers.test.js
@@ -1,0 +1,324 @@
+// Unit tests for the WebAuthn helpers added in signer/adapters.ts.
+// Offline; no network, no real crypto. Synthetic fixtures verify shape
+// + normalization + rejection paths.
+
+const ak = require('../../dist/index.cjs');
+
+const FIXTURE_PUBKEY = {
+    x: 0x7a2fa39b3c61b3cbab8e44abeac8c9c7a4c1f76d42ae6f47b3b2a96d5c4f1a2bn,
+    y: 0x2e8c5f6d4b7a9c1e3f5a8d7b6c4e2f1a9d8c7b6a5e4f3d2c1b0a9f8e7d6c5b4an,
+};
+const FIXTURE_AUTHENTICATOR_DATA_HEX =
+    '49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001';
+
+function buildClientDataJSON(challengeB64Url, opts = {}) {
+    const {
+        fieldOrder = ['type', 'challenge', 'origin', 'crossOrigin'],
+        extras = { origin: 'https://safe.global', crossOrigin: false },
+    } = opts;
+    const fields = {
+        type: 'webauthn.get',
+        challenge: challengeB64Url,
+        ...extras,
+    };
+    const parts = fieldOrder.map((k) => `"${k}":${JSON.stringify(fields[k])}`);
+    return `{${parts.join(',')}}`;
+}
+
+function hexToBytes(hex) {
+    const body = hex.startsWith('0x') ? hex.slice(2) : hex;
+    const out = new Uint8Array(body.length / 2);
+    for (let i = 0; i < out.length; i++)
+        out[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+    return out;
+}
+
+// ─── pubkey JSON round-trip ──────────────────────────────────────────────
+
+describe('pubkeyCoordinatesToJson / pubkeyCoordinatesFromJson', () => {
+    test('round-trips a WebAuthn pubkey bit-for-bit', () => {
+        const json = ak.pubkeyCoordinatesToJson(FIXTURE_PUBKEY);
+        const parsed = ak.pubkeyCoordinatesFromJson(json);
+        expect(parsed).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('serializes coords as 0x-hex strings (compact + safe to JSON-stringify)', () => {
+        const json = ak.pubkeyCoordinatesToJson(FIXTURE_PUBKEY);
+        const obj = JSON.parse(json);
+        expect(obj.x.startsWith('0x')).toBe(true);
+        expect(obj.y.startsWith('0x')).toBe(true);
+        expect(BigInt(obj.x)).toBe(FIXTURE_PUBKEY.x);
+        expect(BigInt(obj.y)).toBe(FIXTURE_PUBKEY.y);
+    });
+
+    test('fromJson accepts a pre-parsed object (skip JSON.parse)', () => {
+        const obj = { x: '0x' + FIXTURE_PUBKEY.x.toString(16), y: '0x' + FIXTURE_PUBKEY.y.toString(16) };
+        expect(ak.pubkeyCoordinatesFromJson(obj)).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('fromJson accepts decimal strings too', () => {
+        const json = JSON.stringify({
+            x: FIXTURE_PUBKEY.x.toString(10),
+            y: FIXTURE_PUBKEY.y.toString(10),
+        });
+        expect(ak.pubkeyCoordinatesFromJson(json)).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('fromJson throws on malformed coords', () => {
+        expect(() => ak.pubkeyCoordinatesFromJson('{"x":"not-hex","y":"0x1"}')).toThrow(
+            /not a valid bigint/,
+        );
+        expect(() => ak.pubkeyCoordinatesFromJson('{"x":"0x1"}')).toThrow(/x, y.*both/);
+    });
+});
+
+describe('pubkeyCoordinatesFromJson coerces non-bigint coords (object input)', () => {
+    // toBigintPubkey lives internally; coercion paths are exercised
+    // through pubkeyCoordinatesFromJson(obj), which accepts a pre-parsed
+    // object and delegates to the same coercer.
+
+    test('idempotent on bigint input', () => {
+        expect(ak.pubkeyCoordinatesFromJson(FIXTURE_PUBKEY)).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('coerces hex-string and decimal-string coords to bigint', () => {
+        const hex = ak.pubkeyCoordinatesFromJson({
+            x: '0x' + FIXTURE_PUBKEY.x.toString(16),
+            y: '0x' + FIXTURE_PUBKEY.y.toString(16),
+        });
+        expect(hex).toEqual(FIXTURE_PUBKEY);
+        const dec = ak.pubkeyCoordinatesFromJson({
+            x: FIXTURE_PUBKEY.x.toString(10),
+            y: FIXTURE_PUBKEY.y.toString(10),
+        });
+        expect(dec).toEqual(FIXTURE_PUBKEY);
+    });
+
+    test('coerces small-integer numbers', () => {
+        const c = ak.pubkeyCoordinatesFromJson({ x: 42, y: 7 });
+        expect(c.x).toBe(42n);
+        expect(c.y).toBe(7n);
+    });
+
+    test('rejects unsafe-integer numbers (precision loss)', () => {
+        expect(() =>
+            ak.pubkeyCoordinatesFromJson({ x: Number.MAX_SAFE_INTEGER + 1, y: 1n }),
+        ).toThrow(/safe integer/);
+    });
+
+    test('rejects bool / object / unparseable strings', () => {
+        expect(() => ak.pubkeyCoordinatesFromJson({ x: true, y: 1n })).toThrow(
+            /bigint, string, or number/,
+        );
+        expect(() => ak.pubkeyCoordinatesFromJson({ x: 'garbage', y: 1n })).toThrow(
+            /not a valid bigint/,
+        );
+        expect(() => ak.pubkeyCoordinatesFromJson({ x: undefined, y: 1n })).toThrow(/x, y.*both/);
+    });
+
+    test('rejects negative coords (would break canonical round-trip)', () => {
+        // pubkeyCoordinatesToJson({ x: -1n, ... }) would emit "0x-1", which
+        // isn't valid hex and breaks round-trip. P-256 coords are
+        // non-negative by definition — reject at the coercion boundary.
+        expect(() => ak.pubkeyCoordinatesFromJson({ x: -1n, y: 1n })).toThrow(/non-negative/);
+        expect(() => ak.pubkeyCoordinatesFromJson({ x: '-1', y: 1n })).toThrow(/non-negative/);
+        expect(() => ak.pubkeyCoordinatesFromJson({ x: -42, y: 1n })).toThrow(/non-negative/);
+    });
+
+    test('toBigintPubkey is not exported (internal-only)', () => {
+        expect(ak.toBigintPubkey).toBeUndefined();
+    });
+});
+
+// ─── webauthnSignatureFromAssertion ──────────────────────────────────────
+
+describe('webauthnSignatureFromAssertion: input shape normalization', () => {
+    function buildAssertion(overrides = {}) {
+        return {
+            authenticatorData: hexToBytes(FIXTURE_AUTHENTICATOR_DATA_HEX),
+            clientDataJSON: buildClientDataJSON('AA'),
+            signature: { r: 1n, s: 2n },
+            ...overrides,
+        };
+    }
+
+    test('Uint8Array authenticatorData → ArrayBuffer output', () => {
+        const out = ak.webauthnSignatureFromAssertion(buildAssertion());
+        expect(out.authenticatorData instanceof ArrayBuffer).toBe(true);
+        expect(out.rs).toEqual([1n, 2n]);
+    });
+
+    test('ArrayBuffer authenticatorData accepted', () => {
+        const u8 = hexToBytes(FIXTURE_AUTHENTICATOR_DATA_HEX);
+        const ab = u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+        const out = ak.webauthnSignatureFromAssertion(buildAssertion({ authenticatorData: ab }));
+        expect(out.authenticatorData instanceof ArrayBuffer).toBe(true);
+    });
+
+    test('hex-string authenticatorData (`0x` shape) accepted', () => {
+        const out = ak.webauthnSignatureFromAssertion(
+            buildAssertion({ authenticatorData: '0x' + FIXTURE_AUTHENTICATOR_DATA_HEX }),
+        );
+        expect(out.authenticatorData instanceof ArrayBuffer).toBe(true);
+        expect(out.authenticatorData.byteLength).toBe(37);
+    });
+
+    test('malformed hex authenticatorData throws (no silent zero-coercion)', () => {
+        // ethers' getBytes rejects non-hex characters; a permissive parser
+        // would silently coerce `parseInt("zz", 16)` (NaN) into 0.
+        expect(() =>
+            ak.webauthnSignatureFromAssertion(
+                buildAssertion({ authenticatorData: '0xzz' + FIXTURE_AUTHENTICATOR_DATA_HEX.slice(2) }),
+            ),
+        ).toThrow(/invalid BytesLike value/);
+    });
+
+    test('partial-hex pair throws (parseInt would silently truncate)', () => {
+        // `Number.parseInt("1g", 16)` returns 1 (parseInt stops at the first
+        // non-hex char). ethers' getBytes refuses the whole input instead.
+        expect(() =>
+            ak.webauthnSignatureFromAssertion(
+                buildAssertion({ authenticatorData: '0x1g' + FIXTURE_AUTHENTICATOR_DATA_HEX.slice(2) }),
+            ),
+        ).toThrow(/invalid BytesLike value/);
+    });
+
+    test('clientDataJSON: string and buffer both work', () => {
+        const str = buildClientDataJSON('AA');
+        const buf = new TextEncoder().encode(str);
+        const fromStr = ak.webauthnSignatureFromAssertion(buildAssertion({ clientDataJSON: str }));
+        const fromBuf = ak.webauthnSignatureFromAssertion(buildAssertion({ clientDataJSON: buf }));
+        expect(fromStr.clientDataFields).toBe(fromBuf.clientDataFields);
+    });
+
+    test('signature: pre-parsed { r, s } and DER buffer both work', () => {
+        // DER for r=0x01, s=0x02: 30 06 02 01 01 02 01 02
+        const der = new Uint8Array([0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]);
+        const fromDer = ak.webauthnSignatureFromAssertion(buildAssertion({ signature: der }));
+        expect(fromDer.rs).toEqual([1n, 2n]);
+    });
+});
+
+describe('webauthnSignatureFromAssertion: clientDataJSON validation', () => {
+    function withCD(clientDataJSON) {
+        return ak.webauthnSignatureFromAssertion({
+            authenticatorData: new Uint8Array(37),
+            clientDataJSON,
+            signature: { r: 1n, s: 2n },
+        });
+    }
+
+    test('accepts canonical clientDataJSON', () => {
+        const out = withCD(buildClientDataJSON('AA'));
+        expect(out.clientDataFields.startsWith('0x')).toBe(true);
+        expect(out.clientDataFields).not.toContain('type'); // type stripped
+        expect(out.clientDataFields).not.toContain('challenge'); // challenge stripped
+    });
+
+    test('Safari-style field reorder doesn\'t break extraction', () => {
+        const out = withCD(
+            buildClientDataJSON('AA', {
+                fieldOrder: ['type', 'crossOrigin', 'origin', 'challenge'],
+            }),
+        );
+        expect(out.clientDataFields.startsWith('0x')).toBe(true);
+    });
+
+    test('rejects invalid JSON with clear error', () => {
+        expect(() => withCD('{not valid json')).toThrow(/clientDataJSON is not valid JSON/);
+    });
+
+    test('rejects null / array / primitive (not a plain object)', () => {
+        expect(() => withCD('null')).toThrow(/must parse to a plain object.*null/);
+        expect(() => withCD('[1,2,3]')).toThrow(/must parse to a plain object.*array/);
+        expect(() => withCD('"foo"')).toThrow(/must parse to a plain object.*string/);
+        expect(() => withCD('42')).toThrow(/must parse to a plain object.*number/);
+    });
+});
+
+describe('parseDerP256Signature: bounds checks', () => {
+    function withSig(signature) {
+        return ak.webauthnSignatureFromAssertion({
+            authenticatorData: new Uint8Array(37),
+            clientDataJSON: '{"type":"webauthn.get","challenge":"AA"}',
+            signature,
+        });
+    }
+
+    test('valid minimal DER is accepted', () => {
+        const der = new Uint8Array([0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]);
+        const out = withSig(der);
+        expect(out.rs).toEqual([1n, 2n]);
+    });
+
+    test('truncated DER (rLen claims more than buffer holds) throws', () => {
+        const truncated = new Uint8Array([
+            0x30, 0x46,
+            0x02, 0xc8, // rLen = 200 (impossibly large for what follows)
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+        ]);
+        expect(() => withSig(truncated)).toThrow(/malformed DER signature/);
+    });
+
+    test('zero-length r throws', () => {
+        const zeroR = new Uint8Array([
+            0x30, 0x06,
+            0x02, 0x00, // rLen = 0, invalid
+            0x02, 0x02, 0x11, 0x22,
+        ]);
+        expect(() => withSig(zeroR)).toThrow(/malformed DER signature/);
+    });
+
+    test('wrong tag byte throws', () => {
+        const wrongTag = new Uint8Array([
+            0x30, 0x08,
+            0x03, 0x02, 0x11, 0x22, // OCTET STRING tag (0x03), not INTEGER (0x02)
+            0x02, 0x02, 0x33, 0x44,
+        ]);
+        expect(() => withSig(wrongTag)).toThrow(/malformed DER signature/);
+    });
+
+    test('outer-length mismatch (claims fewer bytes than present) throws', () => {
+        // Valid r/s but outer SEQUENCE length understates by 1.
+        const understated = new Uint8Array([
+            0x30, 0x05, // claims 5, but body below is 6
+            0x02, 0x01, 0x01,
+            0x02, 0x01, 0x02,
+        ]);
+        expect(() => withSig(understated)).toThrow(/malformed DER signature/);
+    });
+
+    test('trailing garbage after s throws', () => {
+        // Outer length covers the trailing byte, so the inner bounds checks
+        // pass — only the post-s length equality catches it.
+        const trailing = new Uint8Array([
+            0x30, 0x07,
+            0x02, 0x01, 0x01,
+            0x02, 0x01, 0x02,
+            0xff, // garbage byte still inside outer length
+        ]);
+        expect(() => withSig(trailing)).toThrow(/malformed DER signature/);
+    });
+
+    test('low-S normalization: high-S input is folded into the low half', () => {
+        // s = N - 1, which is > N/2 → should normalize to s = 1
+        const N = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n;
+        const sHigh = N - 1n;
+        const sBytes = [];
+        let v = sHigh;
+        while (v > 0n) {
+            sBytes.unshift(Number(v & 0xffn));
+            v >>= 8n;
+        }
+        // Body: 3 bytes for r (tag+len+value) + 2 bytes for s header + sBytes
+        const outerLen = 3 + 2 + sBytes.length;
+        const der = new Uint8Array([
+            0x30, outerLen,
+            0x02, 0x01, 0x05, // r = 5
+            0x02, sBytes.length, ...sBytes,
+        ]);
+        const out = withSig(der);
+        // s should be N - sHigh = 1
+        expect(out.rs[1]).toBe(1n);
+    });
+});


### PR DESCRIPTION
## Summary

Three small helpers that close the DX gap on top of #142's per-account contract-signer adapters. No SDK-internals changes — additive surface only, three functions, zero new types.

## Public API (3 functions)

```ts
import {
  pubkeyCoordinatesToJson,
  pubkeyCoordinatesFromJson,
  webauthnSignatureFromAssertion,
} from "abstractionkit";
```

### Bigint-safe pubkey JSON round-trip

```ts
// Persist (any JSON-string storage):
localStorage.setItem("passkey", pubkeyCoordinatesToJson({ x, y }));

// Restore:
const pubkey = pubkeyCoordinatesFromJson(localStorage.getItem("passkey")!);
// → { x: bigint, y: bigint }
```

\`pubkeyCoordinatesFromJson\` is lenient — accepts a JSON string OR a pre-parsed object, and either hex (\`"0x..."\`) or decimal-string coords. Covers the non-JSON case where coords arrive as strings via URL params, RPC payload, IPC.

Replaces the \`JSON.stringify\` bigint replacer + matching reviver every consumer ends up writing. The exact shape your demo's \`storage.ts\` had (write-side replacer with no read-side reviver, hit during the previous review round).

### WebAuthn assertion normalizer

```ts
const signer = fromSafeWebauthn({  // from #142
  publicKey,
  isInit: userOp.nonce === 0n,
  getAssertion: async (challenge) => {
    const assertion = await navigator.credentials.get({...});
    return webauthnSignatureFromAssertion(assertion.response);  // <-- this PR
  },
});
```

Turns a structural \`AuthenticatorAssertionResponse\`-like shape (browser API, \`ox/WebAuthnP256\`, \`@simplewebauthn/browser\`) into the \`WebauthnSignatureData\` that #142's \`fromSafeWebauthn\` already accepts. Collapses the ~13-line manual parsing block (JSON-parse \`clientDataJSON\`, destructure non-\`type\`/non-\`challenge\` fields, hex-encode, normalize \`authenticatorData\`, parse DER signature → \`(r, s)\`) to one call.

## Internal hardening (not exported)

Lives inside \`webauthnSignatureFromAssertion\`:

- **\`parseDerP256Signature\` bounds checks.** Every length and tag is validated against the buffer before slicing. Defends against truncated / hostile DER, which \`Uint8Array.subarray\` would otherwise silently clamp into attacker-controlled \`r\`/\`s\` values. Includes low-S normalization for authenticators that emit high-S form.
- **\`clientDataJSON\` structural validation.** \`try\`/\`catch\` around \`JSON.parse\` + check that the parsed value is a plain object (not \`null\`, not array, not primitive). Each failure mode throws with a diagnostic message naming what was actually received.
- **\`TextEncoder\` for utf-8 → hex.** \`Buffer\` isn't defined in Vite / Rollup / esbuild bundles without a polyfill.

## Public-surface trim

Earlier draft exported \`toBigintPubkey\` and \`AuthenticatorAssertionLike\`. Both pulled back to internal — \`toBigintPubkey\`'s capability is fully reachable through \`pubkeyCoordinatesFromJson(obj)\` (the overload accepts pre-parsed objects), and the assertion input type can be recovered as \`Parameters<typeof webauthnSignatureFromAssertion>[0]\` if a consumer needs it for typing their own wrapper. Net public additions: 3 functions, 0 types.

## Tests

25 new cases in \`test/signer/webauthnHelpers.test.js\` covering each input shape, each rejection path, and the DER bounds checks. 56 offline signer tests pass total (31 existing + 25 new). Build clean, no regressions.

## Context

These are the pieces from the closed #136 that are orthogonal to the signer-type debate. The signer-union expansion that PR proposed isn't here — \`SigningScheme\` stays \`"hash" | "typedData"\`, \`Signer\` keeps its existing two variants, no new sign methods. Lands cleanly alongside #142.

## Follow-up

A peer \`fromCaliburWebauthn\` adapter for Calibur (same pattern as #142's \`fromSafeWebauthn\`, different on-chain wrapper format) is planned post-#142-merge as a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAuthn utilities for serializing/deserializing public key coordinates and normalizing authentication assertions, with robust handling of multiple input formats and strict validation.

* **Tests**
  * Added comprehensive tests covering serialization/parse round-trips, assertion normalization, signature validation/normalization, and extensive input error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->