### PR TITLE
feat(simple7702): support EIP-712 typed-data signing for v0.8/v0.9

### DIFF
--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -3,7 +3,7 @@ import { Bundler } from "src/Bundler";
 import { BaseUserOperationDummyValues, ENTRYPOINT_V8, ENTRYPOINT_V9 } from "src/constants";
 import { AbstractionKitError } from "src/errors";
 import { invokeSigner, pickScheme } from "src/signer/negotiate";
-import type { Signer as AkSigner, SignContext, SigningScheme } from "src/signer/types";
+import type { Signer as AkSigner, SignContext, SigningScheme, TypedData } from "src/signer/types";
 import type {
 	GasOption,
 	JsonRpcResult,
@@ -19,6 +19,8 @@ import {
 	createRevokeDelegationAuthorization,
 } from "src/utils7702";
 import {
+	buildPackedInitCodeV8V9,
+	buildPaymasterAndData,
 	createCallData,
 	createUserOperationHash,
 	fetchAccountNonce,
@@ -753,16 +755,123 @@ export class BaseSimple7702Account extends SmartAccount {
 	}
 
 	/**
-	 * Schemes Simple7702 accepts from a Signer. Only raw-hash ECDSA, since
-	 * the delegatee verifies a plain signature over the userOp hash.
+	 * Schemes Simple7702 accepts from a Signer. EntryPoint v0.8/v0.9 introduced
+	 * an EIP-712 domain at the EntryPoint contract, and the userOpHash IS the
+	 * EIP-712 digest of the PackedUserOperation under that domain — so signing
+	 * the typed data and signing the raw hash produce signatures that verify
+	 * against the same `userOpHash` (and recover to the same signer address).
+	 * Deterministic-ECDSA signers (ethers, viem, MetaMask) yield byte-identical
+	 * bytes; signers that differ in `s` / `v` normalization still validate the
+	 * same on-chain.
+	 *
+	 * `typedData` is listed first so JSON-RPC wallets that can only sign typed
+	 * data work without a separate code path; `hash` remains a valid fallback
+	 * for local-key signers.
 	 */
-	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["hash"];
+	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["typedData", "hash"];
 
 	/**
-	 * Sign a UserOperation with an {@link AkSigner}. Signer must implement
-	 * `signHash`, since Simple7702 only verifies raw ECDSA over the userOp
-	 * hash. JSON-RPC wallets and anything that only provides `signTypedData`
-	 * fail offline with a specific error.
+	 * EIP-712 type definition for {@link UserOperationV8} / {@link UserOperationV9}
+	 * under the EntryPoint v0.8/v0.9 domain. Stable across both versions.
+	 */
+	public static readonly EIP712_PACKED_USEROP_TYPE = {
+		PackedUserOperation: [
+			{ name: "sender", type: "address" },
+			{ name: "nonce", type: "uint256" },
+			{ name: "initCode", type: "bytes" },
+			{ name: "callData", type: "bytes" },
+			{ name: "accountGasLimits", type: "bytes32" },
+			{ name: "preVerificationGas", type: "uint256" },
+			{ name: "gasFees", type: "bytes32" },
+			{ name: "paymasterAndData", type: "bytes" },
+		],
+	} as const;
+
+	/**
+	 * Build the EIP-712 typed data payload for a UserOperation under the
+	 * EntryPoint v0.8/v0.9 domain. The digest of this payload equals the
+	 * UserOperation hash returned by {@link createUserOperationHash}, so a
+	 * wallet calling `signTypedData(domain, types, message)` produces a
+	 * signature that verifies against the same `userOpHash` as a raw ECDSA
+	 * signature over that hash. Deterministic-ECDSA signers yield byte-
+	 * identical signatures; signers that differ in `s` / `v` normalization
+	 * still validate the same on-chain.
+	 *
+	 * Use this when integrating wallets that only expose `signTypedData`
+	 * (for example, JSON-RPC providers, viem `WalletClient`), or to display
+	 * structured fields in the wallet's signing prompt instead of a hex
+	 * blob.
+	 *
+	 * @param userOperation - Unsigned UserOperation to wrap
+	 * @param chainId - Target chain ID (must match the chain that will validate
+	 *   the signature)
+	 * @returns EIP-712 {@link TypedData} payload ready for `signTypedData`
+	 * @throws {AbstractionKitError} if this account targets an EntryPoint
+	 *   version other than v0.8 / v0.9. Earlier EntryPoints define the
+	 *   userOpHash differently and require raw-hash signing.
+	 */
+	public getUserOperationEip712TypedData(
+		userOperation: UserOperationV8 | UserOperationV9,
+		chainId: bigint,
+	): TypedData {
+		const ep = this.entrypointAddress.toLowerCase();
+		const isV9 = ep === ENTRYPOINT_V9.toLowerCase();
+		if (ep !== ENTRYPOINT_V8.toLowerCase() && !isV9) {
+			throw new AbstractionKitError(
+				"BAD_DATA",
+				`getUserOperationEip712TypedData supports EntryPoint v0.8 / v0.9 only; ` +
+					`this account targets ${this.entrypointAddress}. Use signUserOperation ` +
+					`(raw-hash ECDSA) for earlier EntryPoint versions.`,
+			);
+		}
+
+		const abiCoder = AbiCoder.defaultAbiCoder();
+		const initCode = buildPackedInitCodeV8V9(userOperation);
+		const accountGasLimits =
+			"0x" +
+			abiCoder.encode(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
+			abiCoder.encode(["uint128"], [userOperation.callGasLimit]).slice(34);
+		const gasFees =
+			"0x" +
+			abiCoder.encode(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
+			abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
+		const paymasterAndData = buildPaymasterAndData(userOperation, isV9);
+
+		return {
+			domain: {
+				name: "ERC4337",
+				version: "1",
+				chainId,
+				verifyingContract: this.entrypointAddress as `0x${string}`,
+			},
+			types: BaseSimple7702Account.EIP712_PACKED_USEROP_TYPE as unknown as Record<
+				string,
+				Array<{ name: string; type: string }>
+			>,
+			primaryType: "PackedUserOperation",
+			message: {
+				sender: userOperation.sender,
+				nonce: userOperation.nonce,
+				initCode,
+				callData: userOperation.callData,
+				accountGasLimits,
+				preVerificationGas: userOperation.preVerificationGas,
+				gasFees,
+				paymasterAndData,
+			},
+		};
+	}
+
+	/**
+	 * Sign a UserOperation with an {@link AkSigner}. The signer can implement
+	 * either `signTypedData` (preferred — JSON-RPC wallets, viem `WalletClient`)
+	 * or `signHash` (local keys, hardware wallets). Both schemes produce
+	 * signatures that validate against the same `userOpHash` because the
+	 * v0.8 / v0.9 userOpHash IS the EIP-712 digest of the PackedUserOperation
+	 * (deterministic-ECDSA signers yield byte-identical bytes).
+	 *
+	 * Signers that implement neither method fail offline with an actionable
+	 * error.
 	 */
 	protected async baseSignUserOperationWithSigner<T extends UserOperationV8 | UserOperationV9>(
 		useroperation: T,
@@ -770,7 +879,7 @@ export class BaseSimple7702Account extends SmartAccount {
 		chainId: bigint,
 	): Promise<string> {
 		const scheme = pickScheme(signer, BaseSimple7702Account.ACCEPTED_SIGNING_SCHEMES, {
-			accountName: "Simple7702 (raw ECDSA over userOpHash)",
+			accountName: "Simple7702 (EIP-712 typed data or raw ECDSA over userOpHash)",
 			signerIndex: 0,
 		});
 		const hash = createUserOperationHash(
@@ -783,7 +892,11 @@ export class BaseSimple7702Account extends SmartAccount {
 			chainId,
 			entryPoint: this.entrypointAddress,
 		};
-		return invokeSigner(signer, scheme, { hash, context });
+		const typedData =
+			scheme === "typedData"
+				? this.getUserOperationEip712TypedData(useroperation, chainId)
+				: undefined;
+		return invokeSigner(signer, scheme, { hash, typedData, context });
 	}
 
 	/**
@@ -991,13 +1104,20 @@ export class Simple7702Account extends BaseSimple7702Account {
 	}
 
 	/**
-	 * Sign a {@link UserOperationV8} using an {@link ExternalSigner}.
-	 * Simple7702 only accepts raw-hash ECDSA; signers without `signHash`
-	 * fail offline with an actionable error.
+	 * Sign a {@link UserOperationV8} using an {@link ExternalSigner}. Accepts
+	 * signers that implement `signTypedData` (preferred — JSON-RPC wallets,
+	 * viem `WalletClient`), `signHash` (local keys, hardware wallets), or
+	 * both. The v0.8 userOpHash IS the EIP-712 digest of the PackedUserOperation
+	 * under the EntryPoint domain, so both schemes produce signatures that
+	 * validate against the same `userOpHash`.
 	 *
 	 * For signing with a raw private-key string, use the sync
 	 * {@link signUserOperation} method, or wrap explicitly with
 	 * `fromPrivateKey(pk)`.
+	 *
+	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} to
+	 *   obtain the typed data payload directly (e.g., to drive a wallet's
+	 *   `signTypedData` outside this dispatch).
 	 */
 	public async signUserOperationWithSigner(
 		useroperation: UserOperationV8,

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -771,36 +771,26 @@ export class BaseSimple7702Account extends SmartAccount {
 	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["typedData", "hash"];
 
 	/**
-	 * EIP-712 type definition for {@link UserOperationV8} / {@link UserOperationV9}
-	 * under the EntryPoint v0.8/v0.9 domain. Stable across both versions.
-	 */
-	public static readonly EIP712_PACKED_USEROP_TYPE = {
-		PackedUserOperation: [
-			{ name: "sender", type: "address" },
-			{ name: "nonce", type: "uint256" },
-			{ name: "initCode", type: "bytes" },
-			{ name: "callData", type: "bytes" },
-			{ name: "accountGasLimits", type: "bytes32" },
-			{ name: "preVerificationGas", type: "uint256" },
-			{ name: "gasFees", type: "bytes32" },
-			{ name: "paymasterAndData", type: "bytes" },
-		],
-	} as const;
-
-	/**
 	 * Build the EIP-712 typed data payload for a UserOperation under the
-	 * EntryPoint v0.8/v0.9 domain. The digest of this payload equals the
-	 * UserOperation hash returned by {@link createUserOperationHash}, so a
-	 * wallet calling `signTypedData(domain, types, message)` produces a
-	 * signature that verifies against the same `userOpHash` as a raw ECDSA
-	 * signature over that hash. Deterministic-ECDSA signers yield byte-
-	 * identical signatures; signers that differ in `s` / `v` normalization
-	 * still validate the same on-chain.
+	 * EntryPoint v0.8 / v0.9 domain. Lower-level escape hatch for integrators
+	 * driving `signTypedData` themselves with their own signing primitive
+	 * (HSM, MPC, custom wallet abstraction). Most callers should pass an
+	 * {@link AkSigner} to {@link signUserOperationWithSigner} instead, which
+	 * builds this internally.
 	 *
-	 * Use this when integrating wallets that only expose `signTypedData`
-	 * (for example, JSON-RPC providers, viem `WalletClient`), or to display
-	 * structured fields in the wallet's signing prompt instead of a hex
-	 * blob.
+	 * The digest of the returned payload equals the UserOperation hash from
+	 * {@link createUserOperationHash}, so a wallet calling
+	 * `signTypedData(domain, types, message)` produces a signature that
+	 * verifies against the same `userOpHash` as raw ECDSA over that hash.
+	 * Deterministic-ECDSA signers yield byte-identical signatures; signers
+	 * that differ in `s` / `v` normalization still validate the same on-chain.
+	 *
+	 * Common use cases beyond direct signing:
+	 *   - Inspect / log the typed data the wallet will display.
+	 *   - Render a custom confirmation UI before delegating to a wallet's
+	 *     `signTypedData`.
+	 *   - Drive non-`ExternalSigner`-shaped signers (HSM, MPC service,
+	 *     backend signing pipelines).
 	 *
 	 * @param userOperation - Unsigned UserOperation to wrap
 	 * @param chainId - Target chain ID (must match the chain that will validate
@@ -837,6 +827,19 @@ export class BaseSimple7702Account extends SmartAccount {
 			abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
 		const paymasterAndData = buildPaymasterAndData(userOperation, isV9);
 
+		const types = {
+			PackedUserOperation: [
+				{ name: "sender", type: "address" },
+				{ name: "nonce", type: "uint256" },
+				{ name: "initCode", type: "bytes" },
+				{ name: "callData", type: "bytes" },
+				{ name: "accountGasLimits", type: "bytes32" },
+				{ name: "preVerificationGas", type: "uint256" },
+				{ name: "gasFees", type: "bytes32" },
+				{ name: "paymasterAndData", type: "bytes" },
+			],
+		};
+
 		return {
 			domain: {
 				name: "ERC4337",
@@ -844,10 +847,7 @@ export class BaseSimple7702Account extends SmartAccount {
 				chainId,
 				verifyingContract: this.entrypointAddress as `0x${string}`,
 			},
-			types: BaseSimple7702Account.EIP712_PACKED_USEROP_TYPE as unknown as Record<
-				string,
-				Array<{ name: string; type: string }>
-			>,
+			types,
 			primaryType: "PackedUserOperation",
 			message: {
 				sender: userOperation.sender,
@@ -1104,20 +1104,34 @@ export class Simple7702Account extends BaseSimple7702Account {
 	}
 
 	/**
-	 * Sign a {@link UserOperationV8} using an {@link ExternalSigner}. Accepts
-	 * signers that implement `signTypedData` (preferred — JSON-RPC wallets,
-	 * viem `WalletClient`), `signHash` (local keys, hardware wallets), or
-	 * both. The v0.8 userOpHash IS the EIP-712 digest of the PackedUserOperation
-	 * under the EntryPoint domain, so both schemes produce signatures that
-	 * validate against the same `userOpHash`.
+	 * Sign a {@link UserOperationV8} using an {@link ExternalSigner}. This is
+	 * the recommended entry point for any non-private-key signer.
+	 *
+	 * Accepts signers that implement `signTypedData` (JSON-RPC wallets, viem
+	 * `WalletClient`, browser wallets), `signHash` (local keys, hardware
+	 * wallets), or both. The v0.8 userOpHash IS the EIP-712 digest of the
+	 * PackedUserOperation under the EntryPoint domain, so both schemes
+	 * produce signatures that validate against the same `userOpHash`.
+	 *
+	 * Wrapping a custom signing primitive is just an object literal; no
+	 * adapter function required:
+	 *
+	 * ```ts
+	 * const signer: ExternalSigner = {
+	 *   address: ownerAddress,
+	 *   signTypedData: async (td) => myWallet.signTypedData(td),
+	 * }
+	 * userOp.signature = await account.signUserOperationWithSigner(userOp, signer, chainId)
+	 * ```
 	 *
 	 * For signing with a raw private-key string, use the sync
 	 * {@link signUserOperation} method, or wrap explicitly with
 	 * `fromPrivateKey(pk)`.
 	 *
-	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} to
-	 *   obtain the typed data payload directly (e.g., to drive a wallet's
-	 *   `signTypedData` outside this dispatch).
+	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} for
+	 *   the lower-level escape hatch when you need the typed data outside the
+	 *   dispatcher (e.g., to render a custom confirmation UI or feed an HSM
+	 *   that doesn't fit the {@link ExternalSigner} shape).
 	 */
 	public async signUserOperationWithSigner(
 		useroperation: UserOperationV8,

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -93,19 +93,33 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 	}
 
 	/**
-	 * Sign a {@link UserOperationV9} using an {@link ExternalSigner}. Accepts
-	 * signers that implement `signTypedData` (preferred — JSON-RPC wallets,
-	 * viem `WalletClient`), `signHash` (local keys, hardware wallets), or
-	 * both. The v0.9 userOpHash IS the EIP-712 digest of the PackedUserOperation
-	 * under the EntryPoint domain, so both schemes produce signatures that
-	 * validate against the same `userOpHash`.
+	 * Sign a {@link UserOperationV9} using an {@link ExternalSigner}. This is
+	 * the recommended entry point for any non-private-key signer.
+	 *
+	 * Accepts signers that implement `signTypedData` (JSON-RPC wallets, viem
+	 * `WalletClient`, browser wallets), `signHash` (local keys, hardware
+	 * wallets), or both. The v0.9 userOpHash IS the EIP-712 digest of the
+	 * PackedUserOperation under the EntryPoint domain, so both schemes
+	 * produce signatures that validate against the same `userOpHash`.
+	 *
+	 * Wrapping a custom signing primitive is just an object literal; no
+	 * adapter function required:
+	 *
+	 * ```ts
+	 * const signer: ExternalSigner = {
+	 *   address: ownerAddress,
+	 *   signTypedData: async (td) => myWallet.signTypedData(td),
+	 * }
+	 * userOp.signature = await account.signUserOperationWithSigner(userOp, signer, chainId)
+	 * ```
 	 *
 	 * For signing with a raw private-key string, use the sync
 	 * {@link signUserOperation} method, or wrap explicitly with
 	 * `fromPrivateKey(pk)`.
 	 *
-	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} to
-	 *   obtain the typed data payload directly.
+	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} for
+	 *   the lower-level escape hatch when you need the typed data outside the
+	 *   dispatcher.
 	 */
 	public async signUserOperationWithSigner(
 		useroperation: UserOperationV9,

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -93,10 +93,19 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 	}
 
 	/**
-	 * Sign a {@link UserOperationV9} using an {@link ExternalSigner}.
-	 * Simple7702 only accepts raw-hash ECDSA; signers without `signHash`
-	 * fail offline with an actionable error. For a raw pk string, use the
-	 * sync {@link signUserOperation} method or wrap with `fromPrivateKey`.
+	 * Sign a {@link UserOperationV9} using an {@link ExternalSigner}. Accepts
+	 * signers that implement `signTypedData` (preferred — JSON-RPC wallets,
+	 * viem `WalletClient`), `signHash` (local keys, hardware wallets), or
+	 * both. The v0.9 userOpHash IS the EIP-712 digest of the PackedUserOperation
+	 * under the EntryPoint domain, so both schemes produce signatures that
+	 * validate against the same `userOpHash`.
+	 *
+	 * For signing with a raw private-key string, use the sync
+	 * {@link signUserOperation} method, or wrap explicitly with
+	 * `fromPrivateKey(pk)`.
+	 *
+	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} to
+	 *   obtain the typed data payload directly.
 	 */
 	public async signUserOperationWithSigner(
 		useroperation: UserOperationV9,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,6 +95,88 @@ export function createUserOperationHash(
 }
 
 /**
+ * @internal
+ * Reconstruct the packed `initCode` field for an EntryPoint v0.8/v0.9
+ * UserOperation. When `eip7702Auth.address` is set, the EIP-7702 delegatee
+ * address replaces the factory address in initCode (only `factoryData` is
+ * concatenated). Otherwise, behaves like v0.7 (`factory + factoryData`).
+ *
+ * Shared by {@link createPackedUserOperationV8} /
+ * {@link createPackedUserOperationV9} and Simple7702Account's typed-data
+ * builder. Not part of the public API; only `export`ed for cross-module
+ * use within the package and not re-exported from `src/abstractionkit.ts`.
+ *
+ * @param useroperation - V8 or V9 UserOperation to read fields from
+ * @returns Hex-encoded initCode
+ */
+export function buildPackedInitCodeV8V9(useroperation: UserOperationV8 | UserOperationV9): string {
+	if (useroperation.factory == null) return "0x";
+	const eip7702Auth = useroperation.eip7702Auth;
+	const head =
+		eip7702Auth != null && eip7702Auth.address != null
+			? eip7702Auth.address
+			: useroperation.factory;
+	const factoryData = useroperation.factoryData != null ? useroperation.factoryData.slice(2) : "";
+	return head + factoryData;
+}
+
+/**
+ * @internal
+ * Reconstruct the packed `paymasterAndData` field from a UserOperation's
+ * separate paymaster fields. Returns `0x` when no paymaster is set.
+ *
+ * For EntryPoint v0.9, when `paymasterData` ends with the parallel-paymaster
+ * signature magic suffix (`0x22e325a297439656`), the embedded signature is
+ * stripped so the userOpHash does not commit to the paymaster's signature
+ * over itself. Pass `stripV9PaymasterSig=false` to preserve the wire format.
+ *
+ * Shared by v7/v8/v9 packers and Simple7702Account's typed-data builder.
+ * Not part of the public API; only `export`ed for cross-module use within
+ * the package and not re-exported from `src/abstractionkit.ts`.
+ *
+ * @param useroperation - V7/V8/V9 UserOperation to read fields from
+ * @param stripV9PaymasterSig - Whether to strip the v0.9 paymaster signature suffix
+ * @returns Hex-encoded paymasterAndData
+ */
+export function buildPaymasterAndData(
+	useroperation: UserOperationV7 | UserOperationV8 | UserOperationV9,
+	stripV9PaymasterSig: boolean = false,
+): string {
+	if (useroperation.paymaster == null) return "0x";
+	const abiCoder = AbiCoder.defaultAbiCoder();
+	let paymasterAndData = useroperation.paymaster;
+	if (useroperation.paymasterVerificationGasLimit != null) {
+		paymasterAndData += abiCoder
+			.encode(["uint128"], [useroperation.paymasterVerificationGasLimit])
+			.slice(34);
+	}
+	if (useroperation.paymasterPostOpGasLimit != null) {
+		paymasterAndData += abiCoder
+			.encode(["uint128"], [useroperation.paymasterPostOpGasLimit])
+			.slice(34);
+	}
+	if (useroperation.paymasterData != null) {
+		const PAYMASTER_SIG_MAGIC = "22e325a297439656";
+		if (
+			stripV9PaymasterSig &&
+			useroperation.paymasterData.toLowerCase().endsWith(PAYMASTER_SIG_MAGIC)
+		) {
+			const sigLenHex = useroperation.paymasterData.slice(
+				useroperation.paymasterData.length - 16 - 4,
+				useroperation.paymasterData.length - 16,
+			);
+			const sigLen = parseInt(sigLenHex, 16);
+			const prefixEnd = useroperation.paymasterData.length - 16 - 4 - sigLen * 2;
+			paymasterAndData +=
+				useroperation.paymasterData.slice(0, prefixEnd).replaceAll("0x", "") + PAYMASTER_SIG_MAGIC;
+		} else {
+			paymasterAndData += useroperation.paymasterData.slice(2);
+		}
+	}
+	return paymasterAndData;
+}
+
+/**
  * ABI-encode and pack a UserOperation for hashing (EntryPoint v0.6 format).
  * Bytes fields (initCode, callData, paymasterAndData) are keccak256-hashed before packing.
  *
@@ -162,23 +244,7 @@ export function createPackedUserOperationV7(useroperation: UserOperationV7): str
 		abiCoder.encode(["uint128"], [useroperation.maxPriorityFeePerGas]).slice(34) +
 		abiCoder.encode(["uint128"], [useroperation.maxFeePerGas]).slice(34);
 
-	let paymasterAndData = "0x";
-	if (useroperation.paymaster != null) {
-		paymasterAndData = useroperation.paymaster;
-		if (useroperation.paymasterVerificationGasLimit != null) {
-			paymasterAndData += abiCoder
-				.encode(["uint128"], [useroperation.paymasterVerificationGasLimit])
-				.slice(34);
-		}
-		if (useroperation.paymasterPostOpGasLimit != null) {
-			paymasterAndData += abiCoder
-				.encode(["uint128"], [useroperation.paymasterPostOpGasLimit])
-				.slice(34);
-		}
-		if (useroperation.paymasterData != null) {
-			paymasterAndData += useroperation.paymasterData.slice(2);
-		}
-	}
+	const paymasterAndData = buildPaymasterAndData(useroperation);
 
 	const useroperationValuesArrayWithHashedByteValues = [
 		useroperation.sender,
@@ -230,18 +296,7 @@ function baseCreatePackedUserOperationV8V9(
 ): string {
 	const abiCoder = AbiCoder.defaultAbiCoder();
 
-	let initCode = "0x";
-	if (useroperation.factory != null) {
-		const eip7702Auth = useroperation.eip7702Auth;
-		if (eip7702Auth != null && eip7702Auth.address != null) {
-			initCode = eip7702Auth.address;
-		} else {
-			initCode = useroperation.factory;
-		}
-		if (useroperation.factoryData != null) {
-			initCode += useroperation.factoryData.slice(2);
-		}
-	}
+	const initCode = buildPackedInitCodeV8V9(useroperation);
 
 	const accountGasLimits =
 		"0x" +
@@ -253,36 +308,7 @@ function baseCreatePackedUserOperationV8V9(
 		abiCoder.encode(["uint128"], [useroperation.maxPriorityFeePerGas]).slice(34) +
 		abiCoder.encode(["uint128"], [useroperation.maxFeePerGas]).slice(34);
 
-	let paymasterAndData = "0x";
-	if (useroperation.paymaster != null) {
-		paymasterAndData = useroperation.paymaster;
-		if (useroperation.paymasterVerificationGasLimit != null) {
-			paymasterAndData += abiCoder
-				.encode(["uint128"], [useroperation.paymasterVerificationGasLimit])
-				.slice(34);
-		}
-		if (useroperation.paymasterPostOpGasLimit != null) {
-			paymasterAndData += abiCoder
-				.encode(["uint128"], [useroperation.paymasterPostOpGasLimit])
-				.slice(34);
-		}
-		if (useroperation.paymasterData != null) {
-			const PAYMASTER_SIG_MAGIC = "22e325a297439656";
-			if (is_v9 && useroperation.paymasterData.toLowerCase().endsWith(PAYMASTER_SIG_MAGIC)) {
-				const sigLenHex = useroperation.paymasterData.slice(
-					useroperation.paymasterData.length - 16 - 4,
-					useroperation.paymasterData.length - 16,
-				);
-				const sigLen = parseInt(sigLenHex, 16);
-				const prefixEnd = useroperation.paymasterData.length - 16 - 4 - sigLen * 2;
-				paymasterAndData +=
-					useroperation.paymasterData.slice(0, prefixEnd).replaceAll("0x", "") +
-					PAYMASTER_SIG_MAGIC;
-			} else {
-				paymasterAndData += useroperation.paymasterData.slice(2);
-			}
-		}
-	}
+	const paymasterAndData = buildPaymasterAndData(useroperation, is_v9);
 
 	const useroperationValuesArrayWithHashedByteValues = [
 		// PACKED_USEROP_TYPEHASH

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -615,14 +615,23 @@ describe('Simple7702Account signUserOperationWithSigner', () => {
         expect(signerSig).toBe(pkSig);
     });
 
-    test('rejects signTypedData-only signer with actionable error', async () => {
+    test('signTypedData-only signer succeeds (v0.8 userOpHash IS the EIP-712 digest)', async () => {
+        const wallet = new Wallet(PK1);
         const tdOnly = {
             address: owner,
-            signTypedData: async () => '0x',
+            signTypedData: async (td) =>
+                wallet.signTypedData(td.domain, td.types, td.message),
         };
+        const tdSig = await simple.signUserOperationWithSigner(op, tdOnly, CHAIN_ID);
+        const pkSig = simple.signUserOperation(op, PK1, CHAIN_ID);
+        expect(tdSig).toBe(pkSig);
+    });
+
+    test('rejects signer with neither signHash nor signTypedData', async () => {
+        const empty = { address: owner };
         await expect(
-            simple.signUserOperationWithSigner(op, tdOnly, CHAIN_ID),
-        ).rejects.toThrow(/accepts: \[hash\]; signer provides: \[typedData\]/);
+            simple.signUserOperationWithSigner(op, empty, CHAIN_ID),
+        ).rejects.toThrow(/No compatible signing scheme/);
     });
 });
 
@@ -637,6 +646,18 @@ describe('Simple7702AccountV09 signUserOperationWithSigner', () => {
             op, ak.fromPrivateKey(PK1), CHAIN_ID,
         );
         expect(signerSig).toBe(pkSig);
+    });
+
+    test('signTypedData-only signer succeeds (v0.9 userOpHash IS the EIP-712 digest)', async () => {
+        const wallet = new Wallet(PK1);
+        const tdOnly = {
+            address: owner,
+            signTypedData: async (td) =>
+                wallet.signTypedData(td.domain, td.types, td.message),
+        };
+        const tdSig = await simple.signUserOperationWithSigner(op, tdOnly, CHAIN_ID);
+        const pkSig = simple.signUserOperation(op, PK1, CHAIN_ID);
+        expect(tdSig).toBe(pkSig);
     });
 });
 
@@ -724,7 +745,7 @@ describe('Uint8Array-only / secure-dispose signers', () => {
             .rejects.toThrow(/signer disposed/);
     });
 
-    test('works on Simple7702 / Calibur (hash-only accounts)', async () => {
+    test('works on Simple7702 / Calibur via the hash-signing path', async () => {
         const hexPk = '0x' + '55'.repeat(32);
         const bytes = getBytes(hexPk);
         const signer = fromPrivateKeyBytes(bytes);

--- a/test/simple/simple7702TypedData.test.js
+++ b/test/simple/simple7702TypedData.test.js
@@ -1,0 +1,251 @@
+const { Wallet, computeAddress, recoverAddress, AbiCoder } = require('ethers');
+const ak = require('../../dist/index.cjs');
+require('dotenv').config();
+
+jest.setTimeout(60000);
+
+const ENTRYPOINT_V8 = "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108";
+const ENTRYPOINT_V9 = "0x433709009B8330FDa32311DF1C2AFA402eD8D009";
+const ENTRYPOINT_V7 = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+
+const chainId = BigInt(process.env.CHAIN_ID ?? "11155111");
+// Use a deterministic test key when PRIVATE_KEY1 is unset so unit tests can
+// run without a .env. Hash equivalence checks are signature-based, not
+// requiring a funded account.
+const TEST_PRIVATE_KEY = process.env.PRIVATE_KEY1
+    ?? "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const wallet = new Wallet(TEST_PRIVATE_KEY);
+const ownerAddress = wallet.address;
+
+// Build a baseline UserOperationV8 with placeholder gas/fee values.
+function makeUserOpV8(overrides = {}) {
+    return {
+        sender: ownerAddress,
+        nonce: 7n,
+        factory: null,
+        factoryData: null,
+        callData: "0xb61d27f6"
+            + "000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+            + "0000000000000000000000000000000000000000000000000000000000000060"
+            + "0000000000000000000000000000000000000000000000000000000000000000",
+        callGasLimit: 100000n,
+        verificationGasLimit: 200000n,
+        preVerificationGas: 50000n,
+        maxFeePerGas: 1500000000n,
+        maxPriorityFeePerGas: 100000000n,
+        paymaster: null,
+        paymasterVerificationGasLimit: null,
+        paymasterPostOpGasLimit: null,
+        paymasterData: null,
+        signature: "0x" + "00".repeat(65),
+        eip7702Auth: null,
+        ...overrides,
+    };
+}
+
+function withPaymaster(op) {
+    return {
+        ...op,
+        paymaster: "0xcccccccccccccccccccccccccccccccccccccccc",
+        paymasterVerificationGasLimit: 50000n,
+        paymasterPostOpGasLimit: 30000n,
+        paymasterData: "0xdeadbeef",
+    };
+}
+
+function withEip7702Auth(op) {
+    return {
+        ...op,
+        factory: "0x7702",
+        factoryData: null,
+        eip7702Auth: {
+            chainId: "0x1",
+            address: "0xe6Cae83BdE06E4c305530e199D7217f42808555B",
+            nonce: "0x0",
+            yParity: "0x0",
+            r: "0x4277ba564d2c138823415df0ec8e8f97f30825056d54ec5128a8b29ec2dd81b2",
+            s: "0x1075a1bec7f59848cca899ece93075199cd2aabceb0654b9ae00b881a30044cd",
+        },
+    };
+}
+
+function batchedCallData() {
+    // executeBatch((address,uint256,bytes)[])
+    const abi = AbiCoder.defaultAbiCoder();
+    const encoded = abi.encode(
+        ["(address,uint256,bytes)[]"],
+        [[
+            ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1000n, "0xabcd"],
+            ["0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 0n, "0x"],
+        ]],
+    );
+    return "0x34fcd5be" + encoded.slice(2);
+}
+
+const PERMUTATIONS = [
+    { name: "no paymaster, no eip7702Auth, single call", build: () => makeUserOpV8() },
+    { name: "with paymaster, no eip7702Auth", build: () => withPaymaster(makeUserOpV8()) },
+    { name: "no paymaster, with eip7702Auth", build: () => withEip7702Auth(makeUserOpV8()) },
+    { name: "with paymaster + eip7702Auth", build: () => withPaymaster(withEip7702Auth(makeUserOpV8())) },
+    { name: "batched callData, no paymaster", build: () => makeUserOpV8({ callData: batchedCallData() }) },
+    { name: "batched callData, with paymaster + eip7702Auth", build: () => withPaymaster(withEip7702Auth(makeUserOpV8({ callData: batchedCallData() }))) },
+];
+
+describe('signTypedData / signHash byte-equivalence (v0.8)', () => {
+    PERMUTATIONS.forEach(({ name, build }) => {
+        test(name, async () => {
+            const account = new ak.Simple7702Account(ownerAddress);
+            const userOp = build();
+
+            // Path A: raw-hash signing
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId);
+            const sigA = wallet.signingKey.sign(userOpHash).serialized;
+
+            // Path B: typed-data signing
+            const td = account.getUserOperationEip712TypedData(userOp, chainId);
+            const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
+
+            expect(sigB).toBe(sigA);
+            expect(recoverAddress(userOpHash, sigB).toLowerCase())
+                .toBe(ownerAddress.toLowerCase());
+        });
+    });
+});
+
+describe('signTypedData / signHash byte-equivalence (v0.9)', () => {
+    PERMUTATIONS.forEach(({ name, build }) => {
+        test(name, async () => {
+            const account = new ak.Simple7702AccountV09(ownerAddress);
+            const userOp = build();
+
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
+            const sigA = wallet.signingKey.sign(userOpHash).serialized;
+
+            const td = account.getUserOperationEip712TypedData(userOp, chainId);
+            const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
+
+            expect(sigB).toBe(sigA);
+            expect(recoverAddress(userOpHash, sigB).toLowerCase())
+                .toBe(ownerAddress.toLowerCase());
+        });
+    });
+
+    test('paymaster with magic signature suffix uses stripped form for hashing', async () => {
+        const account = new ak.Simple7702AccountV09(ownerAddress);
+        // 32 bytes of paymaster-side data, then 2 bytes sigLen=64, 64 bytes
+        // signature, then 8 bytes magic = 0x22e325a297439656
+        const sigBytes = "11".repeat(64);
+        const sigLenHex = "0040";
+        const prefix = "ab".repeat(32);
+        const magic = "22e325a297439656";
+        const userOp = {
+            ...makeUserOpV8(),
+            paymaster: "0xcccccccccccccccccccccccccccccccccccccccc",
+            paymasterVerificationGasLimit: 50000n,
+            paymasterPostOpGasLimit: 30000n,
+            paymasterData: "0x" + prefix + sigBytes + sigLenHex + magic,
+        };
+
+        const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
+        const sigA = wallet.signingKey.sign(userOpHash).serialized;
+
+        const td = account.getUserOperationEip712TypedData(userOp, chainId);
+        const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
+
+        expect(sigB).toBe(sigA);
+    });
+});
+
+describe('getUserOperationEip712TypedData domain', () => {
+    test('v0.8 domain uses entrypoint v0.8 verifyingContract', () => {
+        const account = new ak.Simple7702Account(ownerAddress);
+        const td = account.getUserOperationEip712TypedData(makeUserOpV8(), chainId);
+        expect(td.domain.name).toBe("ERC4337");
+        expect(td.domain.version).toBe("1");
+        expect(td.domain.chainId).toBe(chainId);
+        expect(td.domain.verifyingContract).toBe(ENTRYPOINT_V8);
+        expect(td.primaryType).toBe("PackedUserOperation");
+    });
+
+    test('v0.9 domain uses entrypoint v0.9 verifyingContract', () => {
+        const account = new ak.Simple7702AccountV09(ownerAddress);
+        const td = account.getUserOperationEip712TypedData(makeUserOpV8(), chainId);
+        expect(td.domain.verifyingContract).toBe(ENTRYPOINT_V9);
+    });
+
+    test('throws on v0.7 EntryPoint override', () => {
+        const account = new ak.Simple7702Account(ownerAddress, {
+            entrypointAddress: ENTRYPOINT_V7,
+        });
+        expect(() => account.getUserOperationEip712TypedData(makeUserOpV8(), chainId))
+            .toThrow(/typed data|EntryPoint v0\.8|v0\.9/i);
+    });
+});
+
+describe('signUserOperationWithSigner scheme dispatch', () => {
+    function makeAccountAndOp() {
+        const account = new ak.Simple7702Account(ownerAddress);
+        const userOp = makeUserOpV8();
+        return { account, userOp };
+    }
+
+    test('signer with both schemes prefers typedData', async () => {
+        const { account, userOp } = makeAccountAndOp();
+        let typedDataCalled = false;
+        let hashCalled = false;
+        const signer = {
+            address: ownerAddress,
+            signTypedData: async (td) => {
+                typedDataCalled = true;
+                return wallet.signTypedData(td.domain, td.types, td.message);
+            },
+            signHash: async (hash) => {
+                hashCalled = true;
+                return wallet.signingKey.sign(hash).serialized;
+            },
+        };
+        const sig = await account.signUserOperationWithSigner(userOp, signer, chainId);
+        expect(typedDataCalled).toBe(true);
+        expect(hashCalled).toBe(false);
+        const expected = wallet.signingKey.sign(
+            ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId),
+        ).serialized;
+        expect(sig).toBe(expected);
+    });
+
+    test('signTypedData-only signer succeeds', async () => {
+        const { account, userOp } = makeAccountAndOp();
+        const signer = {
+            address: ownerAddress,
+            signTypedData: async (td) =>
+                wallet.signTypedData(td.domain, td.types, td.message),
+        };
+        const sig = await account.signUserOperationWithSigner(userOp, signer, chainId);
+        const expected = wallet.signingKey.sign(
+            ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId),
+        ).serialized;
+        expect(sig).toBe(expected);
+    });
+
+    test('signHash-only signer falls back to hash scheme', async () => {
+        const { account, userOp } = makeAccountAndOp();
+        const signer = {
+            address: ownerAddress,
+            signHash: async (hash) => wallet.signingKey.sign(hash).serialized,
+        };
+        const sig = await account.signUserOperationWithSigner(userOp, signer, chainId);
+        const expected = wallet.signingKey.sign(
+            ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId),
+        ).serialized;
+        expect(sig).toBe(expected);
+    });
+
+    test('signer with neither method throws', async () => {
+        const { account, userOp } = makeAccountAndOp();
+        const signer = { address: ownerAddress };
+        await expect(
+            account.signUserOperationWithSigner(userOp, signer, chainId),
+        ).rejects.toThrow(/No compatible signing scheme/);
+    });
+});


### PR DESCRIPTION
I will follow up with another PR to add support for typed data signing for both SimpleAccount (non 7702) and Calibur Account.

---

EntryPoint v0.8 / v0.9 introduced an EIP-712 domain at the EntryPoint contract; the `userOpHash` IS the EIP-712 digest of `PackedUserOperation` under that domain. This PR loosens `Simple7702Account` and `Simple7702AccountV09` from `ACCEPTED_SIGNING_SCHEMES = ["hash"]` to `["typedData", "hash"]` so JSON-RPC wallets and viem `WalletClient` (signTypedData-only) work without wrapping.

### Design choice

Consistent with the discussion that selected #142 over #136: extends signer support without expanding SDK internals. No new `SigningScheme` value, no new `Signer` union variant, no new `sign*` method on accounts. Just loosens an existing gate and reuses the existing `pickScheme` / `invokeSigner` dispatch. Containment is one base class (`BaseSimple7702Account`); V8 and V09 inherit. Calibur and Safe are untouched.

The only public addition is `getUserOperationEip712TypedData(userOp, chainId)` as a lower-level escape hatch, mirroring the already-public `createUserOperationHash`. EIP-712 is the open standard for structured data signing; an SDK that targets ERC-4337 should expose it as a first-class concept rather than burying it inside a signer-only API.

### Path A (recommended): pass any `signTypedData`-capable signer

```ts
const account = new Simple7702Account(eoaAddress)
const userOp = await account.createUserOperation(
  [tx], nodeRpc, bundlerRpc, { eip7702Auth: { chainId } },
)

userOp.signature = await account.signUserOperationWithSigner(
  userOp,
  fromViemWalletClient(walletClient), // signTypedData-only
  chainId,
)
```

An `ExternalSigner` is just an object literal; no adapter function needed. Wrap any signing primitive inline:

```ts
const signer: ExternalSigner = {
  address: ownerAddress,
  signTypedData: async (td) => myWallet.signTypedData(td),
}
userOp.signature = await account.signUserOperationWithSigner(userOp, signer, chainId)
```

### Path B (escape hatch): drive `signTypedData` yourself

For integrators with their own signing primitive (HSM, MPC, custom wallet abstraction) or who want to render a custom confirmation UI before passing to a wallet:

```ts
const typedData = account.getUserOperationEip712TypedData(userOp, chainId)
userOp.signature = await wallet.signTypedData(
  typedData.domain, typedData.types, typedData.message,
)
```

Both paths produce signatures that validate against the same `userOpHash`. Existing `signHash` / private-key signers continue to work unchanged. Throws with a clear error on EntryPoint v0.6 / v0.7 (those wrap with `eth_sign`, so typed-data signatures don't validate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EIP-712 `signTypedData` signing support for Simple7702 UserOperations targeting EntryPoint v0.8/v0.9.
  * Dual signing capability now supports both typed data and hash-based signing schemes.
  * Enhanced signer compatibility with automatic scheme selection.

* **Documentation**
  * Updated method documentation to reflect new signing capabilities and supported signer types.

* **Tests**
  * Added comprehensive test coverage validating EIP-712 typed data signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
