### PR TITLE
docs(comments): explain +55000 verificationGasLimit buffer

### DIFF
--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -499,8 +499,13 @@ export class Calibur7702Account
 				preVerificationGas = BigInt(estimation.preVerificationGas);
 				verificationGasLimit = BigInt(estimation.verificationGasLimit);
 				callGasLimit = BigInt(estimation.callGasLimit);
-				// Safety margin for P-256/WebAuthn signature verification overhead
-				// that the bundler's simulation may underestimate.
+				// Compensate for signature verification cost the bundler skips
+				// during `eth_estimateUserOperationGas`: estimation runs with a
+				// dummy signature whose signature path is short-circuited
+				// (the dummy doesn't recover to a real key, so the bundler
+				// bypasses signature validation). ~55k gas covers the on-chain
+				// signature path that simulation never paid for, whether the
+				// real key is secp256k1 (ECRECOVER), P-256, or WebAuthn-P256.
 				verificationGasLimit += 55_000n;
 
 				userOperation.maxFeePerGas = inputMaxFeePerGas;

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1704,6 +1704,15 @@ export class SafeAccount extends SmartAccount {
 						stateOverrideSet: overrides.state_override_set,
 						isMultiChainSignature: overrides.isMultiChainSignature,
 					});
+				// Compensate for per-signer signature verification cost the
+				// bundler skips during `eth_estimateUserOperationGas`:
+				// estimation runs with dummy signatures whose signature paths
+				// are short-circuited (dummies don't recover to real owners,
+				// so the bundler bypasses signature validation). Safe iterates
+				// owner signatures inside `validateUserOp`, so each real
+				// signature pays ~55k gas at inclusion that simulation never
+				// paid for. The same pattern (without the per-signer
+				// multiplier) appears in Simple7702 and Calibur.
 				verificationGasLimit += BigInt(dummySignerSignaturePairs.length) * 55_000n;
 
 				userOperation.maxFeePerGas = inputMaxFeePerGas;

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -636,6 +636,12 @@ export class BaseSimple7702Account extends SmartAccount {
 					await this.baseEstimateUserOperationGas(userOperationToEstimate, bundlerRpc, {
 						stateOverrideSet: overrides.state_override_set,
 					});
+				// Compensate for ECDSA verification cost the bundler skips during
+				// `eth_estimateUserOperationGas`: estimation runs with a dummy
+				// signature whose signature path is short-circuited (the dummy
+				// doesn't recover to a real owner, so the bundler bypasses
+				// signature validation). ~55k gas is the on-chain ECRECOVER +
+				// signature decode cost that simulation never paid for.
 				verificationGasLimit += 55_000n;
 
 				userOperation.maxFeePerGas = inputMaxFeePerGas;


### PR DESCRIPTION
Comment-only change. No behavior difference.

The `+55_000n` added to `verificationGasLimit` after bundler estimation across `Simple7702Account`, `Calibur7702Account`, and `SafeAccount` has been load-bearing since v0.2.14 with no inline explanation.

It compensates for signature verification cost the bundler skips during `eth_estimateUserOperationGas`: estimation runs with a dummy signature whose signature path is short-circuited (the dummy doesn't recover to a real owner, so the bundler bypasses signature validation). ~55k gas is the on-chain ECRECOVER + signature decode cost that simulation never paid for.

- Safe applies it per signer (it iterates owner signatures inside `validateUserOp`).
- Simple7702 and Calibur apply it once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced gas estimation for account operations to accurately account for signature verification overhead that was previously underestimated during simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->