### PR TITLE
fix(signer): make callback context optional

### DIFF
--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -63,8 +63,9 @@ function buildMismatchMessage(params: {
  * account-side code stays linear. `typedData` is optional: accounts that
  * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
  *
- * `context` is always forwarded to the signer so power-user implementations
- * can inspect the userOp.
+ * The SDK always forwards `context` here so power-user implementations can
+ * inspect the userOp. The public callback type still keeps context optional
+ * for direct signer calls outside an account method.
  */
 export async function invokeSigner<C>(
 	signer: Signer<C>,

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -83,25 +83,28 @@ interface SignerBase {
  * Sign a 32-byte hash raw (no EIP-191 prefix). Required for Simple7702 /
  * Calibur; acceptable fallback for Safe.
  *
- * Generic over the context type the SDK will pass. Defaults to
+ * Generic over the context type the SDK will pass when signing through an
+ * account. The context argument is optional so direct calls to a signer can
+ * use `signer.signHash(hash)` without passing a placeholder. Defaults to
  * {@link SignContext} (single-op) — set explicitly to
  * {@link MultiOpSignContext} for multi-op signers, or to `unknown` for
  * universal/context-agnostic signers like the built-in adapters.
  */
 export type SignHashFn<C = SignContext> = (
 	hash: `0x${string}`,
-	context: C,
+	context?: C,
 ) => Promise<`0x${string}`>;
 
 /**
  * Sign an EIP-712 typed data payload. Preferred for Safe because wallets
  * can display structured fields instead of a hex blob.
  *
- * Generic over context — see {@link SignHashFn}.
+ * Generic over context — see {@link SignHashFn}. The SDK passes context when
+ * it invokes the signer, but direct callers may omit it.
  */
 export type SignTypedDataFn<C = SignContext> = (
 	data: TypedData,
-	context: C,
+	context?: C,
 ) => Promise<`0x${string}`>;
 
 /**


### PR DESCRIPTION
## Summary
- make signer callback context optional for direct signHash(hash) and signTypedData(data) usage
- keep SDK account signing paths forwarding context for custom signers
- update signer invocation docs to describe the distinction

## Test
- npm run build
- npx jest --runTestsByPath test/signer/signer.test.js --runInBand
- npm run lint