### PR TITLE
chore(repo): add quality guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+-
+
+## Test
+
+-
+
+## Risk / Compatibility
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # ============================================
-# CI Pipeline — Build Only
+# CI Pipeline
 # ============================================
-# Verifies that the main project builds successfully.
+# Verifies that the main project builds and core offline checks pass.
 
 name: CI
 
@@ -36,5 +36,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Lint
+        run: yarn lint
+
+      - name: Type tests
+        run: yarn test:types
+
       - name: Build
         run: yarn build
+
+      - name: Signer unit tests
+        run: yarn test:signer

--- a/docs/signers.md
+++ b/docs/signers.md
@@ -1,0 +1,28 @@
+# Signers
+
+AbstractionKit uses capability-oriented signers for account methods that accept external signing backends. A signer exposes an address and at least one signing method:
+
+- `signHash(hash, context)` signs a raw 32-byte digest with no EIP-191 prefix.
+- `signTypedData(data, context)` signs an EIP-712 payload.
+
+Account implementations choose the best supported scheme for the operation. Safe accounts prefer typed data when available, while Simple7702, Calibur, and Safe multi-chain Merkle signing require raw hash signing.
+
+## Built-in adapters
+
+- `fromPrivateKey(privateKey)` exposes both hash and typed-data signing.
+- `fromEthersWallet(wallet)` exposes both hash and typed-data signing.
+- `fromViem(account)` exposes both hash and typed-data signing for viem local accounts.
+- `fromViemWalletClient(client)` exposes typed-data signing only, which fits browser and JSON-RPC wallets.
+- `fromSafeWebauthn(params)` exposes hash signing only and marks the signer as a Safe contract signer.
+
+## Context
+
+The SDK passes context whenever it invokes a signer through an account method. Single-operation paths receive `{ userOperation, chainId, entryPoint }`. Safe multi-chain Merkle signing receives `{ userOperations, entryPoint }`.
+
+Use context in custom signers for policy checks, audit logs, user prompts, or telemetry. Built-in local-key adapters intentionally ignore context because they only adapt lower-level signing primitives.
+
+## Safe Contract Signers
+
+Safe WebAuthn and EIP-1271 signers must be tagged with `type: "contract"` so Safe signature formatting uses a dynamic contract-signature segment. EOA signers can omit `type` or set `type: "ecdsa"`.
+
+For WebAuthn, pass the same account class and WebAuthn overrides used when the Safe was initialized. The signer address is the shared signer for init operations and the deterministic verifier proxy after deployment.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+	testEnvironment: "node",
+	modulePathIgnorePatterns: ["/.worktrees/"],
+	testPathIgnorePatterns: ["/node_modules/", "/dist/", "/.worktrees/"],
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
 		"prepare": "tsdown",
 		"clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
 		"test": "jest --verbose",
+		"test:signer": "jest --runTestsByPath test/signer/signer.test.js --runInBand",
+		"test:types": "tsc -p test/types/tsconfig.json --noEmit",
 		"lint": "biome lint src",
 		"format": "biome format --write src",
 		"check": "biome check --write src"

--- a/src/account/Safe/adapters.ts
+++ b/src/account/Safe/adapters.ts
@@ -277,8 +277,8 @@ function coerceBigint(v: bigint | string | number, field: string): bigint {
  */
 export function pubkeyCoordinatesToJson(pubkey: WebauthnPublicKey): string {
 	return JSON.stringify({
-		x: "0x" + pubkey.x.toString(16),
-		y: "0x" + pubkey.y.toString(16),
+		x: `0x${pubkey.x.toString(16)}`,
+		y: `0x${pubkey.y.toString(16)}`,
 	});
 }
 

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -58,6 +58,47 @@ function buildSimpleOp(owner) {
     };
 }
 
+function byteLength(hex) {
+    return (hex.length - 2) / 2;
+}
+
+// ─── Signature formatting fixtures ─────────────────────────────────────
+
+describe('Safe signature formatting fixtures', () => {
+    test('EOA signature stays inline after the validity window', () => {
+        const wallet = new Wallet(PK1);
+        const signature = wallet.signingKey.sign('0x' + '11'.repeat(32)).serialized;
+
+        const formatted = ak.SafeAccountV0_3_0.formatSignaturesToUseroperationSignature([
+            { signer: wallet.address, signature },
+        ]);
+
+        expect(byteLength(formatted)).toBe(12 + 65);
+        expect(formatted.endsWith(signature.slice(2))).toBe(true);
+    });
+
+    test('contract signature uses an offset segment plus dynamic bytes', () => {
+        const contractSigner = '0x1000000000000000000000000000000000000000';
+        const contractSignature = '0x' + 'ab'.repeat(96);
+
+        const formatted = ak.SafeAccountV0_3_0.formatSignaturesToUseroperationSignature([
+            {
+                signer: contractSigner,
+                signature: contractSignature,
+                isContractSignature: true,
+            },
+        ]);
+
+        expect(byteLength(formatted)).toBe(12 + 65 + 32 + 96);
+        const body = formatted.slice(2 + 24).toLowerCase();
+        expect(body.slice(0, 64)).toBe(contractSigner.slice(2).padStart(64, '0'));
+        expect(body.slice(64, 128)).toBe('41'.padStart(64, '0'));
+        expect(body.slice(128, 130)).toBe('00');
+        expect(body.slice(130, 194)).toBe('60'.padStart(64, '0'));
+        expect(body.slice(194)).toBe(contractSignature.slice(2));
+    });
+});
+
 // ─── Adapter tests ───────────────────────────────────────────────────────
 
 describe('fromPrivateKey adapter', () => {

--- a/test/types/signer-api.ts
+++ b/test/types/signer-api.ts
@@ -1,0 +1,97 @@
+import {
+	fromEthersWallet,
+	fromPrivateKey,
+	fromSafeWebauthn,
+	type ExternalSigner,
+	type MultiOpSignContext,
+	type SignContext,
+	type TypedData,
+	type UserOperationV9,
+} from "../../src/index";
+
+const address = "0x0000000000000000000000000000000000000001" as const;
+const signature = "0x1234" as `0x${string}`;
+
+const hashOnlySigner: ExternalSigner = {
+	address,
+	signHash: async (_hash) => signature,
+};
+
+const typedDataOnlySigner: ExternalSigner = {
+	address,
+	signTypedData: async (_typedData) => signature,
+};
+
+const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
+	address,
+	signHash: async (_hash, context) => {
+		context.userOperation.sender;
+		context.chainId;
+		context.entryPoint;
+		return signature;
+	},
+	signTypedData: async (_typedData, context) => {
+		context.userOperation.sender;
+		return signature;
+	},
+};
+
+const multiOpSigner: ExternalSigner<MultiOpSignContext<UserOperationV9>> = {
+	address,
+	signHash: async (_hash, context) => {
+		context.userOperations[0]?.chainId;
+		context.entryPoint;
+		return signature;
+	},
+};
+
+const typedData: TypedData = {
+	domain: {
+		name: "Safe",
+		version: "1",
+		chainId: 1n,
+		verifyingContract: address,
+	},
+	types: {
+		SafeOp: [{ name: "sender", type: "address" }],
+	},
+	primaryType: "SafeOp",
+	message: { sender: address },
+};
+
+void typedData;
+void hashOnlySigner;
+void typedDataOnlySigner;
+void dualSchemeSigner;
+void multiOpSigner;
+
+const universalSigner: ExternalSigner<unknown> = fromPrivateKey(`0x${"11".repeat(32)}`);
+void universalSigner;
+
+const ethersLikeSigner = fromEthersWallet({
+	address,
+	signingKey: {
+		sign: () => ({ serialized: signature }),
+	},
+	signTypedData: async () => signature,
+});
+void ethersLikeSigner;
+
+const webauthnSigner: ExternalSigner<unknown> = fromSafeWebauthn({
+	publicKey: { x: 1n, y: 2n },
+	isInit: true,
+	accountClass: {
+		DEFAULT_WEB_AUTHN_SHARED_SIGNER: address,
+		DEFAULT_WEB_AUTHN_SIGNER_FACTORY: address,
+		DEFAULT_WEB_AUTHN_SIGNER_SINGLETON: address,
+		DEFAULT_WEB_AUTHN_SIGNER_PROXY_CREATION_CODE: "0x00",
+		DEFAULT_WEB_AUTHN_PRECOMPILE: address,
+		DEFAULT_WEB_AUTHN_CONTRACT_VERIFIER: address,
+	},
+	getAssertion: async () => ({
+		authenticatorData: new Uint8Array(37).buffer,
+		clientDataFields: "0x",
+		rs: [1n, 2n],
+	}),
+});
+void webauthnSigner;

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["./*.ts"],
+	"exclude": []
+}


### PR DESCRIPTION
## Summary
- add Jest config to ignore local .worktrees and add a focused signer test script
- add TypeScript public API type tests for signer interfaces and adapters
- add offline Safe signature-format fixtures for EOA and contract signatures
- wire CI to run lint, type tests, build, and signer unit tests
- add signer API docs and a PR template
- clean current Biome style notes in Safe WebAuthn adapter helpers

## Test
- npm run test:types
- npm run lint
- npm run build
- npm run test:signer

## Risk / Compatibility
- no runtime API changes
- CI now runs additional offline checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive signer documentation covering capabilities, adapter constructors, context objects, and WebAuthn configuration.

* **Tests**
  * Added signer API type tests and signature formatting validation for Safe compatibility.

* **Chores**
  * Enhanced CI workflow with linting, type checking, and signer tests.
  * Added Jest and TypeScript test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->