### PR TITLE
fix(safe): return per-op SafeOp hash for length=1 multi-chain helper

### DIFF
--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -770,8 +770,14 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 *
 	 * Throws for length=1: the on-chain depth=0 path verifies against the per-op
 	 * SafeOp digest, not a Merkle wrapper, so the wrapper typed data would be
-	 * misleading. Use {@link SafeAccountV0_3_0.getUserOperationEip712Data}
-	 * (or {@link getUserOperationEip712Hash_V9}) for single-op signing.
+	 * misleading. Use {@link SafeMultiChainSigAccountV1.getUserOperationEip712Data}
+	 * (or {@link SafeMultiChainSigAccountV1.getUserOperationEip712Hash}) for
+	 * single-op signing: those multichain-class overrides default
+	 * `safe4337ModuleAddress` to `DEFAULT_SAFE_4337_MODULE_ADDRESS`. The parent
+	 * `SafeAccount.getUserOperationEip712Data_V9` / `getUserOperationEip712Hash_V9`
+	 * helpers default to a different module and would hash against the wrong
+	 * verifying contract unless `overrides.safe4337ModuleAddress` is supplied
+	 * explicitly.
 	 *
 	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs
 	 * @param overrides - optional overrides for the Safe 4337 module address
@@ -791,8 +797,14 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		if (userOperationsToSign.length < 2) {
 			throw new RangeError(
 				"getMultiChainSingleSignatureUserOperationsEip712Data requires >= 2 userOperations. " +
-					"For a single UserOperation, use SafeAccount.getUserOperationEip712Data_V9 / getUserOperationEip712Hash_V9: " +
-					"the on-chain depth=0 path verifies against the per-op SafeOp digest, not a Merkle wrapper.",
+					"For a single UserOperation, use SafeMultiChainSigAccountV1.getUserOperationEip712Data " +
+					"or SafeMultiChainSigAccountV1.getUserOperationEip712Hash (these multichain-class overrides " +
+					"default safe4337ModuleAddress to DEFAULT_SAFE_4337_MODULE_ADDRESS, the multi-chain module). " +
+					"The on-chain depth=0 path verifies against the per-op SafeOp digest, not a Merkle wrapper. " +
+					"If calling the parent SafeAccount.getUserOperationEip712Data_V9 / getUserOperationEip712Hash_V9 " +
+					"helpers directly, you must pass overrides.safe4337ModuleAddress = " +
+					"SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS explicitly so signatures hash " +
+					"the correct verifying contract.",
 			);
 		}
 		const safe4337ModuleAddress =

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -720,8 +720,18 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
-	 * Compute the EIP-712 hash of a multi-chain Merkle tree root for a set of UserOperations.
-	 * This hash is what signers sign to approve multiple cross-chain operations at once.
+	 * Compute the EIP-712 hash that owners must sign for a multi-chain bundle.
+	 *
+	 * For length≥2: returns the Merkle root wrapper digest signed once across
+	 * all UserOperations.
+	 *
+	 * For length=1: returns the per-UserOperation SafeOp digest, matching the
+	 * `merkleTreeDepth == 0` branch on the deployed Safe4337MultiChainSignatureModule
+	 * (which validates against `keccak256(SafeOp)` directly, not the Merkle wrapper).
+	 * Returning the wrapper here would produce a signature the on-chain depth=0
+	 * path rejects with AA24: the formatter still emits the depth=0 layout the
+	 * contract expects, so the digest must match.
+	 *
 	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs
 	 * @param overrides - optional overrides for the Safe 4337 module address
 	 * @returns the EIP-712 hash as a hex string
@@ -730,8 +740,23 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		userOperationsToSignsToSign: UserOperationToSign[],
 		overrides: {
 			safe4337ModuleAddress?: string;
+			entrypointAddress?: string;
 		} = {},
 	): string {
+		if (userOperationsToSignsToSign.length < 1) {
+			throw new RangeError("There should be at least one userOperationsToSign");
+		}
+		if (userOperationsToSignsToSign.length === 1) {
+			const u = userOperationsToSignsToSign[0];
+			return SafeAccount.getUserOperationEip712Hash_V9(u.userOperation, u.chainId, {
+				validAfter: u.validAfter,
+				validUntil: u.validUntil,
+				safe4337ModuleAddress:
+					overrides.safe4337ModuleAddress ??
+					SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
+				entrypointAddress: overrides.entrypointAddress,
+			});
+		}
 		const data = SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Data(
 			userOperationsToSignsToSign,
 			overrides,
@@ -742,6 +767,12 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	/**
 	 * Get the EIP-712 typed data components for a multi-chain Merkle tree root.
 	 * Returns the domain, types, and message value needed for signing or hashing.
+	 *
+	 * Throws for length=1: the on-chain depth=0 path verifies against the per-op
+	 * SafeOp digest, not a Merkle wrapper, so the wrapper typed data would be
+	 * misleading. Use {@link SafeAccountV0_3_0.getUserOperationEip712Data}
+	 * (or {@link getUserOperationEip712Hash_V9}) for single-op signing.
+	 *
 	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs
 	 * @param overrides - optional overrides for the Safe 4337 module address
 	 * @returns an object with domain, types, and messageValue for EIP-712 signing
@@ -757,8 +788,12 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		types: Record<string, { name: string; type: string }[]>;
 		messageValue: MultiChainSignatureMerkleTreeRootTypedMessageValue;
 	} {
-		if (userOperationsToSign.length < 1) {
-			throw new RangeError("There should be at least one userOperationsToSign");
+		if (userOperationsToSign.length < 2) {
+			throw new RangeError(
+				"getMultiChainSingleSignatureUserOperationsEip712Data requires >= 2 userOperations. " +
+					"For a single UserOperation, use SafeAccount.getUserOperationEip712Data_V9 / getUserOperationEip712Hash_V9: " +
+					"the on-chain depth=0 path verifies against the per-op SafeOp digest, not a Merkle wrapper.",
+			);
 		}
 		const safe4337ModuleAddress =
 			overrides.safe4337ModuleAddress ??

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -602,6 +602,50 @@ describe('SafeMultiChainSigAccountV1 signUserOperationWithSigners', () => {
         );
         expect(newSigs).toEqual(legacySigs);
     });
+
+    // The on-chain Safe4337MultiChainSignatureModule's `merkleTreeDepth == 0`
+    // branch verifies against `keccak256(SafeOp)` directly, not the Merkle
+    // wrapper. Returning the wrapper from this helper for length=1 produced
+    // signatures the contract rejected with AA24.
+    test('getMultiChainSingleSignatureUserOperationsEip712Hash length=1 returns the per-op SafeOp hash', () => {
+        const length1Hash = ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash(
+            [{ userOperation: op, chainId: CHAIN_ID, validAfter: 0n, validUntil: 0n }],
+        );
+        const perOpHash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash_V9(
+            op,
+            CHAIN_ID,
+            { safe4337ModuleAddress: ak.SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS },
+        );
+        expect(length1Hash).toBe(perOpHash);
+    });
+
+    test('getMultiChainSingleSignatureUserOperationsEip712Hash length=2 returns the Merkle wrapper hash', () => {
+        const op2 = { ...op, nonce: 1n };
+        const ops = [
+            { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
+            { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
+        ];
+        const wrapperHash = ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash(ops);
+        const perOpHash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash_V9(
+            op, 1n,
+            { safe4337ModuleAddress: ak.SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS },
+        );
+        expect(wrapperHash).not.toBe(perOpHash);
+    });
+
+    test('getMultiChainSingleSignatureUserOperationsEip712Data throws for length=1', () => {
+        expect(() =>
+            ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Data(
+                [{ userOperation: op, chainId: CHAIN_ID, validAfter: 0n, validUntil: 0n }],
+            ),
+        ).toThrow(RangeError);
+    });
+
+    test('getMultiChainSingleSignatureUserOperationsEip712Hash throws for empty input', () => {
+        expect(() =>
+            ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash([]),
+        ).toThrow(RangeError);
+    });
 });
 
 // ─── Single-signer accounts (singular method name) ──────────────────────


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Single-operation bundles now produce the direct per-operation signature digest for faster handling.
  * Multi-operation bundles continue to use the Merkle-style wrapper hash.
  * Added optional entrypoint override for hashing to ensure correct verifying contract is used.

* **Bug Fixes / Validation**
  * Strengthened input validation: empty inputs are rejected; helpers enforce single vs. multi-op requirements with clear errors.

* **Tests**
  * Added tests covering single-op, multi-op, and invalid-input behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->