### PR TITLE
fix(test): use optional chaining for signer context in type test

### DIFF
--- a/test/types/signer-api.ts
+++ b/test/types/signer-api.ts
@@ -25,13 +25,13 @@ const typedDataOnlySigner: ExternalSigner = {
 const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
 	address,
 	signHash: async (_hash, context) => {
-		context.userOperation.sender;
-		context.chainId;
-		context.entryPoint;
+		context?.userOperation.sender;
+		context?.chainId;
+		context?.entryPoint;
 		return signature;
 	},
 	signTypedData: async (_typedData, context) => {
-		context.userOperation.sender;
+		context?.userOperation.sender;
 		return signature;
 	},
 };
@@ -39,8 +39,8 @@ const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
 const multiOpSigner: ExternalSigner<MultiOpSignContext<UserOperationV9>> = {
 	address,
 	signHash: async (_hash, context) => {
-		context.userOperations[0]?.chainId;
-		context.entryPoint;
+		context?.userOperations[0]?.chainId;
+		context?.entryPoint;
 		return signature;
 	},
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of test signers to handle optional context parameters gracefully while maintaining signature consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->