### PR TITLE
revert(signer): make callback context required again

### DIFF
--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -63,9 +63,8 @@ function buildMismatchMessage(params: {
  * account-side code stays linear. `typedData` is optional: accounts that
  * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
  *
- * The SDK always forwards `context` here so power-user implementations can
- * inspect the userOp. The public callback type still keeps context optional
- * for direct signer calls outside an account method.
+ * `context` is always forwarded to the signer so power-user implementations
+ * can inspect the userOp.
  */
 export async function invokeSigner<C>(
 	signer: Signer<C>,

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -83,28 +83,25 @@ interface SignerBase {
  * Sign a 32-byte hash raw (no EIP-191 prefix). Required for Simple7702 /
  * Calibur; acceptable fallback for Safe.
  *
- * Generic over the context type the SDK will pass when signing through an
- * account. The context argument is optional so direct calls to a signer can
- * use `signer.signHash(hash)` without passing a placeholder. Defaults to
+ * Generic over the context type the SDK will pass. Defaults to
  * {@link SignContext} (single-op) — set explicitly to
  * {@link MultiOpSignContext} for multi-op signers, or to `unknown` for
  * universal/context-agnostic signers like the built-in adapters.
  */
 export type SignHashFn<C = SignContext> = (
 	hash: `0x${string}`,
-	context?: C,
+	context: C,
 ) => Promise<`0x${string}`>;
 
 /**
  * Sign an EIP-712 typed data payload. Preferred for Safe because wallets
  * can display structured fields instead of a hex blob.
  *
- * Generic over context — see {@link SignHashFn}. The SDK passes context when
- * it invokes the signer, but direct callers may omit it.
+ * Generic over context — see {@link SignHashFn}.
  */
 export type SignTypedDataFn<C = SignContext> = (
 	data: TypedData,
-	context?: C,
+	context: C,
 ) => Promise<`0x${string}`>;
 
 /**

--- a/test/types/signer-api.ts
+++ b/test/types/signer-api.ts
@@ -25,13 +25,13 @@ const typedDataOnlySigner: ExternalSigner = {
 const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
 	address,
 	signHash: async (_hash, context) => {
-		context?.userOperation.sender;
-		context?.chainId;
-		context?.entryPoint;
+		context.userOperation.sender;
+		context.chainId;
+		context.entryPoint;
 		return signature;
 	},
 	signTypedData: async (_typedData, context) => {
-		context?.userOperation.sender;
+		context.userOperation.sender;
 		return signature;
 	},
 };
@@ -39,8 +39,8 @@ const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
 const multiOpSigner: ExternalSigner<MultiOpSignContext<UserOperationV9>> = {
 	address,
 	signHash: async (_hash, context) => {
-		context?.userOperations[0]?.chainId;
-		context?.entryPoint;
+		context.userOperations[0]?.chainId;
+		context.entryPoint;
 		return signature;
 	},
 };


### PR DESCRIPTION
Reverts #156 and #159.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Breaking Changes
* Signer implementations must now provide a `context` parameter on all function calls. This parameter was previously optional and is now required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->