### PR TITLE
chore(release): 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.6
+
+### Fixes
+
+- **Safe multi-chain single-operation signing now hashes the correct payload.** `SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash` now returns the per-operation SafeOp hash when called with exactly one UserOperation, matching the Safe4337MultiChainSignatureModule `merkleTreeDepth == 0` validation path. This fixes single-operation multi-chain signatures being rejected on-chain with `AA24`.
+- **Safe multi-chain WebAuthn / EIP-1271 signatures keep contract-signer formatting.** `signUserOperationsWithSigners` now preserves the `"contract"` signer type when formatting multi-operation signatures, so dynamic Safe contract-signature segments are emitted correctly.
+
+### Maintenance
+
+- Added signer API documentation, type-level signer tests, signer unit-test coverage, and CI checks for linting, type tests, build, and signer tests.
+
 ## 0.3.5
 
 ### New Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.5   | :white_check_mark: |
+| 0.3.6   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -63,9 +63,8 @@ function buildMismatchMessage(params: {
  * account-side code stays linear. `typedData` is optional: accounts that
  * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
  *
- * The SDK always forwards `context` here so power-user implementations can
- * inspect the userOp. The public callback type still keeps context optional
- * for direct signer calls outside an account method.
+ * `context` is always forwarded to the signer so power-user implementations
+ * can inspect the userOp.
  */
 export async function invokeSigner<C>(
 	signer: Signer<C>,

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -83,28 +83,25 @@ interface SignerBase {
  * Sign a 32-byte hash raw (no EIP-191 prefix). Required for Simple7702 /
  * Calibur; acceptable fallback for Safe.
  *
- * Generic over the context type the SDK will pass when signing through an
- * account. The context argument is optional so direct calls to a signer can
- * use `signer.signHash(hash)` without passing a placeholder. Defaults to
+ * Generic over the context type the SDK will pass. Defaults to
  * {@link SignContext} (single-op) — set explicitly to
  * {@link MultiOpSignContext} for multi-op signers, or to `unknown` for
  * universal/context-agnostic signers like the built-in adapters.
  */
 export type SignHashFn<C = SignContext> = (
 	hash: `0x${string}`,
-	context?: C,
+	context: C,
 ) => Promise<`0x${string}`>;
 
 /**
  * Sign an EIP-712 typed data payload. Preferred for Safe because wallets
  * can display structured fields instead of a hex blob.
  *
- * Generic over context — see {@link SignHashFn}. The SDK passes context when
- * it invokes the signer, but direct callers may omit it.
+ * Generic over context — see {@link SignHashFn}.
  */
 export type SignTypedDataFn<C = SignContext> = (
 	data: TypedData,
-	context?: C,
+	context: C,
 ) => Promise<`0x${string}`>;
 
 /**

--- a/test/types/signer-api.ts
+++ b/test/types/signer-api.ts
@@ -25,13 +25,13 @@ const typedDataOnlySigner: ExternalSigner = {
 const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
 	address,
 	signHash: async (_hash, context) => {
-		context?.userOperation.sender;
-		context?.chainId;
-		context?.entryPoint;
+		context.userOperation.sender;
+		context.chainId;
+		context.entryPoint;
 		return signature;
 	},
 	signTypedData: async (_typedData, context) => {
-		context?.userOperation.sender;
+		context.userOperation.sender;
 		return signature;
 	},
 };
@@ -39,8 +39,8 @@ const dualSchemeSigner: ExternalSigner<SignContext<UserOperationV9>> = {
 const multiOpSigner: ExternalSigner<MultiOpSignContext<UserOperationV9>> = {
 	address,
 	signHash: async (_hash, context) => {
-		context?.userOperations[0]?.chainId;
-		context?.entryPoint;
+		context.userOperations[0]?.chainId;
+		context.entryPoint;
 		return signature;
 	},
 };


### PR DESCRIPTION
## Summary

- Release `abstractionkit@0.3.6`.
- Fix `SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash` for single-operation bundles so it returns the per-op SafeOp hash expected by the on-chain `merkleTreeDepth == 0` path.
- Preserve Safe contract-signer formatting for multi-chain WebAuthn / EIP-1271 signatures.
- Add signer API docs, type tests, signer unit tests, and CI coverage for linting, type tests, build, and signer tests.

## Test

- `yarn lint`
- `yarn test:types`
- `yarn test:signer`
- `yarn build`

## Risk / Compatibility

- Patch release.
- No public API change intended.
- Fixes signatures that could be rejected on-chain for Safe multi-chain single-operation signing and contract-signer multi-operation formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.3.6

* **Bug Fixes**
  * Fixed multi-chain signing to use correct per-operation SafeOp EIP-712 hash calculation.
  * Fixed WebAuthn/EIP-1271 signer formatting to properly preserve contract signature encoding.

* **Documentation**
  * Updated signer callback API documentation to clarify context parameter requirements.

* **Chores**
  * Version bumped to 0.3.6.
  * Updated security policy supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->