### PR TITLE
chore(release): 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.6
+
+### Fixes
+
+- **Safe multi-chain single-operation signing now hashes the correct payload.** `SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash` now returns the per-operation SafeOp hash when called with exactly one UserOperation, matching the Safe4337MultiChainSignatureModule `merkleTreeDepth == 0` validation path. This fixes single-operation multi-chain signatures being rejected on-chain with `AA24`.
+- **Safe multi-chain WebAuthn / EIP-1271 signatures keep contract-signer formatting.** `signUserOperationsWithSigners` now preserves the `"contract"` signer type when formatting multi-operation signatures, so dynamic Safe contract-signature segments are emitted correctly.
+
+### Maintenance
+
+- Added signer API documentation, type-level signer tests, signer unit-test coverage, and CI checks for linting, type tests, build, and signer tests.
+
 ## 0.3.5
 
 ### New Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.5   | :white_check_mark: |
+| 0.3.6   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3140,7 +3140,7 @@ function generateOnChainIdentifier(
 	project: string,
 	platform: "Web" | "Mobile" | "Safe App" | "Widget" = "Web",
 	tool: string = "abstractionkit",
-	toolVersion: string = "0.3.5",
+	toolVersion: string = "0.3.6",
 ): string {
 	const identifierPrefix = "5afe"; // Safe identifier prefix
 	const identifierVersion = "00"; // First version


### PR DESCRIPTION
## Summary

- Release `abstractionkit@0.3.6`.
- Fix `SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash` for single-operation bundles so it returns the per-op SafeOp hash expected by the on-chain `merkleTreeDepth == 0` path.
- Preserve Safe contract-signer formatting for multi-chain WebAuthn / EIP-1271 signatures.
- Add signer API docs, type tests, signer unit tests, and CI coverage for linting, type tests, build, and signer tests.

## Test

- `yarn lint`
- `yarn test:types`
- `yarn test:signer`
- `yarn build`

## Risk / Compatibility

- Patch release.
- No public API change intended.
- Fixes signatures that could be rejected on-chain for Safe multi-chain single-operation signing and contract-signer multi-operation formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected EIP-712 hash for single-operation multi-chain signatures
  * Preserved contract signer types when formatting multi-signature data

* **Maintenance**
  * Default tool version used when generating on-chain identifiers updated to 0.3.6

* **Documentation**
  * Changelog and security docs updated; package version bumped to 0.3.6
<!-- end of auto-generated comment: release notes by coderabbit.ai -->