### PR TITLE
docs(signer): clarify EIP-7702 callback signature shape and chainId plumbing asymmetry

### DIFF
--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -478,6 +478,14 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * {@link SafeAccountV0_3_0.signUserOperationWithSigners} for the full
 	 * design rationale. Sets the multi-chain flag automatically.
 	 *
+	 * Note the chainId plumbing asymmetry vs the multi-op variant:
+	 *   - **Singular** (this method): `chainId` is a positional argument.
+	 *   - **Plural** ({@link signUserOperationsWithSigners}): chainIds live
+	 *     inside each `UserOperationToSign` element, since each op may
+	 *     target a different chain.
+	 * Pick the variant that matches your bundle shape; don't pass the same
+	 * chainId twice.
+	 *
 	 * @param userOperation - UserOperation to sign
 	 * @param signers - one ExternalSigner per owner (any order)
 	 * @param chainId - target chain id
@@ -607,6 +615,15 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * rejects it offline. User-defined single-op signers
 	 * (`Signer<SignContext>`) also don't work — they'd receive a context shape
 	 * they didn't declare.
+	 *
+	 * Note the chainId plumbing asymmetry vs the single-op variant:
+	 *   - **Plural** (this method): each `UserOperationToSign` carries its
+	 *     own `chainId`, since a multichain bundle's ops target different
+	 *     chains.
+	 *   - **Singular** ({@link signUserOperationWithSigners}): `chainId` is
+	 *     a positional argument.
+	 * For a length-1 bundle on this method, set `chainId` on the single
+	 * element rather than reaching for the singular variant.
 	 *
 	 * @param userOperationsToSign - UserOperations + chain IDs + validity windows
 	 * @param signers - one Signer per owner (any order; sorted by address on-chain)

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -480,7 +480,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 *
 	 * Note the chainId plumbing asymmetry vs the multi-op variant:
 	 *   - **Singular** (this method): `chainId` is a positional argument.
-	 *   - **Plural** ({@link signUserOperationsWithSigners}): chainIds live
+	 *   - **Plural** ({@link signUserOperationsWithSigners}): `chainId` lives
 	 *     inside each `UserOperationToSign` element, since each op may
 	 *     target a different chain.
 	 * Pick the variant that matches your bundle shape; don't pass the same

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -117,10 +117,21 @@ export function createAndSignLegacyRawTransaction(
  * `(hash: string) => Promise<string>` for use with viem, ethers Signers,
  * hardware wallets, or MPC signers.
  *
+ * The callback signs the auth hash directly — no EIP-191 / EIP-712 / message
+ * prefix. The returned hex string must be one of:
+ *   - **Standard 65-byte signature** (130 hex chars after `0x`): `r (32) || s (32) || v (1)`,
+ *     where `v` is `0`, `1`, `27`, or `28`. This is the shape every common
+ *     library produces (e.g., ethers v6: `Signature.from(wallet.signingKey.sign(hash)).serialized`;
+ *     viem `LocalAccount.sign({ hash })`).
+ *   - **EIP-2098 compact 64-byte signature** (128 hex chars after `0x`): `r (32) || yParityAndS (32)`,
+ *     where the high bit of the second 32-byte word encodes `yParity`.
+ *
+ * The `0x` prefix is optional. Other lengths or out-of-range `v` values throw.
+ *
  * @param chainId - The chain ID the authorization is valid for.
  * @param address - The contract address to delegate code from.
  * @param nonce - The EOA's nonce at the time of signing.
- * @param signer - The EOA's private key or a signing function that returns a 65-byte signature.
+ * @param signer - The EOA's private key or a signing function returning a 65-byte standard or 64-byte EIP-2098 hex signature.
  * @returns The signed authorization with all numeric values as hex strings.
  */
 export function createAndSignEip7702DelegationAuthorization(


### PR DESCRIPTION
## Summary

Two small JSDoc clarifications that surfaced while writing examples against the SDK.

### 1. `createAndSignEip7702DelegationAuthorization` callback shape

The async overload accepts `(hash: string) => Promise<string>` but doesn't document what the returned hex string must look like. Without reading `parseRawSignature`, callers don't know:

- That no EIP-191 / EIP-712 prefix is applied — the auth hash is signed directly.
- That both **65-byte standard** (`r || s || v` with `v ∈ {0, 1, 27, 28}`) and **EIP-2098 compact** (64-byte `r || yParityAndS`) shapes are accepted.
- That this exactly matches what the common libraries already produce (ethers v6 `Signature.from(wallet.signingKey.sign(hash)).serialized`, viem `LocalAccount.sign({ hash })`), so no manual byte assembly is needed.

This PR adds the shape contract to the JSDoc directly so it's visible at the call site.

### 2. `SafeMultiChainSigAccountV1` singular vs plural chainId plumbing

`signUserOperationWithSigners` (singular) takes `chainId` as a **positional argument**. `signUserOperationsWithSigners` (plural) carries `chainId` **inside each `UserOperationToSign` element**. The asymmetry is reasonable (multichain bundles have per-op chains) but easy to mis-read on first encounter. Each method's JSDoc now points at the other so the rule is discoverable wherever the reader lands.

## Test plan

- [x] `npm run build` clean (no behavior change; JSDoc only)
- [ ] Reviewer-side: visual check of generated TypeDoc / IDE hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified chain ID handling differences between single-operation and multi-operation signing flows, including guidance for single-item bundles.
  * Expanded signer callback docs to specify accepted signature formats, 0x-prefix and length expectations for clearer integration guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/165)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->