### PR TITLE
refactor(safe): wrapper helpers throw for length=1 (each helper does one thing)

### DIFF
--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -721,19 +721,16 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
-	 * Compute the EIP-712 hash that owners must sign for a multi-chain bundle.
+	 * Compute the EIP-712 Merkle root wrapper digest that owners sign once
+	 * across all UserOperations in a multi-chain bundle.
 	 *
-	 * For length≥2: returns the Merkle root wrapper digest signed once across
-	 * all UserOperations.
+	 * Requires length≥2. For a single UserOperation use
+	 * {@link SafeMultiChainSigAccountV1.getUserOperationEip712Hash} (the on-chain
+	 * `merkleTreeDepth == 0` branch verifies against the per-op SafeOp digest,
+	 * not a Merkle wrapper, so signing the wrapper for length=1 produces bytes
+	 * the contract rejects with AA24).
 	 *
-	 * For length=1: returns the per-UserOperation SafeOp digest, matching the
-	 * `merkleTreeDepth == 0` branch on the deployed Safe4337MultiChainSignatureModule
-	 * (which validates against `keccak256(SafeOp)` directly, not the Merkle wrapper).
-	 * Returning the wrapper here would produce a signature the on-chain depth=0
-	 * path rejects with AA24: the formatter still emits the depth=0 layout the
-	 * contract expects, so the digest must match.
-	 *
-	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs
+	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs (length ≥ 2)
 	 * @param overrides - optional overrides for the Safe 4337 module address
 	 * @returns the EIP-712 hash as a hex string
 	 */
@@ -744,20 +741,6 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			entrypointAddress?: string;
 		} = {},
 	): string {
-		if (userOperationsToSignsToSign.length < 1) {
-			throw new RangeError("There should be at least one userOperationsToSign");
-		}
-		if (userOperationsToSignsToSign.length === 1) {
-			const u = userOperationsToSignsToSign[0];
-			return SafeAccount.getUserOperationEip712Hash_V9(u.userOperation, u.chainId, {
-				validAfter: u.validAfter,
-				validUntil: u.validUntil,
-				safe4337ModuleAddress:
-					overrides.safe4337ModuleAddress ??
-					SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
-				entrypointAddress: overrides.entrypointAddress,
-			});
-		}
 		const data = SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Data(
 			userOperationsToSignsToSign,
 			overrides,
@@ -769,18 +752,19 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * Get the EIP-712 typed data components for a multi-chain Merkle tree root.
 	 * Returns the domain, types, and message value needed for signing or hashing.
 	 *
-	 * Throws for length=1: the on-chain depth=0 path verifies against the per-op
-	 * SafeOp digest, not a Merkle wrapper, so the wrapper typed data would be
-	 * misleading. Use {@link SafeMultiChainSigAccountV1.getUserOperationEip712Data}
-	 * (or {@link SafeMultiChainSigAccountV1.getUserOperationEip712Hash}) for
-	 * single-op signing: those multichain-class overrides default
-	 * `safe4337ModuleAddress` to `DEFAULT_SAFE_4337_MODULE_ADDRESS`. The parent
-	 * `SafeAccount.getUserOperationEip712Data_V9` / `getUserOperationEip712Hash_V9`
-	 * helpers default to a different module and would hash against the wrong
-	 * verifying contract unless `overrides.safe4337ModuleAddress` is supplied
-	 * explicitly.
+	 * Requires length≥2. For a single UserOperation use
+	 * {@link SafeMultiChainSigAccountV1.getUserOperationEip712Data} (or
+	 * {@link SafeMultiChainSigAccountV1.getUserOperationEip712Hash}): those
+	 * multichain-class overrides default `safe4337ModuleAddress` to
+	 * `DEFAULT_SAFE_4337_MODULE_ADDRESS`. The on-chain depth=0 path verifies
+	 * against the per-op SafeOp digest, not a Merkle wrapper, so signing the
+	 * wrapper for length=1 produces bytes the contract rejects with AA24. The
+	 * parent `SafeAccount.getUserOperationEip712Data_V9` /
+	 * `getUserOperationEip712Hash_V9` helpers default to a different module and
+	 * would hash against the wrong verifying contract unless
+	 * `overrides.safe4337ModuleAddress` is supplied explicitly.
 	 *
-	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs
+	 * @param userOperationsToSignsToSign - list of UserOperations with their target chain IDs (length ≥ 2)
 	 * @param overrides - optional overrides for the Safe 4337 module address
 	 * @returns an object with domain, types, and messageValue for EIP-712 signing
 	 */
@@ -797,7 +781,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	} {
 		if (userOperationsToSign.length < 2) {
 			throw new RangeError(
-				"getMultiChainSingleSignatureUserOperationsEip712Data requires >= 2 userOperations. " +
+				"Multi-chain Merkle wrapper helpers require >= 2 userOperations. " +
 					"For a single UserOperation, use SafeMultiChainSigAccountV1.getUserOperationEip712Data " +
 					"or SafeMultiChainSigAccountV1.getUserOperationEip712Hash (these multichain-class overrides " +
 					"default safe4337ModuleAddress to DEFAULT_SAFE_4337_MODULE_ADDRESS, the multi-chain module). " +

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -654,32 +654,15 @@ describe('SafeMultiChainSigAccountV1 signUserOperationWithSigners', () => {
 
     // The on-chain Safe4337MultiChainSignatureModule's `merkleTreeDepth == 0`
     // branch verifies against `keccak256(SafeOp)` directly, not the Merkle
-    // wrapper. Returning the wrapper from this helper for length=1 produced
-    // signatures the contract rejected with AA24.
-    test('getMultiChainSingleSignatureUserOperationsEip712Hash length=1 returns the per-op SafeOp hash', () => {
-        const length1Hash = ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash(
-            [{ userOperation: op, chainId: CHAIN_ID, validAfter: 0n, validUntil: 0n }],
-        );
-        const perOpHash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash_V9(
-            op,
-            CHAIN_ID,
-            { safe4337ModuleAddress: ak.SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS },
-        );
-        expect(length1Hash).toBe(perOpHash);
-    });
-
-    test('getMultiChainSingleSignatureUserOperationsEip712Hash length=2 returns the Merkle wrapper hash', () => {
-        const op2 = { ...op, nonce: 1n };
-        const ops = [
-            { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
-            { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
-        ];
-        const wrapperHash = ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash(ops);
-        const perOpHash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash_V9(
-            op, 1n,
-            { safe4337ModuleAddress: ak.SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS },
-        );
-        expect(wrapperHash).not.toBe(perOpHash);
+    // wrapper. The wrapper helpers are wrapper-only (length >= 2); for length=1
+    // callers must use the per-op multichain helpers, otherwise signatures
+    // hash a different digest than what the contract checks (AA24 on-chain).
+    test('getMultiChainSingleSignatureUserOperationsEip712Hash throws for length=1', () => {
+        expect(() =>
+            ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash(
+                [{ userOperation: op, chainId: CHAIN_ID, validAfter: 0n, validUntil: 0n }],
+            ),
+        ).toThrow(RangeError);
     });
 
     test('getMultiChainSingleSignatureUserOperationsEip712Data throws for length=1', () => {
@@ -690,10 +673,34 @@ describe('SafeMultiChainSigAccountV1 signUserOperationWithSigners', () => {
         ).toThrow(RangeError);
     });
 
-    test('getMultiChainSingleSignatureUserOperationsEip712Hash throws for empty input', () => {
+    test('multi-chain wrapper helpers throw for empty input', () => {
         expect(() =>
             ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash([]),
         ).toThrow(RangeError);
+        expect(() =>
+            ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Data([]),
+        ).toThrow(RangeError);
+    });
+
+    test('per-op multichain helpers are the length=1 path (default to multichain module address)', () => {
+        const hash = ak.SafeMultiChainSigAccountV1.getUserOperationEip712Hash(op, CHAIN_ID);
+        const refHash = ak.SafeAccountV0_3_0.getUserOperationEip712Hash_V9(op, CHAIN_ID, {
+            safe4337ModuleAddress: ak.SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
+        });
+        expect(hash).toBe(refHash);
+    });
+
+    test('getMultiChainSingleSignatureUserOperationsEip712Hash length=2 returns the Merkle wrapper digest (distinct from any per-op hash)', () => {
+        const op2 = { ...op, nonce: 1n };
+        const ops = [
+            { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
+            { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
+        ];
+        const wrapperHash = ak.SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash(ops);
+        const perOp1 = ak.SafeMultiChainSigAccountV1.getUserOperationEip712Hash(op, 1n);
+        const perOp2 = ak.SafeMultiChainSigAccountV1.getUserOperationEip712Hash(op2, 10n);
+        expect(wrapperHash).not.toBe(perOp1);
+        expect(wrapperHash).not.toBe(perOp2);
     });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated multi-chain signature handling to enforce proper validation for operation bundles, improving consistency and error messaging.

* **Tests**
  * Enhanced test coverage for multi-chain signature scenarios with updated validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->