### PR TITLE
chore(changelog): align 0.3.6 entry with shipped API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Fixes
 
-- **Safe multi-chain single-operation signing now hashes the correct payload.** `SafeMultiChainSigAccountV1.getMultiChainSingleSignatureUserOperationsEip712Hash` now returns the per-operation SafeOp hash when called with exactly one UserOperation, matching the Safe4337MultiChainSignatureModule `merkleTreeDepth == 0` validation path. This fixes single-operation multi-chain signatures being rejected on-chain with `AA24`.
+- **Safe multi-chain single-operation signing now hashes the correct payload.** Single-op `SafeMultiChainSigAccountV1` flows previously hashed through the Merkle wrapper and were rejected on-chain with `AA24`, since `Safe4337MultiChainSignatureModule` verifies against `keccak256(SafeOp)` directly when `merkleTreeDepth == 0`. The per-op SafeOp digest is now reachable via `SafeMultiChainSigAccountV1.getUserOperationEip712Hash` / `getUserOperationEip712Data`, which default `safe4337ModuleAddress` to the multi-chain module so the digest matches the on-chain verifier without manual override.
 - **Safe multi-chain WebAuthn / EIP-1271 signatures keep contract-signer formatting.** `signUserOperationsWithSigners` now preserves the `"contract"` signer type when formatting multi-operation signatures, so dynamic Safe contract-signature segments are emitted correctly.
+
+### API changes
+
+- **`getMultiChainSingleSignatureUserOperationsEip712Hash` / `...Eip712Data` are wrapper-only and throw for `length < 2`.** They now do one thing: hash the Merkle-wrapped multi-op payload. Single-op callers must use `SafeMultiChainSigAccountV1.getUserOperationEip712Hash` / `getUserOperationEip712Data` (which default `safe4337ModuleAddress` to the multi-chain module). If you call the parent `SafeAccount` helpers directly, pass `safe4337ModuleAddress` explicitly. Their default points at the standard 4337 module, not the multi-chain one.
 
 ### Maintenance
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-chain single-operation signing to produce the expected on-chain digest.

* **Breaking Changes**
  * Multi-operation signing functions now throw an error when called with fewer than 2 operations; single-operation users must use alternative per-operation functions.

* **Documentation**
  * Updated changelog with clarifications on multi-chain signing behavior and module alignment defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->