### PR TITLE
Add getUserOperationEip712Data and getUserOperationEip712Hash to Calibur7702Account, Simple7702Account and Simple7702AccountV09

### DIFF
--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -213,9 +213,11 @@ export class Calibur7702Account
 	 * signature over it produces a wrapped Calibur signature that validates
 	 * against the same hash on-chain.
 	 *
-	 * Only meaningful for Calibur's root key path (secp256k1 raw ECDSA); P-256
-	 * and WebAuthn-P256 keys use their own signature schemes that don't fit
-	 * EIP-712 typed-data signing.
+	 * Intended for the secp256k1 key path (root key or any registered
+	 * secondary secp256k1 key), since `eth_signTypedData_v4` only produces
+	 * secp256k1 signatures. P-256 and WebAuthn-P256 keys sign with their
+	 * own primitives — for those, use {@link getUserOperationEip712Hash}
+	 * (the digest), which is the value-to-be-signed regardless of key type.
 	 *
 	 * @param userOperation - Unsigned UserOperation to wrap
 	 * @param chainId - Target chain ID
@@ -235,6 +237,9 @@ export class Calibur7702Account
 	 * v0.8 / v0.9 domain. For these EntryPoints this digest IS the
 	 * `userOpHash` ({@link getUserOperationHash}); the wrapped Calibur
 	 * signature is verified against this hash on-chain.
+	 *
+	 * Universal across Calibur key types: secp256k1 and P-256 keys sign
+	 * this digest directly, each with their own signing primitive.
 	 *
 	 * @param userOperation - Unsigned UserOperation to hash
 	 * @param chainId - Target chain ID

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -9,8 +9,8 @@ import {
 import { AbstractionKitError } from "src/errors";
 import type { PrependTokenPaymasterApproveAccount } from "src/paymaster/types";
 import { invokeSigner, pickScheme } from "src/signer/negotiate";
-import type { Signer as AkSigner, SignContext, SigningScheme } from "src/signer/types";
-import type { JsonRpcResult, UserOperationV8 } from "src/types";
+import type { Signer as AkSigner, SignContext, SigningScheme, TypedData } from "src/signer/types";
+import type { JsonRpcResult, UserOperationV8, UserOperationV9 } from "src/types";
 import {
 	type Authorization7702Hex,
 	bigintToHex,
@@ -23,6 +23,8 @@ import {
 	fetchAccountNonce,
 	getDelegatedAddress,
 	getFunctionSelector,
+	getUserOperationEip712DataV8V9,
+	getUserOperationEip712HashV8V9,
 	handlefetchGasPrice,
 	sendJsonRpcRequest,
 } from "../../utils";
@@ -201,6 +203,50 @@ export class Calibur7702Account
 	 */
 	public getUserOperationHash(userOperation: UserOperationV8, chainId: bigint): string {
 		return createUserOperationHash(userOperation, this.entrypointAddress, chainId);
+	}
+
+	/**
+	 * Build the EIP-712 typed data payload for a UserOperation under the
+	 * EntryPoint v0.8 / v0.9 domain. Useful for wallets that can only sign
+	 * typed data (`eth_signTypedData_v4`) — the digest of the returned payload
+	 * equals the `userOpHash` ({@link getUserOperationHash}), so a typed-data
+	 * signature over it produces a wrapped Calibur signature that validates
+	 * against the same hash on-chain.
+	 *
+	 * Only meaningful for Calibur's root key path (secp256k1 raw ECDSA); P-256
+	 * and WebAuthn-P256 keys use their own signature schemes that don't fit
+	 * EIP-712 typed-data signing.
+	 *
+	 * @param userOperation - Unsigned UserOperation to wrap
+	 * @param chainId - Target chain ID
+	 * @returns EIP-712 {@link TypedData} payload ready for `signTypedData`
+	 * @throws {AbstractionKitError} if this account targets an EntryPoint
+	 *   version other than v0.8 / v0.9.
+	 */
+	public getUserOperationEip712Data(
+		userOperation: UserOperationV8 | UserOperationV9,
+		chainId: bigint,
+	): TypedData {
+		return getUserOperationEip712DataV8V9(userOperation, this.entrypointAddress, chainId);
+	}
+
+	/**
+	 * Compute the EIP-712 digest of a UserOperation under the EntryPoint
+	 * v0.8 / v0.9 domain. For these EntryPoints this digest IS the
+	 * `userOpHash` ({@link getUserOperationHash}); the wrapped Calibur
+	 * signature is verified against this hash on-chain.
+	 *
+	 * @param userOperation - Unsigned UserOperation to hash
+	 * @param chainId - Target chain ID
+	 * @returns The EIP-712 digest as a hex string
+	 * @throws {AbstractionKitError} if this account targets an EntryPoint
+	 *   version other than v0.8 / v0.9.
+	 */
+	public getUserOperationEip712Hash(
+		userOperation: UserOperationV8 | UserOperationV9,
+		chainId: bigint,
+	): string {
+		return getUserOperationEip712HashV8V9(userOperation, this.entrypointAddress, chainId);
 	}
 
 	// ─── CallData Encoding ───────────────────────────────────────────────

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -19,13 +19,13 @@ import {
 	createRevokeDelegationAuthorization,
 } from "src/utils7702";
 import {
-	buildPackedInitCodeV8V9,
-	buildPaymasterAndData,
 	createCallData,
 	createUserOperationHash,
 	fetchAccountNonce,
 	getDelegatedAddress,
 	getFunctionSelector,
+	getUserOperationEip712DataV8V9,
+	getUserOperationEip712HashV8V9,
 	handlefetchGasPrice,
 	sendJsonRpcRequest,
 } from "../../utils";
@@ -806,66 +806,32 @@ export class BaseSimple7702Account extends SmartAccount {
 	 *   version other than v0.8 / v0.9. Earlier EntryPoints define the
 	 *   userOpHash differently and require raw-hash signing.
 	 */
-	public getUserOperationEip712TypedData(
+	public getUserOperationEip712Data(
 		userOperation: UserOperationV8 | UserOperationV9,
 		chainId: bigint,
 	): TypedData {
-		const ep = this.entrypointAddress.toLowerCase();
-		const isV9 = ep === ENTRYPOINT_V9.toLowerCase();
-		if (ep !== ENTRYPOINT_V8.toLowerCase() && !isV9) {
-			throw new AbstractionKitError(
-				"BAD_DATA",
-				`getUserOperationEip712TypedData supports EntryPoint v0.8 / v0.9 only; ` +
-					`this account targets ${this.entrypointAddress}. Use signUserOperation ` +
-					`(raw-hash ECDSA) for earlier EntryPoint versions.`,
-			);
-		}
+		return getUserOperationEip712DataV8V9(userOperation, this.entrypointAddress, chainId);
+	}
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const initCode = buildPackedInitCodeV8V9(userOperation);
-		const accountGasLimits =
-			"0x" +
-			abiCoder.encode(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
-			abiCoder.encode(["uint128"], [userOperation.callGasLimit]).slice(34);
-		const gasFees =
-			"0x" +
-			abiCoder.encode(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
-			abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
-		const paymasterAndData = buildPaymasterAndData(userOperation, isV9);
-
-		const types = {
-			PackedUserOperation: [
-				{ name: "sender", type: "address" },
-				{ name: "nonce", type: "uint256" },
-				{ name: "initCode", type: "bytes" },
-				{ name: "callData", type: "bytes" },
-				{ name: "accountGasLimits", type: "bytes32" },
-				{ name: "preVerificationGas", type: "uint256" },
-				{ name: "gasFees", type: "bytes32" },
-				{ name: "paymasterAndData", type: "bytes" },
-			],
-		};
-
-		return {
-			domain: {
-				name: "ERC4337",
-				version: "1",
-				chainId,
-				verifyingContract: this.entrypointAddress as `0x${string}`,
-			},
-			types,
-			primaryType: "PackedUserOperation",
-			message: {
-				sender: userOperation.sender,
-				nonce: userOperation.nonce,
-				initCode,
-				callData: userOperation.callData,
-				accountGasLimits,
-				preVerificationGas: userOperation.preVerificationGas,
-				gasFees,
-				paymasterAndData,
-			},
-		};
+	/**
+	 * Compute the EIP-712 digest of a UserOperation under the EntryPoint
+	 * v0.8 / v0.9 domain. For these EntryPoints this digest IS the
+	 * `userOpHash` ({@link createUserOperationHash}); signing it with raw
+	 * ECDSA or via `signTypedData` over the data from
+	 * {@link getUserOperationEip712Data} produces a signature that validates
+	 * against the same hash on-chain.
+	 *
+	 * @param userOperation - Unsigned UserOperation to hash
+	 * @param chainId - Target chain ID
+	 * @returns The EIP-712 digest as a hex string
+	 * @throws {AbstractionKitError} if this account targets an EntryPoint
+	 *   version other than v0.8 / v0.9.
+	 */
+	public getUserOperationEip712Hash(
+		userOperation: UserOperationV8 | UserOperationV9,
+		chainId: bigint,
+	): string {
+		return getUserOperationEip712HashV8V9(userOperation, this.entrypointAddress, chainId);
 	}
 
 	/**
@@ -900,7 +866,7 @@ export class BaseSimple7702Account extends SmartAccount {
 		};
 		const typedData =
 			scheme === "typedData"
-				? this.getUserOperationEip712TypedData(useroperation, chainId)
+				? this.getUserOperationEip712Data(useroperation, chainId)
 				: undefined;
 		return invokeSigner(signer, scheme, { hash, typedData, context });
 	}
@@ -1134,8 +1100,8 @@ export class Simple7702Account extends BaseSimple7702Account {
 	 * {@link signUserOperation} method, or wrap explicitly with
 	 * `fromPrivateKey(pk)`.
 	 *
-	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} for
-	 *   the lower-level escape hatch when you need the typed data outside the
+	 * @see {@link BaseSimple7702Account.getUserOperationEip712Data} for the
+	 *   lower-level escape hatch when you need the typed data outside the
 	 *   dispatcher (e.g., to render a custom confirmation UI or feed an HSM
 	 *   that doesn't fit the {@link ExternalSigner} shape).
 	 */

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -117,8 +117,8 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 	 * {@link signUserOperation} method, or wrap explicitly with
 	 * `fromPrivateKey(pk)`.
 	 *
-	 * @see {@link BaseSimple7702Account.getUserOperationEip712TypedData} for
-	 *   the lower-level escape hatch when you need the typed data outside the
+	 * @see {@link BaseSimple7702Account.getUserOperationEip712Data} for the
+	 *   lower-level escape hatch when you need the typed data outside the
 	 *   dispatcher.
 	 */
 	public async signUserOperationWithSigner(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,6 +130,36 @@ export function buildPackedInitCodeV8V9(useroperation: UserOperationV8 | UserOpe
 
 /**
  * @internal
+ * Pack `(verificationGasLimit, callGasLimit)` into a single `bytes32`
+ * (two uint128 values, big-endian). Matches the on-chain
+ * `PackedUserOperation.accountGasLimits` layout used by EntryPoint v0.7+.
+ */
+function packAccountGasLimits(verificationGasLimit: bigint, callGasLimit: bigint): string {
+	const abiCoder = AbiCoder.defaultAbiCoder();
+	return (
+		"0x" +
+		abiCoder.encode(["uint128"], [verificationGasLimit]).slice(34) +
+		abiCoder.encode(["uint128"], [callGasLimit]).slice(34)
+	);
+}
+
+/**
+ * @internal
+ * Pack `(maxPriorityFeePerGas, maxFeePerGas)` into a single `bytes32`
+ * (two uint128 values, big-endian). Matches the on-chain
+ * `PackedUserOperation.gasFees` layout used by EntryPoint v0.7+.
+ */
+function packGasFees(maxPriorityFeePerGas: bigint, maxFeePerGas: bigint): string {
+	const abiCoder = AbiCoder.defaultAbiCoder();
+	return (
+		"0x" +
+		abiCoder.encode(["uint128"], [maxPriorityFeePerGas]).slice(34) +
+		abiCoder.encode(["uint128"], [maxFeePerGas]).slice(34)
+	);
+}
+
+/**
+ * @internal
  * Reconstruct the packed `paymasterAndData` field from a UserOperation's
  * separate paymaster fields. Returns `0x` when no paymaster is set.
  *
@@ -216,16 +246,12 @@ export function getUserOperationEip712DataV8V9(
 		);
 	}
 
-	const abiCoder = AbiCoder.defaultAbiCoder();
 	const initCode = buildPackedInitCodeV8V9(userOperation);
-	const accountGasLimits =
-		"0x" +
-		abiCoder.encode(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
-		abiCoder.encode(["uint128"], [userOperation.callGasLimit]).slice(34);
-	const gasFees =
-		"0x" +
-		abiCoder.encode(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
-		abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
+	const accountGasLimits = packAccountGasLimits(
+		userOperation.verificationGasLimit,
+		userOperation.callGasLimit,
+	);
+	const gasFees = packGasFees(userOperation.maxPriorityFeePerGas, userOperation.maxFeePerGas);
 	const paymasterAndData = buildPaymasterAndData(userOperation, isV9);
 
 	const types = {
@@ -341,16 +367,11 @@ export function createPackedUserOperationV7(useroperation: UserOperationV7): str
 		}
 	}
 
-	const accountGasLimits =
-		"0x" +
-		abiCoder.encode(["uint128"], [useroperation.verificationGasLimit]).slice(34) +
-		abiCoder.encode(["uint128"], [useroperation.callGasLimit]).slice(34);
-
-	const gasFees =
-		"0x" +
-		abiCoder.encode(["uint128"], [useroperation.maxPriorityFeePerGas]).slice(34) +
-		abiCoder.encode(["uint128"], [useroperation.maxFeePerGas]).slice(34);
-
+	const accountGasLimits = packAccountGasLimits(
+		useroperation.verificationGasLimit,
+		useroperation.callGasLimit,
+	);
+	const gasFees = packGasFees(useroperation.maxPriorityFeePerGas, useroperation.maxFeePerGas);
 	const paymasterAndData = buildPaymasterAndData(useroperation);
 
 	const useroperationValuesArrayWithHashedByteValues = [
@@ -404,17 +425,11 @@ function baseCreatePackedUserOperationV8V9(
 	const abiCoder = AbiCoder.defaultAbiCoder();
 
 	const initCode = buildPackedInitCodeV8V9(useroperation);
-
-	const accountGasLimits =
-		"0x" +
-		abiCoder.encode(["uint128"], [useroperation.verificationGasLimit]).slice(34) +
-		abiCoder.encode(["uint128"], [useroperation.callGasLimit]).slice(34);
-
-	const gasFees =
-		"0x" +
-		abiCoder.encode(["uint128"], [useroperation.maxPriorityFeePerGas]).slice(34) +
-		abiCoder.encode(["uint128"], [useroperation.maxFeePerGas]).slice(34);
-
+	const accountGasLimits = packAccountGasLimits(
+		useroperation.verificationGasLimit,
+		useroperation.callGasLimit,
+	);
+	const gasFees = packGasFees(useroperation.maxPriorityFeePerGas, useroperation.maxFeePerGas);
 	const paymasterAndData = buildPaymasterAndData(useroperation, is_v9);
 
 	const useroperationValuesArrayWithHashedByteValues = [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,14 @@
-import { AbiCoder, getAddress, id, JsonRpcProvider, keccak256 } from "ethers";
+import {
+	AbiCoder,
+	getAddress,
+	id,
+	JsonRpcProvider,
+	keccak256,
+	TypedDataEncoder,
+} from "ethers";
 import { ENTRYPOINT_V6, ENTRYPOINT_V7, ENTRYPOINT_V8, ENTRYPOINT_V9 } from "./constants";
 import { AbstractionKitError, BundlerErrorCodeDict, ensureError } from "./errors";
+import type { TypedData } from "./signer/types";
 import {
 	type AbiInputValue,
 	GasOption,
@@ -174,6 +182,105 @@ export function buildPaymasterAndData(
 		}
 	}
 	return paymasterAndData;
+}
+
+/**
+ * Build the EIP-712 typed data payload for a UserOperation under the
+ * EntryPoint v0.8 / v0.9 domain. The digest of the returned payload equals
+ * the `userOpHash` from {@link createUserOperationHash}, so signing it via
+ * `signTypedData` produces a signature that validates against the same hash
+ * as raw ECDSA over the `userOpHash`.
+ *
+ * Shared by EIP-7702 accounts (Simple7702, Calibur). Earlier EntryPoints
+ * define the userOpHash differently and don't fit this typed-data shape.
+ *
+ * @param userOperation - Unsigned UserOperation to wrap
+ * @param entrypointAddress - The EntryPoint contract address (must be v0.8 or v0.9)
+ * @param chainId - Target chain ID (must match the chain that will validate the signature)
+ * @returns EIP-712 {@link TypedData} payload ready for `signTypedData`
+ * @throws {AbstractionKitError} if `entrypointAddress` is not v0.8 / v0.9
+ */
+export function getUserOperationEip712DataV8V9(
+	userOperation: UserOperationV8 | UserOperationV9,
+	entrypointAddress: string,
+	chainId: bigint,
+): TypedData {
+	const ep = entrypointAddress.toLowerCase();
+	const isV9 = ep === ENTRYPOINT_V9.toLowerCase();
+	if (ep !== ENTRYPOINT_V8.toLowerCase() && !isV9) {
+		throw new AbstractionKitError(
+			"BAD_DATA",
+			`getUserOperationEip712Data supports EntryPoint v0.8 / v0.9 only; ` +
+				`got ${entrypointAddress}. Earlier EntryPoints define the userOpHash ` +
+				`differently and require raw-hash signing.`,
+		);
+	}
+
+	const abiCoder = AbiCoder.defaultAbiCoder();
+	const initCode = buildPackedInitCodeV8V9(userOperation);
+	const accountGasLimits =
+		"0x" +
+		abiCoder.encode(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
+		abiCoder.encode(["uint128"], [userOperation.callGasLimit]).slice(34);
+	const gasFees =
+		"0x" +
+		abiCoder.encode(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
+		abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
+	const paymasterAndData = buildPaymasterAndData(userOperation, isV9);
+
+	const types = {
+		PackedUserOperation: [
+			{ name: "sender", type: "address" },
+			{ name: "nonce", type: "uint256" },
+			{ name: "initCode", type: "bytes" },
+			{ name: "callData", type: "bytes" },
+			{ name: "accountGasLimits", type: "bytes32" },
+			{ name: "preVerificationGas", type: "uint256" },
+			{ name: "gasFees", type: "bytes32" },
+			{ name: "paymasterAndData", type: "bytes" },
+		],
+	};
+
+	return {
+		domain: {
+			name: "ERC4337",
+			version: "1",
+			chainId,
+			verifyingContract: entrypointAddress as `0x${string}`,
+		},
+		types,
+		primaryType: "PackedUserOperation",
+		message: {
+			sender: userOperation.sender,
+			nonce: userOperation.nonce,
+			initCode,
+			callData: userOperation.callData,
+			accountGasLimits,
+			preVerificationGas: userOperation.preVerificationGas,
+			gasFees,
+			paymasterAndData,
+		},
+	};
+}
+
+/**
+ * Compute the EIP-712 digest of a UserOperation under the EntryPoint
+ * v0.8 / v0.9 domain. For these EntryPoints this digest IS the
+ * `userOpHash` ({@link createUserOperationHash}).
+ *
+ * @param userOperation - Unsigned UserOperation to hash
+ * @param entrypointAddress - The EntryPoint contract address (must be v0.8 or v0.9)
+ * @param chainId - Target chain ID
+ * @returns The EIP-712 digest as a hex string
+ * @throws {AbstractionKitError} if `entrypointAddress` is not v0.8 / v0.9
+ */
+export function getUserOperationEip712HashV8V9(
+	userOperation: UserOperationV8 | UserOperationV9,
+	entrypointAddress: string,
+	chainId: bigint,
+): string {
+	const data = getUserOperationEip712DataV8V9(userOperation, entrypointAddress, chainId);
+	return TypedDataEncoder.hash(data.domain, data.types, data.message);
 }
 
 /**

--- a/test/calibur/caliburEip712.test.js
+++ b/test/calibur/caliburEip712.test.js
@@ -1,0 +1,148 @@
+const { Wallet, recoverAddress, AbiCoder } = require('ethers');
+const ak = require('../../dist/index.cjs');
+
+const ENTRYPOINT_V8 = "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108";
+const ENTRYPOINT_V9 = "0x433709009B8330FDa32311DF1C2AFA402eD8D009";
+const ENTRYPOINT_V7 = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+
+const chainId = BigInt(process.env.CHAIN_ID ?? "11155111");
+const wallet = Wallet.createRandom();
+const ownerAddress = wallet.address;
+
+function makeUserOp(overrides = {}) {
+    return {
+        sender: ownerAddress,
+        nonce: 7n,
+        factory: null,
+        factoryData: null,
+        callData: "0x8dd7712f"
+            + "0000000000000000000000000000000000000000000000000000000000000020"
+            + "0000000000000000000000000000000000000000000000000000000000000040"
+            + "0000000000000000000000000000000000000000000000000000000000000001"
+            + "0000000000000000000000000000000000000000000000000000000000000000",
+        callGasLimit: 100000n,
+        verificationGasLimit: 200000n,
+        preVerificationGas: 50000n,
+        maxFeePerGas: 1500000000n,
+        maxPriorityFeePerGas: 100000000n,
+        paymaster: null,
+        paymasterVerificationGasLimit: null,
+        paymasterPostOpGasLimit: null,
+        paymasterData: null,
+        signature: "0x" + "00".repeat(65),
+        eip7702Auth: null,
+        ...overrides,
+    };
+}
+
+function withPaymaster(op) {
+    return {
+        ...op,
+        paymaster: "0xcccccccccccccccccccccccccccccccccccccccc",
+        paymasterVerificationGasLimit: 50000n,
+        paymasterPostOpGasLimit: 30000n,
+        paymasterData: "0xdeadbeef",
+    };
+}
+
+function withEip7702Auth(op) {
+    return {
+        ...op,
+        factory: "0x7702",
+        factoryData: null,
+        eip7702Auth: {
+            chainId: "0x1",
+            address: "0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00",
+            nonce: "0x0",
+            yParity: "0x0",
+            r: "0x4277ba564d2c138823415df0ec8e8f97f30825056d54ec5128a8b29ec2dd81b2",
+            s: "0x1075a1bec7f59848cca899ece93075199cd2aabceb0654b9ae00b881a30044cd",
+        },
+    };
+}
+
+const PERMUTATIONS = [
+    { name: "no paymaster, no eip7702Auth", build: () => makeUserOp() },
+    { name: "with paymaster", build: () => withPaymaster(makeUserOp()) },
+    { name: "with eip7702Auth", build: () => withEip7702Auth(makeUserOp()) },
+    { name: "with paymaster + eip7702Auth", build: () => withPaymaster(withEip7702Auth(makeUserOp())) },
+];
+
+describe('Calibur7702Account.getUserOperationEip712Hash (v0.8)', () => {
+    PERMUTATIONS.forEach(({ name, build }) => {
+        test(`hash equals userOpHash — ${name}`, () => {
+            const account = new ak.Calibur7702Account(ownerAddress);
+            const userOp = build();
+            const eip712Hash = account.getUserOperationEip712Hash(userOp, chainId);
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId);
+            expect(eip712Hash).toBe(userOpHash);
+            expect(eip712Hash).toBe(account.getUserOperationHash(userOp, chainId));
+        });
+    });
+});
+
+describe('Calibur7702Account.getUserOperationEip712Hash (v0.9)', () => {
+    PERMUTATIONS.forEach(({ name, build }) => {
+        test(`hash equals userOpHash — ${name}`, () => {
+            const account = new ak.Calibur7702Account(ownerAddress, {
+                entrypointAddress: ENTRYPOINT_V9,
+                delegateeAddress: ak.CALIBUR_CANDIDE_V0_1_0_SINGLETON_ADDRESS,
+            });
+            const userOp = build();
+            const eip712Hash = account.getUserOperationEip712Hash(userOp, chainId);
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
+            expect(eip712Hash).toBe(userOpHash);
+        });
+    });
+});
+
+describe('Calibur7702Account.getUserOperationEip712Data', () => {
+    test('v0.8 domain matches EntryPoint v0.8', () => {
+        const account = new ak.Calibur7702Account(ownerAddress);
+        const td = account.getUserOperationEip712Data(makeUserOp(), chainId);
+        expect(td.domain.name).toBe("ERC4337");
+        expect(td.domain.version).toBe("1");
+        expect(td.domain.chainId).toBe(chainId);
+        expect(td.domain.verifyingContract).toBe(ENTRYPOINT_V8);
+        expect(td.primaryType).toBe("PackedUserOperation");
+    });
+
+    test('v0.9 domain matches EntryPoint v0.9', () => {
+        const account = new ak.Calibur7702Account(ownerAddress, {
+            entrypointAddress: ENTRYPOINT_V9,
+            delegateeAddress: ak.CALIBUR_CANDIDE_V0_1_0_SINGLETON_ADDRESS,
+        });
+        const td = account.getUserOperationEip712Data(makeUserOp(), chainId);
+        expect(td.domain.verifyingContract).toBe(ENTRYPOINT_V9);
+    });
+
+    test('throws on v0.7 EntryPoint override', () => {
+        const account = new ak.Calibur7702Account(ownerAddress, {
+            entrypointAddress: ENTRYPOINT_V7,
+        });
+        expect(() => account.getUserOperationEip712Data(makeUserOp(), chainId))
+            .toThrow(/EntryPoint v0\.8|v0\.9/i);
+    });
+});
+
+describe('Calibur signTypedData / signHash byte-equivalence (root key)', () => {
+    PERMUTATIONS.forEach(({ name, build }) => {
+        test(`v0.8 — ${name}`, async () => {
+            const account = new ak.Calibur7702Account(ownerAddress);
+            const userOp = build();
+
+            // Path A: raw-hash signing (the existing Calibur path)
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId);
+            const sigA = wallet.signingKey.sign(userOpHash).serialized;
+
+            // Path B: typed-data signing
+            const td = account.getUserOperationEip712Data(userOp, chainId);
+            const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
+
+            // For deterministic ECDSA (ethers), both signatures are byte-identical.
+            expect(sigB).toBe(sigA);
+            expect(recoverAddress(userOpHash, sigB).toLowerCase())
+                .toBe(ownerAddress.toLowerCase());
+        });
+    });
+});

--- a/test/simple/simple7702TypedData.test.js
+++ b/test/simple/simple7702TypedData.test.js
@@ -1,4 +1,4 @@
-const { Wallet, computeAddress, recoverAddress, AbiCoder } = require('ethers');
+const { Wallet, computeAddress, recoverAddress, AbiCoder, TypedDataEncoder } = require('ethers');
 const ak = require('../../dist/index.cjs');
 require('dotenv').config();
 
@@ -103,7 +103,7 @@ describe('signTypedData / signHash byte-equivalence (v0.8)', () => {
             const sigA = wallet.signingKey.sign(userOpHash).serialized;
 
             // Path B: typed-data signing
-            const td = account.getUserOperationEip712TypedData(userOp, chainId);
+            const td = account.getUserOperationEip712Data(userOp, chainId);
             const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
 
             expect(sigB).toBe(sigA);
@@ -122,7 +122,7 @@ describe('signTypedData / signHash byte-equivalence (v0.9)', () => {
             const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
             const sigA = wallet.signingKey.sign(userOpHash).serialized;
 
-            const td = account.getUserOperationEip712TypedData(userOp, chainId);
+            const td = account.getUserOperationEip712Data(userOp, chainId);
             const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
 
             expect(sigB).toBe(sigA);
@@ -150,17 +150,45 @@ describe('signTypedData / signHash byte-equivalence (v0.9)', () => {
         const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
         const sigA = wallet.signingKey.sign(userOpHash).serialized;
 
-        const td = account.getUserOperationEip712TypedData(userOp, chainId);
+        const td = account.getUserOperationEip712Data(userOp, chainId);
         const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
 
         expect(sigB).toBe(sigA);
     });
 });
 
-describe('getUserOperationEip712TypedData domain', () => {
+describe('getUserOperationEip712Hash equivalence', () => {
+    PERMUTATIONS.forEach(({ name, build }) => {
+        test(`v0.8: hash equals userOpHash — ${name}`, () => {
+            const account = new ak.Simple7702Account(ownerAddress);
+            const userOp = build();
+            const eip712Hash = account.getUserOperationEip712Hash(userOp, chainId);
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId);
+            expect(eip712Hash).toBe(userOpHash);
+        });
+
+        test(`v0.9: hash equals userOpHash — ${name}`, () => {
+            const account = new ak.Simple7702AccountV09(ownerAddress);
+            const userOp = build();
+            const eip712Hash = account.getUserOperationEip712Hash(userOp, chainId);
+            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
+            expect(eip712Hash).toBe(userOpHash);
+        });
+    });
+
+    test('throws on v0.7 EntryPoint override', () => {
+        const account = new ak.Simple7702Account(ownerAddress, {
+            entrypointAddress: ENTRYPOINT_V7,
+        });
+        expect(() => account.getUserOperationEip712Hash(makeUserOpV8(), chainId))
+            .toThrow(/EntryPoint v0\.8|v0\.9/i);
+    });
+});
+
+describe('getUserOperationEip712Data domain', () => {
     test('v0.8 domain uses entrypoint v0.8 verifyingContract', () => {
         const account = new ak.Simple7702Account(ownerAddress);
-        const td = account.getUserOperationEip712TypedData(makeUserOpV8(), chainId);
+        const td = account.getUserOperationEip712Data(makeUserOpV8(), chainId);
         expect(td.domain.name).toBe("ERC4337");
         expect(td.domain.version).toBe("1");
         expect(td.domain.chainId).toBe(chainId);
@@ -170,7 +198,7 @@ describe('getUserOperationEip712TypedData domain', () => {
 
     test('v0.9 domain uses entrypoint v0.9 verifyingContract', () => {
         const account = new ak.Simple7702AccountV09(ownerAddress);
-        const td = account.getUserOperationEip712TypedData(makeUserOpV8(), chainId);
+        const td = account.getUserOperationEip712Data(makeUserOpV8(), chainId);
         expect(td.domain.verifyingContract).toBe(ENTRYPOINT_V9);
     });
 
@@ -178,8 +206,8 @@ describe('getUserOperationEip712TypedData domain', () => {
         const account = new ak.Simple7702Account(ownerAddress, {
             entrypointAddress: ENTRYPOINT_V7,
         });
-        expect(() => account.getUserOperationEip712TypedData(makeUserOpV8(), chainId))
-            .toThrow(/typed data|EntryPoint v0\.8|v0\.9/i);
+        expect(() => account.getUserOperationEip712Data(makeUserOpV8(), chainId))
+            .toThrow(/EntryPoint v0\.8|v0\.9/i);
     });
 });
 


### PR DESCRIPTION
 ## Summary

  - Add `getUserOperationEip712Data` and `getUserOperationEip712Hash` to `BaseSimple7702Account` (Simple7702Account / Simple7702AccountV09) and `Calibur7702Account`. For EntryPoint
  v0.8 / v0.9 the `userOpHash` IS the EIP-712 digest of `PackedUserOperation`, so these accessors give integrators direct handles to the typed-data payload (for `eth_signTypedData_v4`
   wallets, HSM, MPC, custom UIs) and to the digest itself.
  - Naming aligns with the existing Safe convention (`SafeAccount.getUserOperationEip712Hash` / `getUserOperationEip712Data`, `SafeMultiChainSigAccountV1.getUserOperationEip712Hash` /
   `getUserOperationEip712Data`).
  - Both classes delegate to two shared helpers in `src/utils.ts` (`getUserOperationEip712DataV8V9` / `getUserOperationEip712HashV8V9`), so the typed-data shape, domain, validation,
  and digest computation live in one place.
  - Calibur-specific note in JSDoc: `Data` is intended for the secp256k1 key path (root or registered secondary, since `eth_signTypedData_v4` only produces secp256k1 signatures);
  `Hash` is universal — the value-to-be-signed for secp256k1 and P-256 keys alike.
  - Drive-by refactor: hoisted the `accountGasLimits` and `gasFees` `uint128+uint128 → bytes32` packing into two private helpers (`packAccountGasLimits`, `packGasFees`) so the three
  packers (`createPackedUserOperationV7`, `baseCreatePackedUserOperationV8V9`, `getUserOperationEip712DataV8V9`) stop repeating it.

  ## Test

  - New `test/calibur/caliburEip712.test.js`: `getUserOperationEip712Hash` equals `createUserOperationHash` for all UserOp permutations (paymaster × eip7702Auth) on EP v0.8 and v0.9;
  domain / `primaryType` checks; throws on v0.7; root-key `signTypedData` ↔ `signHash` byte-equivalence.
  - Updated `test/simple/simple7702TypedData.test.js`: same permutation coverage for Simple7702 + Simple7702V09, plus v0.7-throw via the new method names.
  - `tsc --noEmit` clean; `yarn build` clean; 48 + 16 targeted unit tests pass.

  ## Risk / Compatibility

  - **Breaking:** removes `BaseSimple7702Account.getUserOperationEip712TypedData` (added in 0.3.5). Callers must rename to `getUserOperationEip712Data` — the returned payload and
  shape are unchanged. Worth a CHANGELOG entry and a minor-version bump.
  - No other public API removed; new methods are additive.
  - Error code unchanged (`AbstractionKitError("BAD_DATA", …)`); error text on the v0.7 throw reads `"getUserOperationEip712Data supports EntryPoint v0.8 / v0.9 only; got <addr>. …"`
  — pattern-matchers on `EntryPoint v0\.8|v0\.9` or on `.code` are unaffected.
  - The `accountGasLimits`/`gasFees` helper refactor is behaviorally a no-op — byte-identical output verified by the existing v7/v8/v9 packer tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EIP-712 typed-data support for UserOperations targeting EntryPoint v0.8/v0.9, with methods to generate payloads and digests.

* **Refactor**
  * Consolidated EIP-712 generation logic into shared utilities, eliminating code duplication.
  * Updated account implementations to delegate to centralized EIP-712 helpers.
  * Added comprehensive tests verifying hashing, signing, and cross-version equivalence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->