### PR TITLE
test(integration): add Calibur and SimpleAccount (v8/v9) to e2e matrix

### DIFF
--- a/test/integration/_entrypoints.cjs
+++ b/test/integration/_entrypoints.cjs
@@ -2,5 +2,5 @@
 // (reads status file). Anything else that needs symbols both before and after
 // the suite has booted should live here too.
 module.exports = {
-    SUPPORTED_ENTRYPOINTS: ['v6', 'v7', 'v9'],
+    SUPPORTED_ENTRYPOINTS: ['v6', 'v7', 'v8', 'v9'],
 };

--- a/test/integration/_runnable.cjs
+++ b/test/integration/_runnable.cjs
@@ -14,18 +14,33 @@ const {
     SafeAccountV0_3_0,
     SafeAccountV1_5_0_M_0_3_0,
     SafeMultiChainSigAccountV1,
+    Calibur7702Account,
+    Simple7702Account,
+    Simple7702AccountV09,
 } = require('../../dist/index.cjs');
 const { SUPPORTED_ENTRYPOINTS } = require('./_entrypoints.cjs');
 
 // `entrypoint` selects which per-chain voltaire instance to route through —
 // each (chain × entrypoint) pair has its own bundler EOA and so its own nonce
-// sequence. V0_3_0 and V1_5_0_M_0_3_0 share v7, which is fine; they don't race
-// against V0_2_0 (v6) or MultiChainSigV1 (v9).
+// sequence. V0_3_0 and V1_5_0_M_0_3_0 share v7, and MultiChainSigV1 and
+// SimpleAccountV09 share v9; voltaire serialises bundles per instance so the
+// shared EOA's nonce sequence is fine. v8 is used only by the 7702 accounts.
+//
+// `isSafeMultiSig` flags accounts that use Safe's multi-owner calling
+// convention — `Account.initializeNewAccount([owner])` and
+// `signUserOperation(userOp, [pk], chainId)`. Accounts without the flag (the
+// 7702 ones) construct from a single EOA address, take a single private key,
+// and need an eip7702Auth in the first userOp to delegate the EOA. Tests that
+// share a flow across both branch on the flag inline; tests that exercise
+// Safe-only surfaces filter the matrix down to `isSafeMultiSig` entries.
 const accountVersions = [
-    { name: 'V0_2_0', accountClass: SafeAccountV0_2_0, entrypoint: 'v6' },
-    { name: 'V0_3_0', accountClass: SafeAccountV0_3_0, entrypoint: 'v7' },
-    { name: 'V1_5_0_M_0_3_0', accountClass: SafeAccountV1_5_0_M_0_3_0, entrypoint: 'v7' },
-    { name: 'MultiChainSigV1', accountClass: SafeMultiChainSigAccountV1, entrypoint: 'v9' },
+    { name: 'V0_2_0', accountClass: SafeAccountV0_2_0, entrypoint: 'v6', isSafeMultiSig: true },
+    { name: 'V0_3_0', accountClass: SafeAccountV0_3_0, entrypoint: 'v7', isSafeMultiSig: true },
+    { name: 'V1_5_0_M_0_3_0', accountClass: SafeAccountV1_5_0_M_0_3_0, entrypoint: 'v7', isSafeMultiSig: true },
+    { name: 'MultiChainSigV1', accountClass: SafeMultiChainSigAccountV1, entrypoint: 'v9', isSafeMultiSig: true },
+    { name: 'Calibur', accountClass: Calibur7702Account, entrypoint: 'v8' },
+    { name: 'SimpleAccount', accountClass: Simple7702Account, entrypoint: 'v8' },
+    { name: 'SimpleAccountV09', accountClass: Simple7702AccountV09, entrypoint: 'v9' },
 ];
 
 const runnable = chains.filter((c) => okByName[c.name]);
@@ -39,8 +54,14 @@ const runnableMatrix = (versions = accountVersions) =>
             accountClass: v.accountClass,
             accountVersion: v.name,
             entrypoint: v.entrypoint,
+            isSafeMultiSig: v.isSafeMultiSig === true,
         })),
     );
+
+// Tests that exercise Safe-only surfaces (multi-owner factory options, multi-
+// key signing, Safe-specific signature wrappers) skip the 7702 entries.
+const safeMultiSigMatrix = () =>
+    runnableMatrix(accountVersions.filter((v) => v.isSafeMultiSig));
 
 module.exports = {
     chains,
@@ -48,6 +69,7 @@ module.exports = {
     unrunnable,
     accountVersions,
     runnableMatrix,
+    safeMultiSigMatrix,
     SUPPORTED_ENTRYPOINTS,
     nodeUrl: (entry) => `http://127.0.0.1:${entry.anvilHostPort}`,
     bundlerUrl: (entry) => {

--- a/test/integration/chains.cjs
+++ b/test/integration/chains.cjs
@@ -1,8 +1,8 @@
 // Each chain runs one anvil + one voltaire instance per supported entrypoint
-// (v6 / v7 / v9). Splitting bundlers per entrypoint gives each its own bundler
-// EOA, so handleOps txes for different EP versions don't share a nonce
-// sequence — which removes the "nonce too low" races we saw when many parallel
-// userops funnel through a single bundler.
+// (v6 / v7 / v8 / v9). Splitting bundlers per entrypoint gives each its own
+// bundler EOA, so handleOps txes for different EP versions don't share a
+// nonce sequence — which removes the "nonce too low" races we saw when many
+// parallel userops funnel through a single bundler.
 module.exports = [
     {
         name: 'ethereum',
@@ -10,7 +10,7 @@ module.exports = [
         defaultForkUrl: 'https://ethereum-rpc.publicnode.com',
         forkUrlEnvVar: 'ETHEREUM_RPC',
         anvilHostPort: 8545,
-        bundlerHostPortByEntrypoint: { v6: 3000, v7: 3001, v9: 3002 },
+        bundlerHostPortByEntrypoint: { v6: 3000, v7: 3001, v8: 3003, v9: 3002 },
     },
     {
         name: 'optimism',
@@ -18,7 +18,7 @@ module.exports = [
         defaultForkUrl: 'https://optimism-rpc.publicnode.com',
         forkUrlEnvVar: 'OPTIMISM_RPC',
         anvilHostPort: 8546,
-        bundlerHostPortByEntrypoint: { v6: 3010, v7: 3011, v9: 3012 },
+        bundlerHostPortByEntrypoint: { v6: 3010, v7: 3011, v8: 3013, v9: 3012 },
     },
     // arbitrum is intentionally excluded: voltaire's L1 gas estimation calls
     // Arbitrum's NodeInterface precompile (Nitro runtime), which anvil cannot

--- a/test/integration/e2e/batch-transactions/batch-transactions.test.js
+++ b/test/integration/e2e/batch-transactions/batch-transactions.test.js
@@ -1,5 +1,8 @@
 const { Wallet } = require('ethers');
-const { sendJsonRpcRequest } = require('../../../../dist/index.cjs');
+const {
+    sendJsonRpcRequest,
+    createAndSignEip7702DelegationAuthorization,
+} = require('../../../../dist/index.cjs');
 const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
@@ -16,7 +19,14 @@ describe('batch transactions', () => {
             const { accountClass: Account } = entry;
 
             const owner = Wallet.createRandom();
-            const account = Account.initializeNewAccount([owner.address]);
+            // EIP-7702 accounts: the EOA address IS the account address, so we
+            // construct from the random wallet's own address.
+            let account;
+            if (entry.isSafeMultiSig) {
+                account = Account.initializeNewAccount([owner.address]);
+            } else {
+                account = new Account(owner.address);
+            }
 
             await sendJsonRpcRequest(node, 'anvil_setBalance', [account.accountAddress, toHex(ONE_ETH)]);
 
@@ -25,6 +35,17 @@ describe('batch transactions', () => {
             const value1 = 1_000_000_000_000_000n;
             const value2 = 2_000_000_000_000_000n;
 
+            // First userOp must carry an eip7702Auth to delegate the EOA to the
+            // singleton; the SDK skips the authorisation if the EOA is already
+            // delegated. The delegation and the delegation signature are only
+            // needed once — subsequent userOps from the same EOA can omit the
+            // eip7702Auth field. Pass `{ chainId }` so the SDK fills dummy r/s
+            // for gas estimation, then overwrite with a real signed
+            // authorization before sending.
+            const createOverrides = {};
+            if (!entry.isSafeMultiSig) {
+                createOverrides.eip7702Auth = { chainId: BigInt(entry.chainId) };
+            }
             let userOp = await account.createUserOperation(
                 [
                     { to: recipient1, value: value1, data: '0x' },
@@ -32,8 +53,22 @@ describe('batch transactions', () => {
                 ],
                 node,
                 bundler,
+                createOverrides,
             );
-            userOp.signature = account.signUserOperation(userOp, [owner.privateKey], BigInt(entry.chainId));
+            if (entry.isSafeMultiSig) {
+                userOp.signature = account.signUserOperation(userOp, [owner.privateKey], BigInt(entry.chainId));
+            } else {
+                // Delegation signature is only needed once — replace the SDK's
+                // dummy auth with a real one signed by the EOA. Subsequent
+                // userOps from this EOA can skip this step entirely.
+                userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+                    BigInt(userOp.eip7702Auth.chainId),
+                    userOp.eip7702Auth.address,
+                    BigInt(userOp.eip7702Auth.nonce),
+                    owner.privateKey,
+                );
+                userOp.signature = account.signUserOperation(userOp, owner.privateKey, BigInt(entry.chainId));
+            }
 
             const sent = await account.sendUserOperation(userOp, bundler);
             const receipt = await sent.included();

--- a/test/integration/e2e/eip-712-signing/eip-712-signing.test.js
+++ b/test/integration/e2e/eip-712-signing/eip-712-signing.test.js
@@ -1,6 +1,6 @@
 const { Wallet } = require('ethers');
 const { sendJsonRpcRequest } = require('../../../../dist/index.cjs');
-const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
+const { safeMultiSigMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
 
@@ -8,7 +8,7 @@ const ONE_ETH = 10n ** 18n;
 const toHex = (n) => `0x${n.toString(16)}`;
 
 describe('eip-712 signing', () => {
-    test.concurrent.each(runnableMatrix())(
+    test.concurrent.each(safeMultiSigMatrix())(
         'sign userop via EIP-712 typed data: $chainName / $accountVersion (chainId $chainId)',
         async (entry) => {
             const node = nodeUrl(entry);

--- a/test/integration/e2e/multisig/multisig.test.js
+++ b/test/integration/e2e/multisig/multisig.test.js
@@ -1,6 +1,6 @@
 const { Wallet } = require('ethers');
 const { sendJsonRpcRequest } = require('../../../../dist/index.cjs');
-const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
+const { safeMultiSigMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
 
@@ -8,7 +8,7 @@ const ONE_ETH = 10n ** 18n;
 const toHex = (n) => `0x${n.toString(16)}`;
 
 describe('multisig safe account', () => {
-    test.concurrent.each(runnableMatrix())(
+    test.concurrent.each(safeMultiSigMatrix())(
         '2-of-2 owners must both sign: $chainName / $accountVersion (chainId $chainId)',
         async (entry) => {
             const node = nodeUrl(entry);

--- a/test/integration/e2e/onchain-identifier/onchain-identifier.test.js
+++ b/test/integration/e2e/onchain-identifier/onchain-identifier.test.js
@@ -1,6 +1,6 @@
 const { Wallet } = require('ethers');
 const { sendJsonRpcRequest } = require('../../../../dist/index.cjs');
-const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
+const { safeMultiSigMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
 
@@ -8,7 +8,7 @@ const ONE_ETH = 10n ** 18n;
 const toHex = (n) => `0x${n.toString(16)}`;
 
 describe('onchain identifier', () => {
-    test.concurrent.each(runnableMatrix())(
+    test.concurrent.each(safeMultiSigMatrix())(
         'identifier embedded in callData + tx input: $chainName / $accountVersion (chainId $chainId)',
         async (entry) => {
             const node = nodeUrl(entry);

--- a/test/integration/e2e/signer/customSigner.test.js
+++ b/test/integration/e2e/signer/customSigner.test.js
@@ -1,5 +1,8 @@
 const { Wallet } = require('ethers');
-const { sendJsonRpcRequest } = require('../../../../dist/index.cjs');
+const {
+    sendJsonRpcRequest,
+    createAndSignEip7702DelegationAuthorization,
+} = require('../../../../dist/index.cjs');
 const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
@@ -21,22 +24,58 @@ describe('signer: customSigner', () => {
                 signHash: async (hash) => wallet.signingKey.sign(hash).serialized,
             };
 
-            const account = Account.initializeNewAccount([signer.address]);
+            // EIP-7702 accounts: the EOA address IS the account address, so we
+            // construct from the random wallet's own address.
+            let account;
+            if (entry.isSafeMultiSig) {
+                account = Account.initializeNewAccount([signer.address]);
+            } else {
+                account = new Account(signer.address);
+            }
             await sendJsonRpcRequest(node, 'anvil_setBalance', [account.accountAddress, toHex(ONE_ETH)]);
 
             const recipient = Wallet.createRandom().address;
             const value = 1_000_000_000_000_000n;
 
+            // First userOp must carry an eip7702Auth to delegate the EOA to the
+            // singleton; the SDK skips the authorisation if the EOA is already
+            // delegated. The delegation and the delegation signature are only
+            // needed once — subsequent userOps from the same EOA can omit the
+            // eip7702Auth field. Pass `{ chainId }` so the SDK fills dummy r/s
+            // for gas estimation, then overwrite with a real signed
+            // authorization before sending.
+            const createOverrides = {};
+            if (!entry.isSafeMultiSig) {
+                createOverrides.eip7702Auth = { chainId: BigInt(entry.chainId) };
+            }
             const userOp = await account.createUserOperation(
                 [{ to: recipient, value, data: '0x' }],
                 node,
                 bundler,
+                createOverrides,
             );
-            userOp.signature = await account.signUserOperationWithSigners(
-                userOp,
-                [signer],
-                BigInt(entry.chainId),
-            );
+            if (entry.isSafeMultiSig) {
+                userOp.signature = await account.signUserOperationWithSigners(
+                    userOp,
+                    [signer],
+                    BigInt(entry.chainId),
+                );
+            } else {
+                // Delegation signature is only needed once — replace the SDK's
+                // dummy auth with a real one signed by the EOA. Subsequent
+                // userOps from this EOA can skip this step entirely.
+                userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+                    BigInt(userOp.eip7702Auth.chainId),
+                    userOp.eip7702Auth.address,
+                    BigInt(userOp.eip7702Auth.nonce),
+                    wallet.privateKey,
+                );
+                userOp.signature = await account.signUserOperationWithSigner(
+                    userOp,
+                    signer,
+                    BigInt(entry.chainId),
+                );
+            }
 
             const sent = await account.sendUserOperation(userOp, bundler);
             const receipt = await sent.included();

--- a/test/integration/e2e/signer/fromEthersWallet.test.js
+++ b/test/integration/e2e/signer/fromEthersWallet.test.js
@@ -1,5 +1,9 @@
 const { Wallet } = require('ethers');
-const { fromEthersWallet, sendJsonRpcRequest } = require('../../../../dist/index.cjs');
+const {
+    fromEthersWallet,
+    sendJsonRpcRequest,
+    createAndSignEip7702DelegationAuthorization,
+} = require('../../../../dist/index.cjs');
 const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
@@ -21,22 +25,58 @@ describe('signer: fromEthersWallet', () => {
             expect(typeof signer.signHash).toBe('function');
             expect(typeof signer.signTypedData).toBe('function');
 
-            const account = Account.initializeNewAccount([signer.address]);
+            // EIP-7702 accounts: the EOA address IS the account address, so we
+            // construct from the random wallet's own address.
+            let account;
+            if (entry.isSafeMultiSig) {
+                account = Account.initializeNewAccount([signer.address]);
+            } else {
+                account = new Account(signer.address);
+            }
             await sendJsonRpcRequest(node, 'anvil_setBalance', [account.accountAddress, toHex(ONE_ETH)]);
 
             const recipient = Wallet.createRandom().address;
             const value = 1_000_000_000_000_000n;
 
+            // First userOp must carry an eip7702Auth to delegate the EOA to the
+            // singleton; the SDK skips the authorisation if the EOA is already
+            // delegated. The delegation and the delegation signature are only
+            // needed once — subsequent userOps from the same EOA can omit the
+            // eip7702Auth field. Pass `{ chainId }` so the SDK fills dummy r/s
+            // for gas estimation, then overwrite with a real signed
+            // authorization before sending.
+            const createOverrides = {};
+            if (!entry.isSafeMultiSig) {
+                createOverrides.eip7702Auth = { chainId: BigInt(entry.chainId) };
+            }
             const userOp = await account.createUserOperation(
                 [{ to: recipient, value, data: '0x' }],
                 node,
                 bundler,
+                createOverrides,
             );
-            userOp.signature = await account.signUserOperationWithSigners(
-                userOp,
-                [signer],
-                BigInt(entry.chainId),
-            );
+            if (entry.isSafeMultiSig) {
+                userOp.signature = await account.signUserOperationWithSigners(
+                    userOp,
+                    [signer],
+                    BigInt(entry.chainId),
+                );
+            } else {
+                // Delegation signature is only needed once — replace the SDK's
+                // dummy auth with a real one signed by the EOA. Subsequent
+                // userOps from this EOA can skip this step entirely.
+                userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+                    BigInt(userOp.eip7702Auth.chainId),
+                    userOp.eip7702Auth.address,
+                    BigInt(userOp.eip7702Auth.nonce),
+                    wallet.privateKey,
+                );
+                userOp.signature = await account.signUserOperationWithSigner(
+                    userOp,
+                    signer,
+                    BigInt(entry.chainId),
+                );
+            }
 
             const sent = await account.sendUserOperation(userOp, bundler);
             const receipt = await sent.included();

--- a/test/integration/e2e/signer/fromViem.test.js
+++ b/test/integration/e2e/signer/fromViem.test.js
@@ -1,6 +1,10 @@
 const { Wallet } = require('ethers');
 const { privateKeyToAccount } = require('viem/accounts');
-const { fromViem, sendJsonRpcRequest } = require('../../../../dist/index.cjs');
+const {
+    fromViem,
+    sendJsonRpcRequest,
+    createAndSignEip7702DelegationAuthorization,
+} = require('../../../../dist/index.cjs');
 const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
@@ -23,22 +27,58 @@ describe('signer: fromViem', () => {
             expect(typeof signer.signHash).toBe('function');
             expect(typeof signer.signTypedData).toBe('function');
 
-            const account = Account.initializeNewAccount([signer.address]);
+            // EIP-7702 accounts: the EOA address IS the account address, so we
+            // construct from the random wallet's own address.
+            let account;
+            if (entry.isSafeMultiSig) {
+                account = Account.initializeNewAccount([signer.address]);
+            } else {
+                account = new Account(signer.address);
+            }
             await sendJsonRpcRequest(node, 'anvil_setBalance', [account.accountAddress, toHex(ONE_ETH)]);
 
             const recipient = Wallet.createRandom().address;
             const value = 1_000_000_000_000_000n;
 
+            // First userOp must carry an eip7702Auth to delegate the EOA to the
+            // singleton; the SDK skips the authorisation if the EOA is already
+            // delegated. The delegation and the delegation signature are only
+            // needed once — subsequent userOps from the same EOA can omit the
+            // eip7702Auth field. Pass `{ chainId }` so the SDK fills dummy r/s
+            // for gas estimation, then overwrite with a real signed
+            // authorization before sending.
+            const createOverrides = {};
+            if (!entry.isSafeMultiSig) {
+                createOverrides.eip7702Auth = { chainId: BigInt(entry.chainId) };
+            }
             const userOp = await account.createUserOperation(
                 [{ to: recipient, value, data: '0x' }],
                 node,
                 bundler,
+                createOverrides,
             );
-            userOp.signature = await account.signUserOperationWithSigners(
-                userOp,
-                [signer],
-                BigInt(entry.chainId),
-            );
+            if (entry.isSafeMultiSig) {
+                userOp.signature = await account.signUserOperationWithSigners(
+                    userOp,
+                    [signer],
+                    BigInt(entry.chainId),
+                );
+            } else {
+                // Delegation signature is only needed once — replace the SDK's
+                // dummy auth with a real one signed by the EOA. Subsequent
+                // userOps from this EOA can skip this step entirely.
+                userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+                    BigInt(userOp.eip7702Auth.chainId),
+                    userOp.eip7702Auth.address,
+                    BigInt(userOp.eip7702Auth.nonce),
+                    ethersWallet.privateKey,
+                );
+                userOp.signature = await account.signUserOperationWithSigner(
+                    userOp,
+                    signer,
+                    BigInt(entry.chainId),
+                );
+            }
 
             const sent = await account.sendUserOperation(userOp, bundler);
             const receipt = await sent.included();

--- a/test/integration/e2e/signer/fromViemWalletClient.test.js
+++ b/test/integration/e2e/signer/fromViemWalletClient.test.js
@@ -1,7 +1,11 @@
 const { Wallet } = require('ethers');
 const { createWalletClient, http } = require('viem');
 const { privateKeyToAccount } = require('viem/accounts');
-const { fromViemWalletClient, sendJsonRpcRequest } = require('../../../../dist/index.cjs');
+const {
+    fromViemWalletClient,
+    sendJsonRpcRequest,
+    createAndSignEip7702DelegationAuthorization,
+} = require('../../../../dist/index.cjs');
 const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
@@ -9,8 +13,15 @@ jest.setTimeout(120000);
 const ONE_ETH = 10n ** 18n;
 const toHex = (n) => `0x${n.toString(16)}`;
 
+// Calibur only accepts `signHash`-capable signers (its userOp signature is a
+// raw ECDSA over the userOp hash, then wrapped). A viem WalletClient signer
+// only exposes `signTypedData`, so this adapter combination is unsupported by
+// design — `signUserOperationWithSigner` throws offline with an actionable
+// error. Filter Calibur out so the matrix only covers compatible pairings.
+const matrix = runnableMatrix().filter((entry) => entry.accountVersion !== 'Calibur');
+
 describe('signer: fromViemWalletClient', () => {
-    test.concurrent.each(runnableMatrix())(
+    test.concurrent.each(matrix)(
         'viem WalletClient adapter signs userop: $chainName / $accountVersion (chainId $chainId)',
         async (entry) => {
             const node = nodeUrl(entry);
@@ -28,22 +39,58 @@ describe('signer: fromViemWalletClient', () => {
             expect(typeof signer.signHash).toBe('undefined');
             expect(typeof signer.signTypedData).toBe('function');
 
-            const account = Account.initializeNewAccount([signer.address]);
+            // EIP-7702 accounts: the EOA address IS the account address, so we
+            // construct from the random wallet's own address.
+            let account;
+            if (entry.isSafeMultiSig) {
+                account = Account.initializeNewAccount([signer.address]);
+            } else {
+                account = new Account(signer.address);
+            }
             await sendJsonRpcRequest(node, 'anvil_setBalance', [account.accountAddress, toHex(ONE_ETH)]);
 
             const recipient = Wallet.createRandom().address;
             const value = 1_000_000_000_000_000n;
 
+            // First userOp must carry an eip7702Auth to delegate the EOA to the
+            // singleton; the SDK skips the authorisation if the EOA is already
+            // delegated. The delegation and the delegation signature are only
+            // needed once — subsequent userOps from the same EOA can omit the
+            // eip7702Auth field. Pass `{ chainId }` so the SDK fills dummy r/s
+            // for gas estimation, then overwrite with a real signed
+            // authorization before sending.
+            const createOverrides = {};
+            if (!entry.isSafeMultiSig) {
+                createOverrides.eip7702Auth = { chainId: BigInt(entry.chainId) };
+            }
             const userOp = await account.createUserOperation(
                 [{ to: recipient, value, data: '0x' }],
                 node,
                 bundler,
+                createOverrides,
             );
-            userOp.signature = await account.signUserOperationWithSigners(
-                userOp,
-                [signer],
-                BigInt(entry.chainId),
-            );
+            if (entry.isSafeMultiSig) {
+                userOp.signature = await account.signUserOperationWithSigners(
+                    userOp,
+                    [signer],
+                    BigInt(entry.chainId),
+                );
+            } else {
+                // Delegation signature is only needed once — replace the SDK's
+                // dummy auth with a real one signed by the EOA. Subsequent
+                // userOps from this EOA can skip this step entirely.
+                userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+                    BigInt(userOp.eip7702Auth.chainId),
+                    userOp.eip7702Auth.address,
+                    BigInt(userOp.eip7702Auth.nonce),
+                    ethersWallet.privateKey,
+                );
+                userOp.signature = await account.signUserOperationWithSigner(
+                    userOp,
+                    signer,
+                    BigInt(entry.chainId),
+                );
+            }
 
             const sent = await account.sendUserOperation(userOp, bundler);
             const receipt = await sent.included();

--- a/test/integration/globalSetup.cjs
+++ b/test/integration/globalSetup.cjs
@@ -126,6 +126,7 @@ function startVoltaire(chain, ep, bundlerSecret) {
         '--logs_number_of_ranges', '1',
         '--enforce_gas_price_tolerance', '50',
         '--bundle_gas_estimation_multiplier', '3',
+        '--eip7702', 'y',
     ]);
 }
 


### PR DESCRIPTION
## Summary

Extends the account matrix with three EIP-7702 accounts: Calibur and SimpleAccount on EntryPoint v0.8, and SimpleAccountV09 on v0.9. v0.8 joins the per-chain bundler set (each chain now runs four voltaire instances), and the bundlers are launched with --eip7702.

Account-agnostic suites (batch-transactions, signer/*) branch on a new isSafeMultiSig matrix flag to handle the 7702 lifecycle: ctor takes the EOA address rather than [owner], signing takes a single key rather than [key], and the first userOp must carry a real eip7702Auth.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EIP-7702 delegation flows and Safe multi-sig account types.
  * Extended entrypoint support to include v8.

* **Tests**
  * Updated integration tests to support new EIP-7702 and Safe multi-sig account configurations.
  * Enhanced bundler configuration for additional entrypoint version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/177)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->