### PR TITLE
Extends EIP-712 typed-data signing for the remaining accounts and unifies the EIP-712 helper API surface

### DIFF
--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -168,6 +168,33 @@ export class Calibur7702Account
 		return abiCoder.encode(["bytes32", "bytes", "bytes"], [keyHash, rawSignature, hookData]);
 	}
 
+	/**
+	 * Format a raw EIP-712 signature (from `signTypedData` over the payload
+	 * returned by {@link getUserOperationEip712Data}) into Calibur's
+	 * `userOp.signature` layout. Provided for API parity with Safe's
+	 * `formatEip712SingleSignatureToUseroperationSignature`.
+	 *
+	 * Under EntryPoint v0.8 / v0.9 the userOpHash IS the EIP-712 digest of
+	 * the PackedUserOperation, so a raw-hash signature and a typed-data
+	 * signature are byte-identical for deterministic-ECDSA signers; this
+	 * method is therefore equivalent to {@link wrapSignature} with the same
+	 * `keyHash` / `hookData`. The default `keyHash` is the root-key hash
+	 * (`bytes32(0)`), which selects the EOA's own secp256k1 key.
+	 *
+	 * @param signature - Raw ECDSA signature (65 bytes, hex-encoded) from
+	 *   `signTypedData` over the payload from {@link getUserOperationEip712Data}
+	 * @param overrides - Optional `keyHash` / `hookData` overrides
+	 * @returns Hex-encoded wrapped signature ready for `userOp.signature`
+	 */
+	public static formatEip712SingleSignatureToUseroperationSignature(
+		signature: string,
+		overrides: CaliburSignatureOverrides = {},
+	): string {
+		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
+		const hookData = overrides.hookData ?? "0x";
+		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);
+	}
+
 	/** The EntryPoint contract address this account targets */
 	readonly entrypointAddress: string;
 	/** The Calibur singleton (delegatee) contract address */
@@ -658,27 +685,31 @@ export class Calibur7702Account
 	}
 
 	/**
-	 * Schemes Calibur accepts from a Signer. Only raw-hash ECDSA, since
-	 * the account verifies a plain signature over the userOp hash, then
-	 * wraps with `(keyHash, signature, hookData)`.
+	 * Schemes Calibur accepts from a Signer. EntryPoint v0.8/v0.9 introduced
+	 * an EIP-712 domain at the EntryPoint contract, and the userOpHash IS the
+	 * EIP-712 digest of the PackedUserOperation under that domain — so signing
+	 * the typed data and signing the raw hash produce signatures that verify
+	 * against the same `userOpHash` (and recover to the same signer address).
+	 * Deterministic-ECDSA signers (ethers, viem, MetaMask) yield byte-identical
+	 * bytes; signers that differ in `s` / `v` normalization still validate the
+	 * same on-chain.
+	 *
+	 * `typedData` is listed first so JSON-RPC wallets that can only sign typed
+	 * data work without a separate code path; `hash` remains a valid fallback
+	 * for local-key signers.
 	 */
-	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["hash"];
+	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["typedData", "hash"];
 
 	/**
-	 * Sign a UserOperation using an {@link ExternalSigner}. Calibur only
-	 * accepts raw-hash ECDSA; signers without `signHash` fail offline with
-	 * an actionable error.
+	 * Sign a UserOperation with an {@link AkSigner}. The signer can implement
+	 * either `signTypedData` (preferred — JSON-RPC wallets, viem `WalletClient`)
+	 * or `signHash` (local keys, hardware wallets). Both schemes produce
+	 * signatures that validate against the same `userOpHash` because the
+	 * v0.8 / v0.9 userOpHash IS the EIP-712 digest of the PackedUserOperation
+	 * (deterministic-ECDSA signers yield byte-identical bytes).
 	 *
-	 * For signing with a raw private-key string, use the sync
-	 * {@link signUserOperation} method, or wrap explicitly with
-	 * `fromPrivateKey(pk)`. For secondary (non-root) keys, pass the key
-	 * hash via `overrides.keyHash`.
-	 *
-	 * @example
-	 * import { fromViem, fromEthersWallet } from "abstractionkit";
-	 * userOp.signature = await account.signUserOperationWithSigner(
-	 *   userOp, fromViem(privateKeyToAccount(pk)), chainId,
-	 * );
+	 * Signers that implement neither method fail offline with an actionable
+	 * error.
 	 */
 	public async signUserOperationWithSigner(
 		userOperation: UserOperationV8,
@@ -700,7 +731,13 @@ export class Calibur7702Account
 			chainId,
 			entryPoint: this.entrypointAddress,
 		};
-		const signature = await invokeSigner(signer, scheme, { hash, context });
+		const typedData =
+			scheme === "typedData"
+				? Calibur7702Account.getUserOperationEip712Data(userOperation, chainId, {
+						entrypointAddress: this.entrypointAddress,
+					})
+				: undefined;
+		const signature = await invokeSigner(signer, scheme, { hash, typedData, context });
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
 		const hookData = overrides.hookData ?? "0x";
 		return Calibur7702Account.wrapSignature(keyHash, signature, hookData);

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -209,9 +209,8 @@ export class Calibur7702Account
 	 * Build the EIP-712 typed data payload for a UserOperation under the
 	 * EntryPoint v0.8 / v0.9 domain. Useful for wallets that can only sign
 	 * typed data (`eth_signTypedData_v4`) — the digest of the returned payload
-	 * equals the `userOpHash` ({@link getUserOperationHash}), so a typed-data
-	 * signature over it produces a wrapped Calibur signature that validates
-	 * against the same hash on-chain.
+	 * equals the `userOpHash`, so a typed-data signature over it produces a
+	 * wrapped Calibur signature that validates against the same hash on-chain.
 	 *
 	 * Intended for the secp256k1 key path (root key or any registered
 	 * secondary secp256k1 key), since `eth_signTypedData_v4` only produces
@@ -221,37 +220,41 @@ export class Calibur7702Account
 	 *
 	 * @param userOperation - Unsigned UserOperation to wrap
 	 * @param chainId - Target chain ID
+	 * @param overrides - Override the entrypoint address (defaults to EntryPoint v0.8)
 	 * @returns EIP-712 {@link TypedData} payload ready for `signTypedData`
-	 * @throws {AbstractionKitError} if this account targets an EntryPoint
-	 *   version other than v0.8 / v0.9.
+	 * @throws {AbstractionKitError} if the target EntryPoint is not v0.8 / v0.9.
 	 */
-	public getUserOperationEip712Data(
+	public static getUserOperationEip712Data(
 		userOperation: UserOperationV8 | UserOperationV9,
 		chainId: bigint,
+		overrides: { entrypointAddress?: string } = {},
 	): TypedData {
-		return getUserOperationEip712DataV8V9(userOperation, this.entrypointAddress, chainId);
+		const entrypointAddress = overrides.entrypointAddress ?? ENTRYPOINT_V8;
+		return getUserOperationEip712DataV8V9(userOperation, entrypointAddress, chainId);
 	}
 
 	/**
 	 * Compute the EIP-712 digest of a UserOperation under the EntryPoint
 	 * v0.8 / v0.9 domain. For these EntryPoints this digest IS the
-	 * `userOpHash` ({@link getUserOperationHash}); the wrapped Calibur
-	 * signature is verified against this hash on-chain.
+	 * `userOpHash`; the wrapped Calibur signature is verified against this
+	 * hash on-chain.
 	 *
 	 * Universal across Calibur key types: secp256k1 and P-256 keys sign
 	 * this digest directly, each with their own signing primitive.
 	 *
 	 * @param userOperation - Unsigned UserOperation to hash
 	 * @param chainId - Target chain ID
+	 * @param overrides - Override the entrypoint address (defaults to EntryPoint v0.8)
 	 * @returns The EIP-712 digest as a hex string
-	 * @throws {AbstractionKitError} if this account targets an EntryPoint
-	 *   version other than v0.8 / v0.9.
+	 * @throws {AbstractionKitError} if the target EntryPoint is not v0.8 / v0.9.
 	 */
-	public getUserOperationEip712Hash(
+	public static getUserOperationEip712Hash(
 		userOperation: UserOperationV8 | UserOperationV9,
 		chainId: bigint,
+		overrides: { entrypointAddress?: string } = {},
 	): string {
-		return getUserOperationEip712HashV8V9(userOperation, this.entrypointAddress, chainId);
+		const entrypointAddress = overrides.entrypointAddress ?? ENTRYPOINT_V8;
+		return getUserOperationEip712HashV8V9(userOperation, entrypointAddress, chainId);
 	}
 
 	// ─── CallData Encoding ───────────────────────────────────────────────

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -1,7 +1,16 @@
 import { getAddress, TypedDataEncoder, Wallet } from "ethers";
-import { EIP712_MULTI_CHAIN_OPERATIONS_TYPE, ENTRYPOINT_V9 } from "src/constants";
+import {
+	EIP712_MULTI_CHAIN_OPERATIONS_PRIMARY_TYPE,
+	EIP712_MULTI_CHAIN_OPERATIONS_TYPE,
+	ENTRYPOINT_V9,
+} from "src/constants";
 import { invokeSigner, pickScheme } from "src/signer/negotiate";
-import type { Signer as AkSigner, MultiOpSignContext, SignContext } from "src/signer/types";
+import type {
+	Signer as AkSigner,
+	MultiOpSignContext,
+	SignContext,
+	TypedData,
+} from "src/signer/types";
 import type { MetaTransaction, OnChainIdentifierParamsType, UserOperationV9 } from "../../types";
 import {
 	DEFAULT_WEB_AUTHN_DAIMO_VERIFIER_V_0_2_1,
@@ -605,15 +614,15 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	/**
 	 * Sign a list of UserOperations with a single multi-chain signature. Each
 	 * signer signs the Merkle root of the UserOperation EIP-712 hashes via
-	 * raw-hash signing; `signTypedData` isn't exposed because the Merkle root
-	 * is opaque and has no meaningful typed-data display.
+	 * either `signTypedData` (the root is wrapped in an EIP-712 `MerkleTreeRoot`
+	 * message) or raw-hash signing; both schemes produce signatures that
+	 * validate against the same on-chain digest.
 	 *
 	 * Signers always receive {@link MultiOpSignContext}. The built-in adapters
-	 * `fromPrivateKey`, `fromViem`, and `fromEthersWallet` return
-	 * `Signer<unknown>` and work here without retyping; `fromViemWalletClient`
-	 * does **not** — it only exposes `signTypedData`, so {@link pickScheme}
-	 * rejects it offline. User-defined single-op signers
-	 * (`Signer<SignContext>`) also don't work — they'd receive a context shape
+	 * `fromPrivateKey`, `fromViem`, `fromEthersWallet`, and `fromViemWalletClient`
+	 * all work here without retyping (`fromViemWalletClient` will sign the
+	 * typed-data Merkle wrapper). User-defined single-op signers
+	 * (`Signer<SignContext>`) still don't work — they'd receive a context shape
 	 * they didn't declare.
 	 *
 	 * Note the chainId plumbing asymmetry vs the single-op variant:
@@ -678,19 +687,31 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			// instead of after an external signer has been prompted.
 			const normalizedAddresses = signers.map((signer) => getAddress(signer.address));
 
-			// Merkle root is opaque; signTypedData has nothing meaningful to
-			// display, so we require raw-hash signing.
-			signers.forEach((signer, i) => {
-				pickScheme(signer, ["hash"], {
+			// The Merkle root is wrapped in an EIP-712 `MerkleTreeRoot` message
+			// whose digest equals `merkleTreeRootHash`, so a typed-data signature
+			// over it is byte-identical (for deterministic-ECDSA signers) to a
+			// raw-hash signature. Accept both schemes so JSON-RPC wallets that
+			// only sign typed data can sign multi-op bundles.
+			const typedDataForBundle: TypedData = {
+				domain: {
+					verifyingContract: this.safe4337ModuleAddress as `0x${string}`,
+				},
+				types: EIP712_MULTI_CHAIN_OPERATIONS_TYPE,
+				primaryType: EIP712_MULTI_CHAIN_OPERATIONS_PRIMARY_TYPE,
+				message: { merkleTreeRoot: root },
+			};
+			const schemes = signers.map((signer, i) =>
+				pickScheme(signer, ["typedData", "hash"], {
 					accountName: "SafeMultiChainSigAccountV1 (multi-op Merkle root)",
 					signerIndex: i,
-				});
-			});
+				}),
+			);
 
 			const signatures = await Promise.all(
-				signers.map((signer) =>
-					invokeSigner(signer, "hash", {
+				signers.map((signer, i) =>
+					invokeSigner(signer, schemes[i], {
 						hash: merkleTreeRootHash,
+						typedData: typedDataForBundle,
 						context,
 					}),
 				),

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -791,26 +791,23 @@ export class BaseSimple7702Account extends SmartAccount {
 	 * Deterministic-ECDSA signers yield byte-identical signatures; signers
 	 * that differ in `s` / `v` normalization still validate the same on-chain.
 	 *
-	 * Common use cases beyond direct signing:
-	 *   - Inspect / log the typed data the wallet will display.
-	 *   - Render a custom confirmation UI before delegating to a wallet's
-	 *     `signTypedData`.
-	 *   - Drive non-`ExternalSigner`-shaped signers (HSM, MPC service,
-	 *     backend signing pipelines).
+	 * The base class defaults to EntryPoint v0.8; subclasses
+	 * ({@link Simple7702AccountV09}) override with their own default.
 	 *
 	 * @param userOperation - Unsigned UserOperation to wrap
 	 * @param chainId - Target chain ID (must match the chain that will validate
 	 *   the signature)
+	 * @param overrides - Override the entrypoint address
 	 * @returns EIP-712 {@link TypedData} payload ready for `signTypedData`
-	 * @throws {AbstractionKitError} if this account targets an EntryPoint
-	 *   version other than v0.8 / v0.9. Earlier EntryPoints define the
-	 *   userOpHash differently and require raw-hash signing.
+	 * @throws {AbstractionKitError} if the target EntryPoint is not v0.8 / v0.9.
 	 */
-	public getUserOperationEip712Data(
+	public static getUserOperationEip712Data(
 		userOperation: UserOperationV8 | UserOperationV9,
 		chainId: bigint,
+		overrides: { entrypointAddress?: string } = {},
 	): TypedData {
-		return getUserOperationEip712DataV8V9(userOperation, this.entrypointAddress, chainId);
+		const entrypointAddress = overrides.entrypointAddress ?? ENTRYPOINT_V8;
+		return getUserOperationEip712DataV8V9(userOperation, entrypointAddress, chainId);
 	}
 
 	/**
@@ -823,15 +820,17 @@ export class BaseSimple7702Account extends SmartAccount {
 	 *
 	 * @param userOperation - Unsigned UserOperation to hash
 	 * @param chainId - Target chain ID
+	 * @param overrides - Override the entrypoint address (defaults to EntryPoint v0.8)
 	 * @returns The EIP-712 digest as a hex string
-	 * @throws {AbstractionKitError} if this account targets an EntryPoint
-	 *   version other than v0.8 / v0.9.
+	 * @throws {AbstractionKitError} if the target EntryPoint is not v0.8 / v0.9.
 	 */
-	public getUserOperationEip712Hash(
+	public static getUserOperationEip712Hash(
 		userOperation: UserOperationV8 | UserOperationV9,
 		chainId: bigint,
+		overrides: { entrypointAddress?: string } = {},
 	): string {
-		return getUserOperationEip712HashV8V9(userOperation, this.entrypointAddress, chainId);
+		const entrypointAddress = overrides.entrypointAddress ?? ENTRYPOINT_V8;
+		return getUserOperationEip712HashV8V9(userOperation, entrypointAddress, chainId);
 	}
 
 	/**
@@ -866,7 +865,9 @@ export class BaseSimple7702Account extends SmartAccount {
 		};
 		const typedData =
 			scheme === "typedData"
-				? this.getUserOperationEip712Data(useroperation, chainId)
+				? BaseSimple7702Account.getUserOperationEip712Data(useroperation, chainId, {
+						entrypointAddress: this.entrypointAddress,
+					})
 				: undefined;
 		return invokeSigner(signer, scheme, { hash, typedData, context });
 	}

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -1,5 +1,5 @@
 import { ENTRYPOINT_V9 } from "src/constants";
-import type { Signer as AkSigner } from "src/signer/types";
+import type { Signer as AkSigner, TypedData } from "src/signer/types";
 import type { StateOverrideSet, UserOperationV9 } from "src/types";
 import type { SendUseroperationResponse } from "../SendUseroperationResponse";
 import {
@@ -16,6 +16,36 @@ import {
  */
 export class Simple7702AccountV09 extends BaseSimple7702Account {
 	static readonly DEFAULT_DELEGATEE_ADDRESS = "0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5";
+
+	/**
+	 * Build the EIP-712 typed data payload for a {@link UserOperationV9}
+	 * under the EntryPoint v0.9 domain. See
+	 * {@link BaseSimple7702Account.getUserOperationEip712Data} for the
+	 * full semantics; this override just defaults `entrypointAddress` to v0.9.
+	 */
+	public static getUserOperationEip712Data(
+		userOperation: UserOperationV9,
+		chainId: bigint,
+		overrides: { entrypointAddress?: string } = {},
+	): TypedData {
+		return BaseSimple7702Account.getUserOperationEip712Data(userOperation, chainId, {
+			entrypointAddress: overrides.entrypointAddress ?? ENTRYPOINT_V9,
+		});
+	}
+
+	/**
+	 * Compute the EIP-712 digest of a {@link UserOperationV9} under the
+	 * EntryPoint v0.9 domain. Defaults `entrypointAddress` to v0.9.
+	 */
+	public static getUserOperationEip712Hash(
+		userOperation: UserOperationV9,
+		chainId: bigint,
+		overrides: { entrypointAddress?: string } = {},
+	): string {
+		return BaseSimple7702Account.getUserOperationEip712Hash(userOperation, chainId, {
+			entrypointAddress: overrides.entrypointAddress ?? ENTRYPOINT_V9,
+		});
+	}
 
 	/**
 	 * @param accountAddress - The EOA address that will be delegated via EIP-7702

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -61,7 +61,7 @@ function buildMismatchMessage(params: {
 /**
  * Invoke a signer for one scheme. Keeps the dispatch in one place so the
  * account-side code stays linear. `typedData` is optional: accounts that
- * only accept the `"hash"` scheme (Simple7702, Calibur) pass just `hash`.
+ * only accept the `"hash"` scheme can pass just `hash`.
  *
  * `context` is always forwarded to the signer so power-user implementations
  * can inspect the userOp.

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -47,11 +47,11 @@ export interface SignContext<T extends BaseUserOperation = BaseUserOperation> {
  *
  * Type your multi-op signer as `ExternalSigner<MultiOpSignContext>` for
  * full autocomplete on `userOperations`. Pre-built adapters
- * `fromPrivateKey`, `fromViem`, and `fromEthersWallet` return a universal
- * `Signer<unknown>` and work on either single-op or multi-op paths
- * without retyping. `fromViemWalletClient` only exposes `signTypedData`,
- * so it's usable on single-op paths only — the multi-op Merkle root is
- * opaque, has no typed-data display, and requires raw-hash signing.
+ * `fromPrivateKey`, `fromViem`, `fromEthersWallet`, and
+ * `fromViemWalletClient` all return a universal `Signer<unknown>` and
+ * work on either single-op or multi-op paths without retyping — the
+ * multi-op Merkle root is wrapped in an EIP-712 `MerkleTreeRoot`
+ * message, so `signTypedData`-only signers are accepted.
  */
 export interface MultiOpSignContext<T extends BaseUserOperation = BaseUserOperation> {
 	readonly userOperations: ReadonlyArray<{

--- a/test/calibur/caliburEip712.test.js
+++ b/test/calibur/caliburEip712.test.js
@@ -73,7 +73,7 @@ describe('Calibur7702Account.getUserOperationEip712Hash (v0.8)', () => {
         test(`hash equals userOpHash — ${name}`, () => {
             const account = new ak.Calibur7702Account(ownerAddress);
             const userOp = build();
-            const eip712Hash = account.getUserOperationEip712Hash(userOp, chainId);
+            const eip712Hash = ak.Calibur7702Account.getUserOperationEip712Hash(userOp, chainId);
             const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V8, chainId);
             expect(eip712Hash).toBe(userOpHash);
             expect(eip712Hash).toBe(account.getUserOperationHash(userOp, chainId));
@@ -84,22 +84,18 @@ describe('Calibur7702Account.getUserOperationEip712Hash (v0.8)', () => {
 describe('Calibur7702Account.getUserOperationEip712Hash (v0.9)', () => {
     PERMUTATIONS.forEach(({ name, build }) => {
         test(`hash equals userOpHash — ${name}`, () => {
-            const account = new ak.Calibur7702Account(ownerAddress, {
+            const eip712Hash = ak.Calibur7702Account.getUserOperationEip712Hash(build(), chainId, {
                 entrypointAddress: ENTRYPOINT_V9,
-                delegateeAddress: ak.CALIBUR_CANDIDE_V0_1_0_SINGLETON_ADDRESS,
             });
-            const userOp = build();
-            const eip712Hash = account.getUserOperationEip712Hash(userOp, chainId);
-            const userOpHash = ak.createUserOperationHash(userOp, ENTRYPOINT_V9, chainId);
+            const userOpHash = ak.createUserOperationHash(build(), ENTRYPOINT_V9, chainId);
             expect(eip712Hash).toBe(userOpHash);
         });
     });
 });
 
 describe('Calibur7702Account.getUserOperationEip712Data', () => {
-    test('v0.8 domain matches EntryPoint v0.8', () => {
-        const account = new ak.Calibur7702Account(ownerAddress);
-        const td = account.getUserOperationEip712Data(makeUserOp(), chainId);
+    test('v0.8 domain matches EntryPoint v0.8 (default)', () => {
+        const td = ak.Calibur7702Account.getUserOperationEip712Data(makeUserOp(), chainId);
         expect(td.domain.name).toBe("ERC4337");
         expect(td.domain.version).toBe("1");
         expect(td.domain.chainId).toBe(chainId);
@@ -107,28 +103,25 @@ describe('Calibur7702Account.getUserOperationEip712Data', () => {
         expect(td.primaryType).toBe("PackedUserOperation");
     });
 
-    test('v0.9 domain matches EntryPoint v0.9', () => {
-        const account = new ak.Calibur7702Account(ownerAddress, {
+    test('v0.9 domain matches EntryPoint v0.9 (override)', () => {
+        const td = ak.Calibur7702Account.getUserOperationEip712Data(makeUserOp(), chainId, {
             entrypointAddress: ENTRYPOINT_V9,
-            delegateeAddress: ak.CALIBUR_CANDIDE_V0_1_0_SINGLETON_ADDRESS,
         });
-        const td = account.getUserOperationEip712Data(makeUserOp(), chainId);
         expect(td.domain.verifyingContract).toBe(ENTRYPOINT_V9);
     });
 
     test('throws on v0.7 EntryPoint override', () => {
-        const account = new ak.Calibur7702Account(ownerAddress, {
-            entrypointAddress: ENTRYPOINT_V7,
-        });
-        expect(() => account.getUserOperationEip712Data(makeUserOp(), chainId))
-            .toThrow(/EntryPoint v0\.8|v0\.9/i);
+        expect(() =>
+            ak.Calibur7702Account.getUserOperationEip712Data(makeUserOp(), chainId, {
+                entrypointAddress: ENTRYPOINT_V7,
+            }),
+        ).toThrow(/EntryPoint v0\.8|v0\.9/i);
     });
 });
 
 describe('Calibur signTypedData / signHash byte-equivalence (root key)', () => {
     PERMUTATIONS.forEach(({ name, build }) => {
         test(`v0.8 — ${name}`, async () => {
-            const account = new ak.Calibur7702Account(ownerAddress);
             const userOp = build();
 
             // Path A: raw-hash signing (the existing Calibur path)
@@ -136,7 +129,7 @@ describe('Calibur signTypedData / signHash byte-equivalence (root key)', () => {
             const sigA = wallet.signingKey.sign(userOpHash).serialized;
 
             // Path B: typed-data signing
-            const td = account.getUserOperationEip712Data(userOp, chainId);
+            const td = ak.Calibur7702Account.getUserOperationEip712Data(userOp, chainId);
             const sigB = await wallet.signTypedData(td.domain, td.types, td.message);
 
             // For deterministic ECDSA (ethers), both signatures are byte-identical.

--- a/test/integration/e2e/eip-712-signing/eip-712-signing.test.js
+++ b/test/integration/e2e/eip-712-signing/eip-712-signing.test.js
@@ -1,6 +1,9 @@
 const { Wallet } = require('ethers');
-const { sendJsonRpcRequest } = require('../../../../dist/index.cjs');
-const { safeMultiSigMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
+const {
+    sendJsonRpcRequest,
+    createAndSignEip7702DelegationAuthorization,
+} = require('../../../../dist/index.cjs');
+const { runnableMatrix, unrunnable, nodeUrl, bundlerUrl } = require('../../_runnable.cjs');
 
 jest.setTimeout(120000);
 
@@ -8,7 +11,7 @@ const ONE_ETH = 10n ** 18n;
 const toHex = (n) => `0x${n.toString(16)}`;
 
 describe('eip-712 signing', () => {
-    test.concurrent.each(safeMultiSigMatrix())(
+    test.concurrent.each(runnableMatrix())(
         'sign userop via EIP-712 typed data: $chainName / $accountVersion (chainId $chainId)',
         async (entry) => {
             const node = nodeUrl(entry);
@@ -16,43 +19,86 @@ describe('eip-712 signing', () => {
             const { accountClass: Account } = entry;
 
             const owner = Wallet.createRandom();
-            const account = Account.initializeNewAccount([owner.address]);
+            // EIP-7702 accounts: the EOA address IS the account address, so
+            // construct from the random wallet's own address.
+            let account;
+            if (entry.isSafeMultiSig) {
+                account = Account.initializeNewAccount([owner.address]);
+            } else {
+                account = new Account(owner.address);
+            }
 
             await sendJsonRpcRequest(node, 'anvil_setBalance', [account.accountAddress, toHex(ONE_ETH)]);
 
             const recipient = Wallet.createRandom().address;
             const value = 1_000_000_000_000_000n;
 
+            // First 7702 userOp must carry an eip7702Auth so the EOA gets
+            // delegated to the singleton; pass `{ chainId }` for dummy r/s
+            // during gas estimation and overwrite with a real signed auth
+            // before sending.
+            const createOverrides = {};
+            if (!entry.isSafeMultiSig) {
+                createOverrides.eip7702Auth = { chainId: BigInt(entry.chainId) };
+            }
             const userOp = await account.createUserOperation(
                 [{ to: recipient, value, data: '0x' }],
                 node,
                 bundler,
+                createOverrides,
             );
 
-            const { domain, types, messageValue } = Account.getUserOperationEip712Data(
+            const { domain, types, messageValue, message } = Account.getUserOperationEip712Data(
                 userOp,
                 BigInt(entry.chainId),
             );
             const { EIP712Domain, ...typesForSigning } = types;
-            const signature = await owner.signTypedData(domain, typesForSigning, messageValue);
-
-            // MultiChainSigV1's on-chain module verifies against a Merkle root
-            // even for single-op signatures, so the formatter needs to mark
-            // this signature as multi-chain so the wrapper includes the Merkle
-            // proof bit. For other Safe versions the override is ignored.
-            const isMultiChain = entry.accountVersion === 'MultiChainSigV1';
-            const singleFormatted = Account.formatEip712SingleSignatureToUseroperationSignature(
-                signature,
-                { isMultiChainSignature: isMultiChain },
+            // Safe's helper exposes the typed value under `messageValue`; the
+            // shared v8/v9 helper (Calibur, Simple7702) exposes it under
+            // `message`. Take whichever is defined.
+            const signature = await owner.signTypedData(
+                domain,
+                typesForSigning,
+                messageValue ?? message,
             );
-            const pluralFormatted = Account.formatEip712SignaturesToUseroperationSignature(
-                ['0x0000000000000000000000000000000000000000'],
-                [signature],
-                { isMultiChainSignature: isMultiChain },
-            );
-            expect(singleFormatted).toBe(pluralFormatted);
 
-            userOp.signature = singleFormatted;
+            if (entry.isSafeMultiSig) {
+                // MultiChainSigV1's on-chain module verifies against a Merkle
+                // root even for single-op signatures, so the formatter needs
+                // to mark this signature as multi-chain so the wrapper
+                // includes the Merkle proof bit. Other Safe versions ignore.
+                const isMultiChain = entry.accountVersion === 'MultiChainSigV1';
+                const singleFormatted = Account.formatEip712SingleSignatureToUseroperationSignature(
+                    signature,
+                    { isMultiChainSignature: isMultiChain },
+                );
+                const pluralFormatted = Account.formatEip712SignaturesToUseroperationSignature(
+                    [owner.address],
+                    [signature],
+                    { isMultiChainSignature: isMultiChain },
+                );
+                expect(singleFormatted).toBe(pluralFormatted);
+                userOp.signature = singleFormatted;
+            } else {
+                // Replace the SDK's dummy 7702 auth with a real one signed by
+                // the EOA; only needed on the first userOp per EOA.
+                userOp.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+                    BigInt(userOp.eip7702Auth.chainId),
+                    userOp.eip7702Auth.address,
+                    BigInt(userOp.eip7702Auth.nonce),
+                    owner.privateKey,
+                );
+                if (entry.accountVersion === 'Calibur') {
+                    // Calibur wraps as abi.encode(keyHash, sig, hookData);
+                    // the default keyHash is bytes32(0) — the EOA's root key.
+                    userOp.signature = Account.formatEip712SingleSignatureToUseroperationSignature(
+                        signature,
+                    );
+                } else {
+                    // Simple7702 (v8 / v09): raw ECDSA signature, no wrapping.
+                    userOp.signature = signature;
+                }
+            }
 
             const sent = await account.sendUserOperation(userOp, bundler);
             const receipt = await sent.included();

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -796,14 +796,16 @@ describe('Calibur7702Account signUserOperationWithSigner', () => {
         expect(signerSig).toBe(pkSig);
     });
 
-    test('rejects signTypedData-only signer', async () => {
+    test('signTypedData-only signer succeeds (v0.8 userOpHash IS the EIP-712 digest)', async () => {
+        const wallet = new Wallet(PK1);
         const tdOnly = {
             address: owner,
-            signTypedData: async () => '0x',
+            signTypedData: async (td) =>
+                wallet.signTypedData(td.domain, td.types, td.message),
         };
-        await expect(
-            calibur.signUserOperationWithSigner(op, tdOnly, CHAIN_ID),
-        ).rejects.toThrow(/accepts: \[hash\]/);
+        const tdSig = await calibur.signUserOperationWithSigner(op, tdOnly, CHAIN_ID);
+        const pkSig = calibur.signUserOperation(op, PK1, CHAIN_ID);
+        expect(tdSig).toBe(pkSig);
     });
 });
 

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -652,6 +652,25 @@ describe('SafeMultiChainSigAccountV1 signUserOperationWithSigners', () => {
         expect(newSigs).toEqual(legacySigs);
     });
 
+    test('multi-op typedData-only signer matches hash signer (Merkle root EIP-712 wrapper)', async () => {
+        const op2 = { ...op, nonce: 1n };
+        const opsToSign = [
+            { userOperation: op, chainId: 1n, validAfter: 0n, validUntil: 0n },
+            { userOperation: op2, chainId: 10n, validAfter: 0n, validUntil: 0n },
+        ];
+        const wallet = new Wallet(PK1);
+        const tdOnly = {
+            address: wallet.address,
+            signTypedData: async (td) =>
+                wallet.signTypedData(td.domain, td.types, td.message),
+        };
+        const tdSigs = await safe.signUserOperationsWithSigners(opsToSign, [tdOnly]);
+        const hashSigs = await safe.signUserOperationsWithSigners(
+            opsToSign, [ak.fromPrivateKey(PK1)],
+        );
+        expect(tdSigs).toEqual(hashSigs);
+    });
+
     // The on-chain Safe4337MultiChainSignatureModule's `merkleTreeDepth == 0`
     // branch verifies against `keccak256(SafeOp)` directly, not the Merkle
     // wrapper. The wrapper helpers are wrapper-only (length >= 2); for length=1


### PR DESCRIPTION
  Summary

  Extends EIP-712 typed-data signing across the remaining account families and unifies the EIP-712 helper API surface.

  Before this PR, only the Safe accounts (single-op path) accepted signTypedData via signUserOperationWithSigner(s). JSON-RPC wallets (MetaMask, viem WalletClient, etc.) that can only
   produce typed-data signatures had no path through Calibur, Simple7702, or the multi-op Merkle path of SafeMultiChainSigAccountV1. This PR closes those gaps and aligns the EIP-712
  helper API across account classes.

  Changes

  1. refactor(calibur, simple) — make EIP-712 helpers public static with entrypoint override (931d469)
  - Calibur7702Account and BaseSimple7702Account: getUserOperationEip712Data / getUserOperationEip712Hash move from instance methods to public static accepting { entrypointAddress }.
  - Simple7702AccountV09 overrides the static with a v0.9 default (mirrors the Safe subclass pattern).
  - Callers can now write Account.getUserOperationEip712Data(op, chainId) regardless of account family.

  2. feat(calibur) — support EIP-712 typed-data signing (ea8ee48)
  - ACCEPTED_SIGNING_SCHEMES becomes ["typedData", "hash"] (was ["hash"]).
  - signUserOperationWithSigner builds the typed-data payload when the negotiated scheme is typedData.
  - New Calibur7702Account.formatEip712SingleSignatureToUseroperationSignature(signature, overrides?) — wraps a raw EIP-712 signature into Calibur's (keyHash, sig, hookData) layout,
  defaulting keyHash to the root-key (bytes32(0)). Provided for API parity with Safe.

  3. feat(safe-multichain) — accept signTypedData on the multi-op Merkle path (6ee5e20)
  - The on-chain Safe4337MultiChainSignatureModule verifies a Merkle root wrapped as TypedDataEncoder.hash({verifyingContract}, MerkleTreeRoot, {merkleTreeRoot}) — i.e. the wrapper IS
   valid EIP-712 typed data. The prior policy that rejected typedData signers offline assumed the wrapper was opaque; that's no longer accurate.
  - signUserOperationsWithSigners (length ≥ 2 path) now negotiates ["typedData", "hash"] and builds the typed-data payload. fromViemWalletClient and other typed-data-only signers can
  now sign multi-op bundles.

  4. test(integration) — extend EIP-712 e2e matrix (167b918)
  - The eip-712-signing e2e suite previously ran against Safe multi-sig accounts only. Widened to the full runnable matrix (Safe + Calibur + Simple7702 v8/v9), with per-family
  branching for signature wrapping and the EIP-7702 delegation auth on the first userOp.

  Tests

  - 133/133 unit tests pass.
  - New regression tests:
    - Calibur signUserOperationWithSigner: signTypedData-only signer succeeds (v0.8 userOpHash IS the EIP-712 digest).
    - SafeMultiChainSig multi-op typedData-only signer matches hash signer (Merkle root EIP-712 wrapper).
  - E2E test covers typedData signing end-to-end on every runnable account.

  Compatibility

  No runtime breaking change for callers using instance APIs that didn't exist on Calibur/Simple7702 before — they remain instance-callable via static dispatch. The protected static
  to public static change in those two classes is purely additive. SafeMultiChainSigAccountV1.signUserOperationsWithSigners previously rejected signTypedData-only signers offline;
  that rejection is removed (now accepts them and produces an equivalent signature).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EIP-712 typed-data signing support for account operations across multiple account types.
  * Enhanced signer compatibility to accept signers that only support typed-data signing.
  * New static helper methods for EIP-712 operations with customizable EntryPoint address overrides.

* **Tests**
  * Expanded test coverage for EIP-712 signing scenarios and typed-data-only signer paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/178)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->