### PR TITLE
chore(release): 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [UNRELEASED]
 
+## 0.3.8
+
 ### New Features
 
-- **Pluggable `Transport` abstraction.** All SDK ↔ bundler / paymaster / node traffic now flows through a single swappable seam, so users can compose fallback, retry, hedging, logging, custom auth, non-HTTP backends (WebSocket / IPC / in-process mocks), or pass an EIP-1193 wallet provider (`window.ethereum`, WalletConnect, viem `WalletClient`, ethers `Eip1193Provider`-shaped objects) without forking the SDK or writing wrapper code. The interface is shaped exactly like EIP-1193:
+- **EIP-712 UserOperation helpers aligned across account families.** `Simple7702Account`, `Simple7702AccountV09`, and `Calibur7702Account` now expose public static `getUserOperationEip712Data(userOp, chainId, overrides?)` and `getUserOperationEip712Hash(userOp, chainId, overrides?)` helpers. This matches the Safe helper naming and supports EntryPoint override via `overrides.entrypointAddress`.
+- **EIP-712 typed-data signing support expanded.** `Calibur7702Account.signUserOperationWithSigner` now accepts `signTypedData` signers, and `Calibur7702Account.formatEip712SingleSignatureToUseroperationSignature(signature, overrides?)` wraps raw typed-data signatures into Calibur's `(keyHash, sig, hookData)` layout. `SafeMultiChainSigAccountV1.signUserOperationsWithSigners` now accepts typed-data-only signers for multi-operation Merkle bundles.
+- **Pluggable `Transport` abstraction.** Node, bundler, and paymaster traffic now accepts EIP-1193-shaped transports:
   ```ts
   interface Transport {
     request<T = unknown>(
@@ -13,18 +17,25 @@
     ): Promise<T>;
   }
   ```
-  Five new public types are exported from the package root: `Transport`, `EventfulTransport` (narrowable subtype for pub/sub-capable backends, with `isEventfulTransport` guard), `BaseRpcTransport` (abstract base that handles JSON-RPC framing, id assignment, and standard error parsing so subclasses implement only the byte-level `send` hook), `HttpTransport` (the default; wraps any URL string, supports a custom `fetch`, static `headers`, and `AbortSignal`), and `JsonRpcNode` (small high-level service class for the ~10 node RPC methods abstractionkit reads). Plus `RequestArgs`, `RequestOptions`, `ProviderRpcError`, `TransportRpcError`, `HttpTransportOptions`, `JsonRpcEnvelope`, `EthCallTransaction`, and `isHttpTransport`.
-- **`JsonRpcNode` service class.** Intentionally not a general Ethereum client — only the methods abstractionkit actually reads, named to match viem/ethers conventions where applicable: `chainId()`, `blockNumber()`, `getCode()`, `call()`, `getTransactionCount()`, `getFeeData()`, `getDelegatedAddress()`, `getEntryPointNonce()`, `getEntryPointDeposit()`, `getEntryPointDepositInfo()`, plus a `request()` pass-through so a `JsonRpcNode` is itself a `Transport`. `getFeeData()` is fully re-implemented on the new transport — no more `ethers.JsonRpcProvider` dependency under the hood.
-- **`Bundler`, `CandidePaymaster`, `Erc7677Paymaster` constructors widen to `string | Transport`.** Existing `new Bundler(url)` / `new CandidePaymaster(url)` / `new Erc7677Paymaster(url)` calls compile and behave identically. Each class now implements `Transport` itself (delegates `.request()` to the underlying transport) so it can be slotted into any transport position. URL-derived inference is preserved for string inputs (`CandidePaymaster` infers `chainId` from the Candide path; `Erc7677Paymaster` auto-detects `provider === "pimlico" | "candide"` from the hostname); pass `options.provider` explicitly to override when constructing from a `Transport`.
-- **Static `.from(input)` helpers on every service class.** `Bundler.from(...)`, `CandidePaymaster.from(...)`, `Erc7677Paymaster.from(...)`, `JsonRpcNode.from(...)` accept `string | Transport | <Self>` and return the input by reference when it's already an instance of that class (no re-wrapping). Used at every public-API widening site so a user's pre-configured `Bundler` (with retry, logging, etc.) is reused for both `sendUserOperation` and the response's `included()` polling.
-- **All `providerRpc?` / `bundlerRpc?` / `nodeRpcUrl` parameters widen.** Every public method that accepted a URL string for a node or bundler now accepts `string | Transport | JsonRpcNode` / `string | Transport | Bundler`. Affects `SafeAccount` + subclasses (`SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0`, `SafeMultiChainSigAccountV1`), `Simple7702Account`, `Simple7702AccountV09`, `Calibur7702Account`, `AllowanceModule`, `SocialRecoveryModule`, and the paymaster classes' `createSponsorPaymasterUserOperation` / `createTokenPaymasterUserOperation` / `createPaymasterUserOperation` methods. EIP-7702 paths in `Simple7702Account` and `Calibur7702Account` route through `JsonRpcNode` like every other node call.
-- **`AbortSignal` support via per-request options bag.** `Transport.request` accepts `options?: { signal?: AbortSignal }`. `HttpTransport` forwards the signal to `fetch`. The options-bag shape leaves room to add `timeoutMs`, `headers`, `retryHint`, etc. in future minor releases without further widening.
-- **`NODE_ERROR` added to `BasicErrorCode`** for failures originating in `JsonRpcNode`. Matches the existing double-wrap shape on `Bundler` (`BUNDLER_ERROR`) and the paymaster classes (`PAYMASTER_ERROR`): outer code is the service-level vocabulary; the specific JSON-RPC code (from the now-active `JsonRpcErrorDict`) is nested in `.cause`. `BAD_DATA` is reserved for malformed-response cases (the RPC succeeded but the data shape was wrong) — a distinction users couldn't make before.
-- **`sendJsonRpcRequest` becomes service-neutral.** The previous implementation applied `BundlerErrorCodeDict` translation to every call regardless of which service was being addressed — a layering inversion. It now throws an EIP-1193-shaped `TransportRpcError` on RPC errors, and each high-level service (`Bundler`, `CandidePaymaster`, `Erc7677Paymaster`, `JsonRpcNode`) owns its own domain translation. External callers see no API change; the function stays a public top-level export with its full 5-arg signature (URL string inputs preserve the historical `headers` and `paramsKeyName` arguments; `Transport` / `JsonRpcNode` inputs delegate to `.request()`).
-- **`Tenderly` helpers untied from `sendJsonRpcRequest`.** `callTenderlySimulateBundle` was the only caller using `sendJsonRpcRequest`'s `paramsKeyName` override, which had forced the helper to special-case `"simulation_results"` response shapes. Tenderly now uses an inline `fetch` call; no public API change.
+  New exports: `Transport`, `EventfulTransport`, `isEventfulTransport`, `BaseRpcTransport`, `HttpTransport`, `isHttpTransport`, `JsonRpcNode`, `TransportRpcError`, `RequestArgs`, `RequestOptions`, `ProviderRpcError`, `HttpTransportOptions`, `JsonRpcEnvelope`, and `EthCallTransaction`.
+- **`JsonRpcNode` service class added.** Methods: `chainId()`, `blockNumber()`, `getCode()`, `call()`, `getTransactionCount()`, `getFeeData()`, `getDelegatedAddress()`, `getEntryPointNonce()`, `getEntryPointDeposit()`, `getEntryPointDepositInfo()`, and `request()`. `getFeeData()` no longer depends on `ethers.JsonRpcProvider`.
+- **RPC inputs widened.** `Bundler`, `CandidePaymaster`, and `Erc7677Paymaster` constructors now accept `string | Transport`; each class implements `Transport` and exposes `.from(input)`. Public `providerRpc?`, `bundlerRpc?`, and `nodeRpcUrl` parameters now accept `string | Transport | JsonRpcNode` for node calls and `string | Transport | Bundler` for bundler calls across Safe, Simple7702, Calibur, `AllowanceModule`, `SocialRecoveryModule`, and paymaster methods.
+- **Request cancellation and service error mapping added.** `Transport.request` accepts `options?: { signal?: AbortSignal }`; `HttpTransport` forwards it to `fetch`. `NODE_ERROR` was added to `BasicErrorCode` for `JsonRpcNode`, and `sendJsonRpcRequest` now throws `TransportRpcError` while service classes translate into their own domain errors.
+- **Tenderly helpers no longer depend on `sendJsonRpcRequest`.** `callTenderlySimulateBundle` now uses an inline `fetch` call; public Tenderly helper signatures are unchanged.
 
 ### Breaking Changes
 
+- **`BaseSimple7702Account#getUserOperationEip712TypedData` moved from an instance method to a static helper and was renamed to `getUserOperationEip712Data`.** The returned typed-data payload shape is unchanged, but callers must switch from `account.getUserOperationEip712TypedData(...)` to the account class' static helper. This aligns Simple7702 with the Safe and Calibur EIP-712 helper API and lets callers override the EntryPoint explicitly when needed. Migration:
+  ```ts
+  // Before
+  const typedData = account.getUserOperationEip712TypedData(userOp, chainId);
+
+  // After
+  const typedData = Simple7702Account.getUserOperationEip712Data(userOp, chainId);
+
+  // For EntryPoint v0.9
+  const typedDataV9 = Simple7702AccountV09.getUserOperationEip712Data(userOp, chainId);
+  ```
 - **`bundler.rpcUrl` / `paymaster.rpcUrl` field removed.** The `readonly rpcUrl: string` field on `Bundler`, `CandidePaymaster`, and `Erc7677Paymaster` is replaced by `readonly transport: Transport`. Migration:
   ```ts
   // Before
@@ -56,7 +67,19 @@
 
 ### Bug Fixes
 
-- **`JsonRpcNode.getFeeData` preserves `bigint` precision above `Number.MAX_SAFE_INTEGER`.** The `gasLevel` multiplier was previously applied via `BigInt(Math.ceil(Number(gasPrice) * gasLevel))`, which silently truncated values above 2^53 wei (the largest integer JS doubles can represent exactly). For gas-price values in that range — possible on test networks, fork environments, or anomalous mainnet spikes — the bottom bits of the returned `maxFeePerGas` / `maxPriorityFeePerGas` were lost. The multiplier is now applied entirely in `BigInt` space (the `gasLevel` is scaled to three-decimal integer precision, multiplied, then ceiling-divided down), preserving the original `Math.ceil(...)` rounding semantics on small values while staying exact for arbitrarily large ones. The previous behavior of `fetchGasPrice` (via ethers' `JsonRpcProvider`) had the same bug; it's gone with the helper's removal.
+- **Social recovery multi-confirm transactions now encode and validate signer data correctly.** `createMultiConfirmRecoveryMetaTransaction` now uses the correct ABI tuple shape, sorts signer addresses with a spec-compliant comparator, and rejects duplicate signers before producing calldata. This prevents malformed recovery confirmations and catches invalid guardian input earlier.
+- **`JsonRpcNode.getFeeData` preserves `bigint` precision above `Number.MAX_SAFE_INTEGER`.** Gas-level multipliers are now applied in `bigint` space instead of via `Number(gasPrice)`, avoiding precision loss for large gas prices.
+
+### Documentation
+
+- **EIP-7702 delegation authorization signer docs are clearer.** `createAndSignEip7702DelegationAuthorization` now documents that callback signers sign the authorization hash directly, without an EIP-191 / EIP-712 prefix, and that both 65-byte standard signatures and 64-byte EIP-2098 compact signatures are accepted.
+- **Safe multi-chain signing docs clarify `chainId` placement.** The single-operation signing JSDoc points out that `chainId` is passed positionally, while multi-operation signing carries `chainId` inside each `UserOperationToSign` item.
+
+### Testing and CI
+
+- **Docker-backed integration test suite added.** The repo now includes an integration Jest config, global setup / teardown, chain matrix helpers, and e2e coverage for passkeys, social recovery, batch transactions, multisig, spend permissions, signer adapters, on-chain identifiers, bundler behavior, and EIP-712 signing.
+- **EIP-7702 accounts added to the e2e matrix.** Calibur, `Simple7702Account` on EntryPoint v0.8, and `Simple7702AccountV09` on EntryPoint v0.9 now run through the account-agnostic integration suites. The local bundler matrix was expanded to run v0.8 with `--eip7702`.
+- **Integration CI expanded.** The integration workflow now supports manual dispatch, fork RPC overrides, per-entrypoint bundlers, cached anvil images, fail-fast chain startup, and cleanup on `SIGINT` / `SIGTERM`.
 
 ## 0.3.7
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.7   | :white_check_mark: |
+| 0.3.8   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3141,7 +3141,7 @@ function generateOnChainIdentifier(
 	project: string,
 	platform: "Web" | "Mobile" | "Safe App" | "Widget" = "Web",
 	tool: string = "abstractionkit",
-	toolVersion: string = "0.3.7",
+	toolVersion: string = "0.3.8",
 ): string {
 	const identifierPrefix = "5afe"; // Safe identifier prefix
 	const identifierVersion = "00"; // First version


### PR DESCRIPTION
## Summary
- Bump abstractionkit package version to 0.3.8
- Move the current unreleased changelog entries into the 0.3.8 release section
- Expand the changelog to cover all merged PRs since v0.3.7
- Update supported security version and Safe on-chain identifier default toolVersion to 0.3.8

## Changelog coverage
- Transport abstraction and JsonRpcNode service (#174)
- EIP-712 UserOperation helpers for Simple7702, Simple7702V09, and Calibur (#176)
- EIP-712 typed-data signing across Calibur and Safe multi-chain bundles (#178)
- Breaking Simple7702 EIP-712 helper migration from instance `getUserOperationEip712TypedData` to static `getUserOperationEip712Data` (#176)
- Social recovery multi-confirm encoding, signer sorting, and duplicate rejection fixes (#175)
- EIP-7702 signer and Safe multi-chain chainId documentation clarifications (#165)
- Docker-backed integration suite, integration CI, and EIP-7702 e2e matrix coverage (#175, #177)

## Verification
- yarn build
- yarn test:types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs for EIP-712 UserOperation helpers across account families; expanded typed-data signing and multi-operation signing.
  * Documented pluggable Transport abstraction and new JsonRpcNode usage; request cancellation via AbortSignal and improved RPC error mapping.

* **Bug Fixes**
  * Fixed social-recovery signer encoding/validation, preserved bigint precision for fee data, clarified delegation and multi-chain signing guidance.

* **Breaking Changes**
  * Renamed an EIP-712 helper API (see changelog).

* **Chores**
  * Version bumped to 0.3.8; changelog, docs, CI and Docker-backed e2e tests updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->