### PR TITLE
docs: update delegated address README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ const smartAccount = (await SafeAccountV0_3_0.isDeployed(safeAddress, nodeRpc))
 ```typescript
 import {
   Calibur7702Account,
+  JsonRpcNode,
   createAndSignEip7702DelegationAuthorization,
 } from "abstractionkit";
 
@@ -295,7 +296,7 @@ const response = await account.sendUserOperation(userOp, bundlerRpc);
 const receipt = await response.included();
 ```
 
-After the first UserOp deploys the delegation, subsequent UserOps no longer need `eip7702Auth`. Use `getDelegatedAddress(eoaAddress, nodeRpc)` to check delegation status.
+After the first UserOp deploys the delegation, subsequent UserOps no longer need `eip7702Auth`. Use `JsonRpcNode.from(nodeRpc).getDelegatedAddress(eoaAddress)` to check delegation status.
 
 ### Calibur 7702: register a WebAuthn passkey
 


### PR DESCRIPTION
## Summary

- Update the Calibur 7702 README example to import `JsonRpcNode`.
- Replace the removed top-level `getDelegatedAddress(eoaAddress, nodeRpc)` helper reference with `JsonRpcNode.from(nodeRpc).getDelegatedAddress(eoaAddress)`.

Closes #181.

## Verification

- `corepack yarn install --ignore-scripts --frozen-lockfile`
- `corepack yarn test:types`
- `corepack yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the delegation example to reflect the latest API usage pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->