### PR TITLE
refactor: replace ethers runtime dependency with internal ethereUtils

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,14 @@
 		"node": ">=18"
 	},
 	"dependencies": {
-		"ethers": "^6.13.2"
+		"@noble/curves": "^1.2.0",
+		"@noble/hashes": "^1.3.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.12",
 		"cbor": "^10.0.12",
 		"dotenv": "^16.4.5",
+		"ethers": "^6.13.2",
 		"jest": "^29.7.0",
 		"tsdown": "^0.21.6",
 		"typescript": "^5.1.6",

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -1,4 +1,10 @@
-import {AbiCoder, keccak256, Wallet} from "ethers";
+import {
+	decodeAbiParameters,
+	encodeAbiParameters,
+	keccak256,
+	privateKeyToAddress,
+	signHash,
+} from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {
 	BaseUserOperationDummyValues,
@@ -106,7 +112,7 @@ export class Calibur7702Account
 	 * Dummy ECDSA signature for gas estimation with root key signing.
 	 * Format: `abi.encode(bytes32 keyHash, bytes sig, bytes hookData)`
 	 */
-	static readonly dummySignature: string = AbiCoder.defaultAbiCoder().encode(
+	static readonly dummySignature: string = encodeAbiParameters(
 		["bytes32", "bytes", "bytes"],
 		[
 			ROOT_KEY_HASH,
@@ -124,16 +130,15 @@ export class Calibur7702Account
 	 * @returns A dummy signature suitable for passing as `dummySignature` override
 	 */
 	public static createDummyWebAuthnSignature(keyHash: string): string {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		const dummyClientDataJSON =
 			'{"type":"webauthn.get","challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","origin":"https://example.com","crossOrigin":false}';
 		const challengeIndex = BigInt(dummyClientDataJSON.indexOf('"challenge":"'));
 		const typeIndex = BigInt(dummyClientDataJSON.indexOf('"type":"webauthn.get"'));
-		return abiCoder.encode(
+		return encodeAbiParameters(
 			["bytes32", "bytes", "bytes"],
 			[
 				keyHash,
-				abiCoder.encode(
+				encodeAbiParameters(
 					["(bytes,string,uint256,uint256,uint256,uint256)"],
 					[
 						[
@@ -164,8 +169,7 @@ export class Calibur7702Account
 	 * @returns Hex-encoded wrapped signature ready for `userOp.signature`
 	 */
 	public static wrapSignature(keyHash: string, rawSignature: string, hookData = "0x"): string {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		return abiCoder.encode(["bytes32", "bytes", "bytes"], [keyHash, rawSignature, hookData]);
+		return encodeAbiParameters(["bytes32", "bytes", "bytes"], [keyHash, rawSignature, hookData]);
 	}
 
 	/**
@@ -298,12 +302,11 @@ export class Calibur7702Account
 		transactions: SimpleMetaTransaction[],
 		revertOnFailure = true,
 	): string {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		const calls = transactions.map((tx) => [tx.to, tx.value, tx.data]);
 		// BatchedCall struct { Call[] calls; bool revertOnFailure; }
 		// Solidity's abi.decode(data, (BatchedCall)) expects a single struct/tuple
 		// parameter, which has an extra offset layer compared to two separate args.
-		const batchedCallEncoded = abiCoder.encode(
+		const batchedCallEncoded = encodeAbiParameters(
 			["((address,uint256,bytes)[],bool)"],
 			[[calls, revertOnFailure]],
 		);
@@ -681,8 +684,7 @@ export class Calibur7702Account
 		);
 		const keyHash = overrides.keyHash ?? ROOT_KEY_HASH;
 		const hookData = overrides.hookData ?? "0x";
-		const wallet = new Wallet(privateKey);
-		const ecdsaSig = wallet.signingKey.sign(userOperationHash).serialized;
+		const ecdsaSig = signHash(privateKey, userOperationHash).serialized;
 		return Calibur7702Account.wrapSignature(keyHash, ecdsaSig, hookData);
 	}
 
@@ -759,13 +761,12 @@ export class Calibur7702Account
 		webAuthnAuth: WebAuthnSignatureData,
 		overrides: CaliburSignatureOverrides = {},
 	): string {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		const hookData = overrides.hookData ?? "0x";
 
 		// Encode as a struct/tuple — Calibur decodes with:
 		//   abi.decode(signature, (WebAuthn.WebAuthnAuth))
 		// which expects struct-wrapped encoding (extra offset for dynamic tuple).
-		const webAuthnEncoded = abiCoder.encode(
+		const webAuthnEncoded = encodeAbiParameters(
 			["(bytes,string,uint256,uint256,uint256,uint256)"],
 			[
 				[
@@ -779,7 +780,7 @@ export class Calibur7702Account
 			],
 		);
 
-		return abiCoder.encode(["bytes32", "bytes", "bytes"], [keyHash, webAuthnEncoded, hookData]);
+		return encodeAbiParameters(["bytes32", "bytes", "bytes"], [keyHash, webAuthnEncoded, hookData]);
 	}
 
 	/**
@@ -810,10 +811,9 @@ export class Calibur7702Account
 	 * @returns A {@link CaliburKey} with type Secp256k1
 	 */
 	public static createSecp256k1Key(address: string): CaliburKey {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		return {
 			keyType: CaliburKeyType.Secp256k1,
-			publicKey: abiCoder.encode(["address"], [address]),
+			publicKey: encodeAbiParameters(["address"], [address]),
 		};
 	}
 
@@ -824,10 +824,9 @@ export class Calibur7702Account
 	 * @returns A {@link CaliburKey} with type WebAuthnP256
 	 */
 	public static createWebAuthnP256Key(x: bigint, y: bigint): CaliburKey {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		return {
 			keyType: CaliburKeyType.WebAuthnP256,
-			publicKey: abiCoder.encode(["uint256", "uint256"], [x, y]),
+			publicKey: encodeAbiParameters(["uint256", "uint256"], [x, y]),
 		};
 	}
 
@@ -838,10 +837,9 @@ export class Calibur7702Account
 	 * @returns A {@link CaliburKey} with type P256
 	 */
 	public static createP256Key(x: bigint, y: bigint): CaliburKey {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		return {
 			keyType: CaliburKeyType.P256,
-			publicKey: abiCoder.encode(["uint256", "uint256"], [x, y]),
+			publicKey: encodeAbiParameters(["uint256", "uint256"], [x, y]),
 		};
 	}
 
@@ -854,8 +852,7 @@ export class Calibur7702Account
 	 */
 	public static getKeyHash(key: CaliburKey): string {
 		const innerHash = keccak256(key.publicKey);
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const encoded = abiCoder.encode(["uint8", "bytes32"], [key.keyType, innerHash]);
+		const encoded = encodeAbiParameters(["uint8", "bytes32"], [key.keyType, innerHash]);
 		return keccak256(encoded);
 	}
 
@@ -913,12 +910,11 @@ export class Calibur7702Account
 			);
 		}
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
 
 		// Register: register((uint8 keyType, bytes publicKey))
 		const registerCallData =
 			REGISTER_SELECTOR +
-			abiCoder.encode(["(uint8,bytes)"], [[key.keyType, key.publicKey]]).slice(2);
+			encodeAbiParameters(["(uint8,bytes)"], [[key.keyType, key.publicKey]]).slice(2);
 
 		// Update: update(bytes32 keyHash, uint256 packedSettings)
 		const safeSettings: CaliburKeySettings = {
@@ -928,7 +924,7 @@ export class Calibur7702Account
 		const keyHash = Calibur7702Account.getKeyHash(key);
 		const packedSettings = Calibur7702Account.packKeySettings(safeSettings);
 		const updateCallData =
-			UPDATE_SELECTOR + abiCoder.encode(["bytes32", "uint256"], [keyHash, packedSettings]).slice(2);
+			UPDATE_SELECTOR + encodeAbiParameters(["bytes32", "uint256"], [keyHash, packedSettings]).slice(2);
 
 		return [
 			{ to: ZeroAddress, value: 0n, data: registerCallData },
@@ -943,8 +939,7 @@ export class Calibur7702Account
 	 * @returns A {@link SimpleMetaTransaction} that calls `revoke(bytes32)`
 	 */
 	public static createRevokeKeyMetaTransaction(keyHash: string): SimpleMetaTransaction {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const callData = REVOKE_SELECTOR + abiCoder.encode(["bytes32"], [keyHash]).slice(2);
+		const callData = REVOKE_SELECTOR + encodeAbiParameters(["bytes32"], [keyHash]).slice(2);
 
 		return { to: ZeroAddress, value: 0n, data: callData };
 	}
@@ -1026,7 +1021,7 @@ export class Calibur7702Account
 		} = {},
 	): Promise<string> {
 		// Verify the private key matches this account
-		const signerAddress = new Wallet(eoaPrivateKey).address;
+		const signerAddress = privateKeyToAddress(eoaPrivateKey);
 		if (signerAddress.toLowerCase() !== this.accountAddress.toLowerCase()) {
 			throw new AbstractionKitError(
 				"BAD_DATA",
@@ -1143,10 +1138,9 @@ export class Calibur7702Account
 			);
 		}
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		const packedSettings = Calibur7702Account.packKeySettings(settings);
 		const callData =
-			UPDATE_SELECTOR + abiCoder.encode(["bytes32", "uint256"], [keyHash, packedSettings]).slice(2);
+			UPDATE_SELECTOR + encodeAbiParameters(["bytes32", "uint256"], [keyHash, packedSettings]).slice(2);
 
 		return { to: ZeroAddress, value: 0n, data: callData };
 	}
@@ -1158,8 +1152,7 @@ export class Calibur7702Account
 	 * @returns A {@link SimpleMetaTransaction} that calls `invalidateNonce(uint256)`
 	 */
 	public static createInvalidateNonceMetaTransaction(newNonce: bigint): SimpleMetaTransaction {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const callData = INVALIDATE_NONCE_SELECTOR + abiCoder.encode(["uint256"], [newNonce]).slice(2);
+		const callData = INVALIDATE_NONCE_SELECTOR + encodeAbiParameters(["uint256"], [newNonce]).slice(2);
 
 		return { to: ZeroAddress, value: 0n, data: callData };
 	}
@@ -1200,8 +1193,7 @@ export class Calibur7702Account
 	 * @returns True if the key is registered
 	 */
 	public async isKeyRegistered(providerRpc: string | Transport | JsonRpcNode, keyHash: string): Promise<boolean> {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const callData = IS_REGISTERED_SELECTOR + abiCoder.encode(["bytes32"], [keyHash]).slice(2);
+		const callData = IS_REGISTERED_SELECTOR + encodeAbiParameters(["bytes32"], [keyHash]).slice(2);
 
 		const result = await sendJsonRpcRequest(providerRpc, "eth_call", [
 			{
@@ -1213,7 +1205,7 @@ export class Calibur7702Account
 		]);
 
 		if (typeof result === "string") {
-			const decoded = abiCoder.decode(["bool"], result);
+			const decoded = decodeAbiParameters(["bool"], result);
 			return decoded[0] as boolean;
 		}
 		throw new AbstractionKitError("BAD_DATA", "Unexpected response from isRegistered call");
@@ -1230,8 +1222,7 @@ export class Calibur7702Account
 		providerRpc: string | Transport | JsonRpcNode,
 		keyHash: string,
 	): Promise<CaliburKeySettingsResult> {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const callData = GET_KEY_SETTINGS_SELECTOR + abiCoder.encode(["bytes32"], [keyHash]).slice(2);
+		const callData = GET_KEY_SETTINGS_SELECTOR + encodeAbiParameters(["bytes32"], [keyHash]).slice(2);
 
 		const result = await sendJsonRpcRequest(providerRpc, "eth_call", [
 			{
@@ -1243,7 +1234,7 @@ export class Calibur7702Account
 		]);
 
 		if (typeof result === "string") {
-			const decoded = abiCoder.decode(["uint256"], result);
+			const decoded = decodeAbiParameters(["uint256"], result);
 			return Calibur7702Account.unpackKeySettings(BigInt(decoded[0]));
 		}
 		throw new AbstractionKitError("BAD_DATA", "Unexpected response from getKeySettings call");
@@ -1257,8 +1248,7 @@ export class Calibur7702Account
 	 * @returns Parsed {@link CaliburKey}
 	 */
 	public async getKey(providerRpc: string | Transport | JsonRpcNode, keyHash: string): Promise<CaliburKey> {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const callData = GET_KEY_SELECTOR + abiCoder.encode(["bytes32"], [keyHash]).slice(2);
+		const callData = GET_KEY_SELECTOR + encodeAbiParameters(["bytes32"], [keyHash]).slice(2);
 
 		const result = await sendJsonRpcRequest(providerRpc, "eth_call", [
 			{
@@ -1270,7 +1260,7 @@ export class Calibur7702Account
 		]);
 
 		if (typeof result === "string") {
-			const decoded = abiCoder.decode(["(uint8,bytes)"], result);
+			const decoded = decodeAbiParameters(["(uint8,bytes)"], result);
 			const keyTuple = decoded[0] as [number, string];
 			return {
 				keyType: Number(keyTuple[0]) as CaliburKeyType,
@@ -1294,7 +1284,6 @@ export class Calibur7702Account
 		providerRpc: string | Transport | JsonRpcNode,
 		overrides: { blockNumber?: bigint } = {},
 	): Promise<CaliburKey[]> {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		let blockTag: string;
 		if (overrides.blockNumber != null) {
 			blockTag = `0x${overrides.blockNumber.toString(16)}`;
@@ -1328,7 +1317,7 @@ export class Calibur7702Account
 		// Batch all keyAt calls in parallel
 		const keyAtPromises: Promise<unknown>[] = [];
 		for (let i = 0; i < count; i++) {
-			const keyAtCallData = KEY_AT_SELECTOR + abiCoder.encode(["uint256"], [i]).slice(2);
+			const keyAtCallData = KEY_AT_SELECTOR + encodeAbiParameters(["uint256"], [i]).slice(2);
 
 			keyAtPromises.push(
 				sendJsonRpcRequest(providerRpc, "eth_call", [
@@ -1353,7 +1342,7 @@ export class Calibur7702Account
 					`Unexpected response from keyAt(${i}) call on ${this.accountAddress}`,
 				);
 			}
-			const decoded = abiCoder.decode(["(uint8,bytes)"], keyResult);
+			const decoded = decodeAbiParameters(["(uint8,bytes)"], keyResult);
 			const keyTuple = decoded[0] as [number, string];
 			keys.push({
 				keyType: Number(keyTuple[0]) as CaliburKeyType,
@@ -1408,7 +1397,6 @@ export class Calibur7702Account
 		paymasterAddress: string,
 		approveAmount: bigint,
 	): string {
-		const abiCoder = AbiCoder.defaultAbiCoder();
 
 		// Build approve transaction
 		const approveFunctionSelector = getFunctionSelector("approve(address,uint256)");
@@ -1429,7 +1417,7 @@ export class Calibur7702Account
 		}
 
 		// Decode: strip selector -> decode BatchedCall struct
-		const batchedCallDecoded = abiCoder.decode(
+		const batchedCallDecoded = decodeAbiParameters(
 			["((address,uint256,bytes)[],bool)"],
 			`0x${callData.slice(10)}`,
 		);
@@ -1453,7 +1441,7 @@ export class Calibur7702Account
 
 		// Re-encode as BatchedCall struct
 		const calls = decodedTransactions.map((tx) => [tx.to, tx.value, tx.data]);
-		const batchedCallEncoded = abiCoder.encode(
+		const batchedCallEncoded = encodeAbiParameters(
 			["((address,uint256,bytes)[],bool)"],
 			[[calls, revertOnFailure]],
 		);

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -1205,8 +1205,8 @@ export class Calibur7702Account
 		]);
 
 		if (typeof result === "string") {
-			const decoded = decodeAbiParameters(["bool"], result);
-			return decoded[0] as boolean;
+			const decoded = decodeAbiParameters<[boolean]>(["bool"], result);
+			return decoded[0];
 		}
 		throw new AbstractionKitError("BAD_DATA", "Unexpected response from isRegistered call");
 	}
@@ -1234,7 +1234,7 @@ export class Calibur7702Account
 		]);
 
 		if (typeof result === "string") {
-			const decoded = decodeAbiParameters(["uint256"], result);
+			const decoded = decodeAbiParameters<[bigint]>(["uint256"], result);
 			return Calibur7702Account.unpackKeySettings(BigInt(decoded[0]));
 		}
 		throw new AbstractionKitError("BAD_DATA", "Unexpected response from getKeySettings call");
@@ -1260,8 +1260,8 @@ export class Calibur7702Account
 		]);
 
 		if (typeof result === "string") {
-			const decoded = decodeAbiParameters(["(uint8,bytes)"], result);
-			const keyTuple = decoded[0] as [number, string];
+			const decoded = decodeAbiParameters<[[bigint, string]]>(["(uint8,bytes)"], result);
+			const keyTuple = decoded[0];
 			return {
 				keyType: Number(keyTuple[0]) as CaliburKeyType,
 				publicKey: keyTuple[1] as string,
@@ -1342,8 +1342,8 @@ export class Calibur7702Account
 					`Unexpected response from keyAt(${i}) call on ${this.accountAddress}`,
 				);
 			}
-			const decoded = decodeAbiParameters(["(uint8,bytes)"], keyResult);
-			const keyTuple = decoded[0] as [number, string];
+			const decoded = decodeAbiParameters<[[bigint, string]]>(["(uint8,bytes)"], keyResult);
+			const keyTuple = decoded[0];
 			keys.push({
 				keyType: Number(keyTuple[0]) as CaliburKeyType,
 				publicKey: keyTuple[1] as string,
@@ -1417,20 +1417,17 @@ export class Calibur7702Account
 		}
 
 		// Decode: strip selector -> decode BatchedCall struct
-		const batchedCallDecoded = decodeAbiParameters(
-			["((address,uint256,bytes)[],bool)"],
-			`0x${callData.slice(10)}`,
-		);
-		const existingCalls = batchedCallDecoded[0][0] as [];
-		const revertOnFailure = batchedCallDecoded[0][1] as boolean;
+		const batchedCallDecoded = decodeAbiParameters<
+			[[Array<[string, bigint, string | Uint8Array]>, boolean]]
+		>(["((address,uint256,bytes)[],bool)"], `0x${callData.slice(10)}`);
+		const existingCalls = batchedCallDecoded[0][0];
+		const revertOnFailure = batchedCallDecoded[0][1];
 
-		const decodedTransactions: SimpleMetaTransaction[] = existingCalls.map(
-			(call: [string, bigint, string]) => ({
-				to: call[0],
-				value: BigInt(call[1]),
-				data: typeof call[2] !== "string" ? new TextDecoder().decode(call[2]) : call[2],
-			}),
-		);
+		const decodedTransactions: SimpleMetaTransaction[] = existingCalls.map((call) => ({
+			to: call[0],
+			value: BigInt(call[1]),
+			data: typeof call[2] !== "string" ? new TextDecoder().decode(call[2]) : call[2],
+		}));
 
 		// Prepend approve
 		decodedTransactions.unshift({

--- a/src/account/Safe/MerkleTree.ts
+++ b/src/account/Safe/MerkleTree.ts
@@ -1,4 +1,4 @@
-import { keccak256 } from "ethers";
+import { keccak256 } from "../../ethereUtils";
 
 /**
  * Hashes two values together using keccak256, sorting them so the smaller

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -393,7 +393,7 @@ export class SafeAccount extends SmartAccount {
 		}
 		if (safeModuleExecutorFunctionSelector != null) {
 			const params = `0x${callData.slice(10)}`;
-			const decodedParams = decodeAbiParameters(
+			const decodedParams = decodeAbiParameters<[string, bigint, string | Uint8Array, bigint]>(
 				[
 					"address", //to
 					"uint256", //value
@@ -411,8 +411,8 @@ export class SafeAccount extends SmartAccount {
 
 			return [
 				{
-					to: decodedParams[0] as string,
-					value: BigInt(decodedParams[1] as string),
+					to: decodedParams[0],
+					value: BigInt(decodedParams[1]),
 					data: accountCallDataString,
 					operation: Number(decodedParams[3]),
 				},
@@ -2632,7 +2632,7 @@ export class SafeAccount extends SmartAccount {
 		};
 		const getOwnersResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		const decodedCalldata = decodeAbiParameters(["address[]"], getOwnersResult);
+		const decodedCalldata = decodeAbiParameters<[string[]]>(["address[]"], getOwnersResult);
 
 		return decodedCalldata[0];
 	}
@@ -2652,7 +2652,7 @@ export class SafeAccount extends SmartAccount {
 		};
 		const getThresholdResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		const decodedCalldata = decodeAbiParameters(["uint256"], getThresholdResult);
+		const decodedCalldata = decodeAbiParameters<[bigint]>(["uint256"], getThresholdResult);
 
 		return Number(decodedCalldata[0]);
 	}
@@ -2700,7 +2700,10 @@ export class SafeAccount extends SmartAccount {
 						"probably not deployed yet.",
 				);
 			}
-			const decodedCalldata = decodeAbiParameters(["address[]", "address"], getModulesResult);
+			const decodedCalldata = decodeAbiParameters<[string[], string]>(
+				["address[]", "address"],
+				getModulesResult,
+			);
 			return [decodedCalldata[0], decodedCalldata[1]];
 		} catch (err) {
 			const error = ensureError(err);
@@ -2731,7 +2734,7 @@ export class SafeAccount extends SmartAccount {
 		};
 		const isModuleEnabledResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		const decodedCalldata = decodeAbiParameters(["bool"], isModuleEnabledResult);
+		const decodedCalldata = decodeAbiParameters<[boolean]>(["bool"], isModuleEnabledResult);
 
 		return decodedCalldata[0];
 	}
@@ -2869,7 +2872,7 @@ export class SafeAccount extends SmartAccount {
 			},
 		);
 
-		const decodedCalldata = decodeAbiParameters(["bool"], isModuleEnabledResult);
+		const decodedCalldata = decodeAbiParameters<[boolean]>(["bool"], isModuleEnabledResult);
 
 		return decodedCalldata[0];
 	}

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1,13 +1,16 @@
 import {
-	AbiCoder,
-	ethers,
+	concat,
+	dataLength,
+	decodeAbiParameters,
+	encodeAbiParameters,
 	getAddress,
+	hashTypedData,
 	keccak256,
+	privateKeyToAddress,
+	signHash,
 	solidityPacked,
 	solidityPackedKeccak256,
-	TypedDataEncoder,
-	Wallet,
-} from "ethers";
+} from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {AbstractionKitError, ensureError} from "src/errors";
 import {SafeAccountFactory} from "src/factory/SafeAccountFactory";
@@ -389,9 +392,8 @@ export class SafeAccount extends SmartAccount {
 			safeModuleExecutorFunctionSelector = SafeModuleExecutorFunctionSelector.executeUserOp;
 		}
 		if (safeModuleExecutorFunctionSelector != null) {
-			const abiCoder = AbiCoder.defaultAbiCoder();
 			const params = `0x${callData.slice(10)}`;
-			const decodedParams = abiCoder.decode(
+			const decodedParams = decodeAbiParameters(
 				[
 					"address", //to
 					"uint256", //value
@@ -730,7 +732,7 @@ export class SafeAccount extends SmartAccount {
 		} = {},
 	): string {
 		const data = SafeAccount.getUserOperationEip712Data_V6(useroperation, chainId, overrides);
-		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+		return hashTypedData(data.domain, data.types, data.messageValue);
 	}
 
 	private static baseGetUserOperationEip712DataV7V8V9(
@@ -754,8 +756,6 @@ export class SafeAccount extends SmartAccount {
 		const safe4337ModuleAddress =
 			overrides.safe4337ModuleAddress ?? "0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226";
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
-
 		let initCode = "0x";
 		if (useroperation.factory != null) {
 			initCode = useroperation.factory;
@@ -768,14 +768,16 @@ export class SafeAccount extends SmartAccount {
 		if (useroperation.paymaster != null) {
 			paymasterAndData = useroperation.paymaster;
 			if (useroperation.paymasterVerificationGasLimit != null) {
-				paymasterAndData += abiCoder
-					.encode(["uint128"], [useroperation.paymasterVerificationGasLimit])
-					.slice(34);
+				paymasterAndData += encodeAbiParameters(
+					["uint128"],
+					[useroperation.paymasterVerificationGasLimit],
+				).slice(34);
 			}
 			if (useroperation.paymasterPostOpGasLimit != null) {
-				paymasterAndData += abiCoder
-					.encode(["uint128"], [useroperation.paymasterPostOpGasLimit])
-					.slice(34);
+				paymasterAndData += encodeAbiParameters(
+					["uint128"],
+					[useroperation.paymasterPostOpGasLimit],
+				).slice(34);
 			}
 			if (useroperation.paymasterData != null) {
 				const PAYMASTER_SIG_MAGIC = "22e325a297439656";
@@ -881,7 +883,7 @@ export class SafeAccount extends SmartAccount {
 		} = {},
 	): string {
 		const data = SafeAccount.getUserOperationEip712Data_V7(useroperation, chainId, overrides);
-		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+		return hashTypedData(data.domain, data.types, data.messageValue);
 	}
 
 	/**
@@ -949,7 +951,7 @@ export class SafeAccount extends SmartAccount {
 		} = {},
 	): string {
 		const data = SafeAccount.getUserOperationEip712Data_V9(useroperation, chainId, overrides);
-		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+		return hashTypedData(data.domain, data.types, data.messageValue);
 	}
 
 	/**
@@ -1799,10 +1801,9 @@ export class SafeAccount extends SmartAccount {
 
 		const signerSignaturePairs: SignerSignaturePair[] = [];
 		for (const privateKey of privateKeys) {
-			const wallet = new Wallet(privateKey);
-			const signature = wallet.signingKey.sign(userOperationEip712Hash).serialized;
+			const signature = signHash(privateKey, userOperationEip712Hash).serialized;
 			signerSignaturePairs.push({
-				signer: wallet.address,
+				signer: privateKeyToAddress(privateKey),
 				signature,
 			});
 		}
@@ -1875,7 +1876,7 @@ export class SafeAccount extends SmartAccount {
 			entrypointAddress,
 			safe4337ModuleAddress: moduleAddress,
 		});
-		const userOpHash = TypedDataEncoder.hash(
+		const userOpHash = hashTypedData(
 			typedDataRaw.domain,
 			typedDataRaw.types,
 			typedDataRaw.messageValue,
@@ -2175,27 +2176,27 @@ export class SafeAccount extends SmartAccount {
 					return {
 						segments: [
 							...segments,
-							ethers.solidityPacked(["uint256", "uint256", "uint8"], [signer, start + offset, 0]),
+							solidityPacked(["uint256", "uint256", "uint8"], [signer, start + offset, 0]),
 						],
-						offset: offset + 32 + ethers.dataLength(signature),
+						offset: offset + 32 + dataLength(signature),
 					};
 				} else {
 					return {
-						segments: [...segments, ethers.solidityPacked(["bytes"], [signature])],
+						segments: [...segments, solidityPacked(["bytes"], [signature])],
 						offset: offset,
 					};
 				}
 			},
 			{ segments: [] as string[], offset: 0 },
 		);
-		return ethers.concat([
+		return concat([
 			...segments,
 			...signerSignaturePairs.map(({ signer, signature, isContractSignature }) => {
 				isContractSignature = isContractSignature || typeof signer !== "string";
 				if (isContractSignature) {
-					return ethers.solidityPacked(
+					return solidityPacked(
 						["uint256", "bytes"],
-						[ethers.dataLength(signature), signature],
+						[dataLength(signature), signature],
 					);
 				} else {
 					//only append signatures if a contract signature
@@ -2211,7 +2212,7 @@ export class SafeAccount extends SmartAccount {
 	 * @returns formatted signature
 	 */
 	public static createWebAuthnSignature(signatureData: WebauthnSignatureData): string {
-		return ethers.AbiCoder.defaultAbiCoder().encode(
+		return encodeAbiParameters(
 			["bytes", "bytes", "uint256[2]"],
 			[
 				new Uint8Array(signatureData.authenticatorData),
@@ -2631,8 +2632,7 @@ export class SafeAccount extends SmartAccount {
 		};
 		const getOwnersResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const decodedCalldata = abiCoder.decode(["address[]"], getOwnersResult);
+		const decodedCalldata = decodeAbiParameters(["address[]"], getOwnersResult);
 
 		return decodedCalldata[0];
 	}
@@ -2652,8 +2652,7 @@ export class SafeAccount extends SmartAccount {
 		};
 		const getThresholdResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const decodedCalldata = abiCoder.decode(["uint256"], getThresholdResult);
+		const decodedCalldata = decodeAbiParameters(["uint256"], getThresholdResult);
 
 		return Number(decodedCalldata[0]);
 	}
@@ -2701,8 +2700,7 @@ export class SafeAccount extends SmartAccount {
 						"probably not deployed yet.",
 				);
 			}
-			const abiCoder = AbiCoder.defaultAbiCoder();
-			const decodedCalldata = abiCoder.decode(["address[]", "address"], getModulesResult);
+			const decodedCalldata = decodeAbiParameters(["address[]", "address"], getModulesResult);
 			return [decodedCalldata[0], decodedCalldata[1]];
 		} catch (err) {
 			const error = ensureError(err);
@@ -2733,8 +2731,7 @@ export class SafeAccount extends SmartAccount {
 		};
 		const isModuleEnabledResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const decodedCalldata = abiCoder.decode(["bool"], isModuleEnabledResult);
+		const decodedCalldata = decodeAbiParameters(["bool"], isModuleEnabledResult);
 
 		return decodedCalldata[0];
 	}
@@ -2872,7 +2869,7 @@ export class SafeAccount extends SmartAccount {
 			},
 		);
 
-		const decodedCalldata = AbiCoder.defaultAbiCoder().decode(["bool"], isModuleEnabledResult);
+		const decodedCalldata = decodeAbiParameters(["bool"], isModuleEnabledResult);
 
 		return decodedCalldata[0];
 	}
@@ -2883,10 +2880,9 @@ export class SafeAccount extends SmartAccount {
 		eip7212WebAuthnContractVerifier: string,
 		webAuthnSignerSingleton: string,
 	): string {
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const x = abiCoder.encode(["uint256"], [signer.x]);
-		const y = abiCoder.encode(["uint256"], [signer.y]);
-		const verifiers = abiCoder.encode(
+		const x = encodeAbiParameters(["uint256"], [signer.x]);
+		const y = encodeAbiParameters(["uint256"], [signer.y]);
+		const verifiers = encodeAbiParameters(
 			["uint176"],
 			[
 				"0x" +

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -1,4 +1,9 @@
-import {getAddress, TypedDataEncoder, Wallet} from "ethers";
+import {
+	getAddress,
+	hashTypedData,
+	privateKeyToAddress,
+	signHash,
+} from "../../ethereUtils";
 import type {Bundler} from "src/Bundler";
 import {
 	EIP712_MULTI_CHAIN_OPERATIONS_PRIMARY_TYPE,
@@ -565,7 +570,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			});
 			const [root, proofs] = generateMerkleProofs(userOperationsHashes);
 
-			const merkleTreeRootHash = TypedDataEncoder.hash(
+			const merkleTreeRootHash = hashTypedData(
 				{ verifyingContract: this.safe4337ModuleAddress },
 				EIP712_MULTI_CHAIN_OPERATIONS_TYPE,
 				{ merkleTreeRoot: root },
@@ -573,10 +578,9 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 
 			const signerSignaturePairs: SignerSignaturePair[] = [];
 			for (const privateKey of privateKeys) {
-				const wallet = new Wallet(privateKey);
-				const signature = wallet.signingKey.sign(merkleTreeRootHash).serialized;
+				const signature = signHash(privateKey, merkleTreeRootHash).serialized;
 				signerSignaturePairs.push({
-					signer: wallet.address,
+					signer: privateKeyToAddress(privateKey),
 					signature,
 				});
 			}
@@ -673,7 +677,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			});
 			const [root, proofs] = generateMerkleProofs(userOperationsHashes);
 
-			const merkleTreeRootHash = TypedDataEncoder.hash(
+			const merkleTreeRootHash = hashTypedData(
 				{ verifyingContract: this.safe4337ModuleAddress },
 				EIP712_MULTI_CHAIN_OPERATIONS_TYPE,
 				{ merkleTreeRoot: root },
@@ -780,7 +784,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 			userOperationsToSignsToSign,
 			overrides,
 		);
-		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+		return hashTypedData(data.domain, data.types, data.messageValue);
 	}
 
 	/**

--- a/src/account/Safe/adapters.ts
+++ b/src/account/Safe/adapters.ts
@@ -1,4 +1,4 @@
-import { getBytes, hexlify } from "ethers";
+import { getBytes, hexlify } from "../../ethereUtils";
 import type { Signer } from "src/signer/types";
 import { SafeAccount } from "./SafeAccount";
 import type { WebauthnPublicKey, WebauthnSignatureData } from "./types";

--- a/src/account/Safe/modules/AllowanceModule.ts
+++ b/src/account/Safe/modules/AllowanceModule.ts
@@ -1,3 +1,4 @@
+import {decodeAbiParameters} from "../../../ethereUtils";
 import type {Transport} from "../../../transport";
 import {JsonRpcNode} from "../../../transport";
 import type {MetaTransaction} from "../../../types";
@@ -313,7 +314,7 @@ export class AllowanceModule extends SafeModule {
 
 		const tokens = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 		this.checkForEmptyResultAndRevert(tokens, "getTokens");
-		const decodedCalldata = this.abiCoder.decode(["address[]"], tokens);
+		const decodedCalldata = decodeAbiParameters<[string[]]>(["address[]"], tokens);
 		return decodedCalldata[0];
 	}
 
@@ -346,7 +347,7 @@ export class AllowanceModule extends SafeModule {
 
 		const tokenAllowance = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 		this.checkForEmptyResultAndRevert(tokenAllowance, "getTokenAllowance");
-		const decodedCalldata = this.abiCoder.decode(["uint256[5]"], tokenAllowance);
+		const decodedCalldata = decodeAbiParameters<[bigint[]]>(["uint256[5]"], tokenAllowance);
 		const allowance = decodedCalldata[0];
 		return {
 			amount: BigInt(allowance[0]),
@@ -429,7 +430,10 @@ export class AllowanceModule extends SafeModule {
 
 		const delegates = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 		this.checkForEmptyResultAndRevert(delegates, "getDelegates");
-		const decodedCalldata = this.abiCoder.decode(["address[]", "uint48"], delegates);
+		const decodedCalldata = decodeAbiParameters<[string[], bigint]>(
+			["address[]", "uint48"],
+			delegates,
+		);
 
 		return {
 			results: decodedCalldata[0],

--- a/src/account/Safe/modules/SafeModule.ts
+++ b/src/account/Safe/modules/SafeModule.ts
@@ -1,4 +1,4 @@
-import { AbiCoder } from "ethers";
+import { decodeAbiParameters, encodeAbiParameters } from "src/ethereUtils";
 import { AbstractionKitError } from "src/errors";
 import type { MetaTransaction } from "../../../types";
 import { SafeAccount } from "../SafeAccount";
@@ -9,14 +9,16 @@ import { SafeAccount } from "../SafeAccount";
  */
 export abstract class SafeModule {
 	readonly moduleAddress: string;
-	protected readonly abiCoder: AbiCoder;
+	protected readonly abiCoder = {
+		encode: encodeAbiParameters,
+		decode: decodeAbiParameters,
+	};
 
 	/**
 	 * @param moduleAddress - The deployed address of the Safe module contract.
 	 */
 	constructor(moduleAddress: string) {
 		this.moduleAddress = moduleAddress;
-		this.abiCoder = AbiCoder.defaultAbiCoder();
 	}
 
 	/**

--- a/src/account/Safe/modules/SafeModule.ts
+++ b/src/account/Safe/modules/SafeModule.ts
@@ -1,4 +1,3 @@
-import { decodeAbiParameters, encodeAbiParameters } from "src/ethereUtils";
 import { AbstractionKitError } from "src/errors";
 import type { MetaTransaction } from "../../../types";
 import { SafeAccount } from "../SafeAccount";
@@ -9,10 +8,6 @@ import { SafeAccount } from "../SafeAccount";
  */
 export abstract class SafeModule {
 	readonly moduleAddress: string;
-	protected readonly abiCoder = {
-		encode: encodeAbiParameters,
-		decode: decodeAbiParameters,
-	};
 
 	/**
 	 * @param moduleAddress - The deployed address of the Safe module contract.

--- a/src/account/Safe/modules/SocialRecoveryModule.ts
+++ b/src/account/Safe/modules/SocialRecoveryModule.ts
@@ -1,4 +1,5 @@
 import {AbstractionKitError} from "../../../errors";
+import {decodeAbiParameters} from "../../../ethereUtils";
 import type {Transport} from "../../../transport";
 import {JsonRpcNode} from "../../../transport";
 import type {MetaTransaction} from "../../../types";
@@ -321,7 +322,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const recoveryHashResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(recoveryHashResult, "getRecoveryHash");
-		const decodedCalldata = this.abiCoder.decode(["bytes32"], recoveryHashResult);
+		const decodedCalldata = decodeAbiParameters<[string]>(["bytes32"], recoveryHashResult);
 		return decodedCalldata[0];
 	}
 
@@ -347,7 +348,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const recoveryRequestResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(recoveryRequestResult, "getRecoveryRequest");
-		const decodedCalldata = this.abiCoder.decode(
+		const decodedCalldata = decodeAbiParameters<[[bigint, bigint, bigint, string[]]]>(
 			["(uint256,uint256,uint64,address[])"],
 			recoveryRequestResult,
 		);
@@ -389,7 +390,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const recoveryApprovalResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(recoveryApprovalResult, "getRecoveryApprovals");
-		const decodedCalldata = this.abiCoder.decode(["uint256"], recoveryApprovalResult);
+		const decodedCalldata = decodeAbiParameters<[bigint]>(["uint256"], recoveryApprovalResult);
 
 		return BigInt(decodedCalldata[0]);
 	}
@@ -425,7 +426,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const hasGuardianApprovedResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(hasGuardianApprovedResult, "hasGuardianApproved");
-		const decodedCalldata = this.abiCoder.decode(["bool"], hasGuardianApprovedResult);
+		const decodedCalldata = decodeAbiParameters<[boolean]>(["bool"], hasGuardianApprovedResult);
 
 		return Boolean(decodedCalldata[0]);
 	}
@@ -458,7 +459,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const isGuardianResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(isGuardianResult, "isGuardian");
-		const decodedCalldata = this.abiCoder.decode(["bool"], isGuardianResult);
+		const decodedCalldata = decodeAbiParameters<[boolean]>(["bool"], isGuardianResult);
 
 		return Boolean(decodedCalldata[0]);
 	}
@@ -484,7 +485,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const guardiansCountResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(guardiansCountResult, "guardiansCount");
-		const decodedCalldata = this.abiCoder.decode(["uint256"], guardiansCountResult);
+		const decodedCalldata = decodeAbiParameters<[bigint]>(["uint256"], guardiansCountResult);
 
 		return BigInt(decodedCalldata[0]);
 	}
@@ -510,7 +511,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const thresholdResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(thresholdResult, "threshold");
-		const decodedCalldata = this.abiCoder.decode(["uint256"], thresholdResult);
+		const decodedCalldata = decodeAbiParameters<[bigint]>(["uint256"], thresholdResult);
 
 		return BigInt(decodedCalldata[0]);
 	}
@@ -536,7 +537,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const getGuardiansResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(getGuardiansResult, "threshold");
-		const decodedCalldata = this.abiCoder.decode(["address[]"], getGuardiansResult);
+		const decodedCalldata = decodeAbiParameters<[string[]]>(["address[]"], getGuardiansResult);
 
 		return decodedCalldata[0];
 	}
@@ -562,7 +563,7 @@ export class SocialRecoveryModule extends SafeModule {
 		const nonceResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
 		this.checkForEmptyResultAndRevert(nonceResult, "threshold");
-		const decodedCalldata = this.abiCoder.decode(["uint256"], nonceResult);
+		const decodedCalldata = decodeAbiParameters<[bigint]>(["uint256"], nonceResult);
 
 		return BigInt(decodedCalldata[0]);
 	}

--- a/src/account/Safe/multisend.ts
+++ b/src/account/Safe/multisend.ts
@@ -1,4 +1,4 @@
-import { AbiCoder, getBytes, solidityPacked } from "ethers";
+import { decodeAbiParameters, getBytes, solidityPacked } from "../../ethereUtils";
 import { type MetaTransaction, Operation } from "src/types";
 
 /**
@@ -34,7 +34,6 @@ export function encodeMultiSendCallData(metaTransactions: MetaTransaction[]): st
  * @returns The decoded packed transaction bytes as a hex string.
  */
 export function decodeMultiSendCallData(callData: string): string {
-	const abiCoder = AbiCoder.defaultAbiCoder();
-	const decodedCalldata = abiCoder.decode(["bytes"], `0x${callData.slice(10)}`);
+	const decodedCalldata = decodeAbiParameters(["bytes"], `0x${callData.slice(10)}`);
 	return decodedCalldata[0] as string;
 }

--- a/src/account/Safe/multisend.ts
+++ b/src/account/Safe/multisend.ts
@@ -34,6 +34,6 @@ export function encodeMultiSendCallData(metaTransactions: MetaTransaction[]): st
  * @returns The decoded packed transaction bytes as a hex string.
  */
 export function decodeMultiSendCallData(callData: string): string {
-	const decodedCalldata = decodeAbiParameters(["bytes"], `0x${callData.slice(10)}`);
-	return decodedCalldata[0] as string;
+	const decodedCalldata = decodeAbiParameters<[string]>(["bytes"], `0x${callData.slice(10)}`);
+	return decodedCalldata[0];
 }

--- a/src/account/Safe/safeMessage.ts
+++ b/src/account/Safe/safeMessage.ts
@@ -1,4 +1,4 @@
-import { hashMessage } from "ethers";
+import { hashMessage } from "../../ethereUtils";
 
 /** The primary EIP-712 type name used for Safe message signing. */
 export const SAFE_MESSAGE_PRIMARY_TYPE = "SafeMessage";

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -948,27 +948,26 @@ export class BaseSimple7702Account extends SmartAccount {
 
 		let decodedMetaTransactions: SimpleMetaTransaction[];
 		if (callData.startsWith(BaseSimple7702Account.batchExecutorFunctionSelector)) {
-			const decodedParamsArray = decodeAbiParameters(
-				BaseSimple7702Account.batchExecutorFunctionInputAbi,
-				`0x${callData.slice(10)}`,
-			)[0] as [];
+			const decodedParamsArray = decodeAbiParameters<
+				[Array<[string, bigint, string | Uint8Array]>]
+			>(BaseSimple7702Account.batchExecutorFunctionInputAbi, `0x${callData.slice(10)}`)[0];
 			decodedMetaTransactions = decodedParamsArray.map((decodedParams) => ({
-				to: decodedParams[0] as string,
-				value: BigInt(decodedParams[1] as string),
+				to: decodedParams[0],
+				value: BigInt(decodedParams[1]),
 				data:
 					typeof decodedParams[2] !== "string"
 						? new TextDecoder().decode(decodedParams[2])
 						: decodedParams[2],
 			}));
 		} else if (callData.startsWith(BaseSimple7702Account.executorFunctionSelector)) {
-			const decodedParams = decodeAbiParameters(
+			const decodedParams = decodeAbiParameters<[string, bigint, string | Uint8Array]>(
 				BaseSimple7702Account.executorFunctionInputAbi,
 				`0x${callData.slice(10)}`,
 			);
 			decodedMetaTransactions = [
 				{
-					to: decodedParams[0] as string,
-					value: BigInt(decodedParams[1] as string),
+					to: decodedParams[0],
+					value: BigInt(decodedParams[1]),
 					data:
 						typeof decodedParams[2] !== "string"
 							? new TextDecoder().decode(decodedParams[2])

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -1,4 +1,4 @@
-import {AbiCoder, Wallet} from "ethers";
+import {decodeAbiParameters, signHash} from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {BaseUserOperationDummyValues, ENTRYPOINT_V8, ENTRYPOINT_V9} from "src/constants";
 import {AbstractionKitError} from "src/errors";
@@ -760,8 +760,7 @@ export class BaseSimple7702Account extends SmartAccount {
 			chainId,
 		);
 
-		const wallet = new Wallet(privateKey);
-		return wallet.signingKey.sign(userOperationHash).serialized;
+		return signHash(privateKey, userOperationHash).serialized;
 	}
 
 	/**
@@ -947,10 +946,9 @@ export class BaseSimple7702Account extends SmartAccount {
 			data: approveCallData,
 		};
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		let decodedMetaTransactions: SimpleMetaTransaction[];
 		if (callData.startsWith(BaseSimple7702Account.batchExecutorFunctionSelector)) {
-			const decodedParamsArray = abiCoder.decode(
+			const decodedParamsArray = decodeAbiParameters(
 				BaseSimple7702Account.batchExecutorFunctionInputAbi,
 				`0x${callData.slice(10)}`,
 			)[0] as [];
@@ -963,7 +961,7 @@ export class BaseSimple7702Account extends SmartAccount {
 						: decodedParams[2],
 			}));
 		} else if (callData.startsWith(BaseSimple7702Account.executorFunctionSelector)) {
-			const decodedParams = abiCoder.decode(
+			const decodedParams = decodeAbiParameters(
 				BaseSimple7702Account.executorFunctionInputAbi,
 				`0x${callData.slice(10)}`,
 			);

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -439,7 +439,9 @@ function _pack(type: string, value: unknown, isArray?: boolean): Uint8Array {
 export function solidityPacked(types: ReadonlyArray<string>, values: ReadonlyArray<unknown>): Hex {
     assertArgument(types.length === values.length, "wrong number of values", "values", values);
     const tight: Uint8Array[] = [];
-    types.forEach((type, index) => tight.push(_pack(type, values[index])));
+    for (let i = 0; i < types.length; i++) {
+        tight.push(_pack(types[i], values[i]));
+    }
     return hexlify(concat(tight));
 }
 
@@ -676,26 +678,47 @@ function encodeTuple(types: AbiType[], values: unknown[]): Uint8Array {
     return concatBytes([...heads, ...tails]);
 }
 
+function ensureRange(data: Uint8Array, offset: number, len: number, what: string): void {
+    if (offset < 0 || len < 0 || offset + len > data.length) {
+        throw new Error(
+            `ABI decode: out-of-bounds read for ${what} ` +
+            `(offset=${offset}, length=${len}, data.length=${data.length})`,
+        );
+    }
+}
+
 function decodeValue(t: AbiType, data: Uint8Array, base: number): unknown {
     switch (t.kind) {
         case "uint": {
+            ensureRange(data, base, WordSize, `${t.signed ? "int" : "uint"}${t.bits}`);
             const raw = toBigInt(data.slice(base, base + WordSize));
             const masked = mask(raw, t.bits);
             return t.signed ? fromTwos(masked, t.bits) : masked;
         }
-        case "address": return getAddress(hexlify(data.slice(base + 12, base + WordSize)));
-        case "bool": return data[base + 31] !== 0;
-        case "bytesN": return hexlify(data.slice(base, base + t.size));
+        case "address":
+            ensureRange(data, base, WordSize, "address");
+            return getAddress(hexlify(data.slice(base + 12, base + WordSize)));
+        case "bool":
+            ensureRange(data, base, WordSize, "bool");
+            return data[base + 31] !== 0;
+        case "bytesN":
+            ensureRange(data, base, WordSize, `bytes${t.size}`);
+            return hexlify(data.slice(base, base + t.size));
         case "bytes": {
+            ensureRange(data, base, WordSize, "bytes length");
             const len = toNumber(data.slice(base, base + WordSize));
+            ensureRange(data, base + WordSize, len, "bytes payload");
             return hexlify(data.slice(base + WordSize, base + WordSize + len));
         }
         case "string": {
+            ensureRange(data, base, WordSize, "string length");
             const len = toNumber(data.slice(base, base + WordSize));
+            ensureRange(data, base + WordSize, len, "string payload");
             return new TextDecoder().decode(data.slice(base + WordSize, base + WordSize + len));
         }
         case "array": {
             if (t.size === -1) {
+                ensureRange(data, base, WordSize, "array length");
                 const len = toNumber(data.slice(base, base + WordSize));
                 return decodeTupleAt(Array<AbiType>(len).fill(t.child), data, base + WordSize);
             }
@@ -711,12 +734,21 @@ function decodeTupleAt(types: AbiType[], data: Uint8Array, base: number): unknow
     let head = 0;
     for (const t of types) {
         if (isDynamic(t)) {
+            ensureRange(data, base + head, WordSize, "tuple offset slot");
             const off = toNumber(data.slice(base + head, base + head + WordSize));
+            if (off < 0 || base + off > data.length) {
+                throw new Error(
+                    `ABI decode: tuple dynamic offset out-of-bounds ` +
+                    `(offset=${off}, base=${base}, data.length=${data.length})`,
+                );
+            }
             out.push(decodeValue(t, data, base + off));
             head += WordSize;
         } else {
+            const size = staticSize(t);
+            ensureRange(data, base + head, size, `tuple static slot (${t.kind})`);
             out.push(decodeValue(t, data, base + head));
-            head += staticSize(t);
+            head += size;
         }
     }
     return out;
@@ -730,8 +762,7 @@ export function encodeAbiParameters(
     return hexlify(encodeTuple(types.map(parseType), values as unknown[]));
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function decodeAbiParameters(types: ReadonlyArray<string>, data: BytesLike): any[] {
+export function decodeAbiParameters(types: ReadonlyArray<string>, data: BytesLike): unknown[] {
     return decodeTupleAt(types.map(parseType), getBytes(data), 0);
 }
 

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -1,0 +1,1001 @@
+/**
+ * ethereUtils — copying related code from ethers v6 with some modification,
+ * covering exactly the surface area used by `abstractionkit`.
+ *
+ * Sources (ethers v6.13.x):
+ *   src.ts/utils/{data,maths,utf8,rlp-encode}.ts
+ *   src.ts/crypto/{keccak,signing-key,signature}.ts
+ *   src.ts/hash/{id,message,solidity,typed-data}.ts
+ *   src.ts/address/{address,checks}.ts
+ *   src.ts/abi/{abi-coder, coders/*}.ts
+ *   src.ts/transaction/address.ts
+ */
+
+import { keccak_256 } from "@noble/hashes/sha3";
+import { secp256k1 } from "@noble/curves/secp256k1";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type Hex = `0x${string}`;
+export type BytesLike = string | Uint8Array;
+export type Numeric = number | bigint;
+export type BigNumberish = string | Numeric;
+export type RlpStructuredDataish = BytesLike | ReadonlyArray<RlpStructuredDataish>;
+
+export interface TypedDataDomain {
+    name?: null | string;
+    version?: null | string;
+    chainId?: null | BigNumberish;
+    verifyingContract?: null | string;
+    salt?: null | BytesLike;
+}
+
+export interface TypedDataField {
+    name: string;
+    type: string;
+}
+
+export interface Signature {
+    r: Hex;
+    s: Hex;
+    v: 27 | 28;
+    yParity: 0 | 1;
+    /** 65-byte hex: `r (32) || s (32) || v (1)`. */
+    serialized: Hex;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errors (simplified)
+//   ethers ships a rich error system; we keep the assertion shape and message
+//   formatting but drop the typed-error machinery (CALL_EXCEPTION,
+//   BUFFER_OVERRUN, NUMERIC_FAULT, …) since none of abstractionkit's call
+//   sites discriminate on them.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function assertArgument(check: unknown, message: string, name: string, value: unknown): asserts check {
+    if (!check) throw new Error(`invalid argument (${name}=${String(value)}, message=${message})`);
+}
+function assertCheck(check: unknown, message: string): asserts check {
+    if (!check) throw new Error(message);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data helpers (src.ts/utils/data.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HexCharacters = "0123456789abcdef";
+
+function _getBytes(value: BytesLike, name?: string, copy?: boolean): Uint8Array {
+    if (value instanceof Uint8Array) {
+        return copy ? new Uint8Array(value) : value;
+    }
+    if (typeof value === "string" && value.length % 2 === 0 && value.match(/^0x[0-9a-f]*$/i)) {
+        const result = new Uint8Array((value.length - 2) / 2);
+        let offset = 2;
+        for (let i = 0; i < result.length; i++) {
+            result[i] = parseInt(value.substring(offset, offset + 2), 16);
+            offset += 2;
+        }
+        return result;
+    }
+    assertArgument(false, "invalid BytesLike value", name || "value", value);
+}
+
+export function getBytes(value: BytesLike, name?: string): Uint8Array {
+    return _getBytes(value, name, false);
+}
+
+function getBytesCopy(value: BytesLike, name?: string): Uint8Array {
+    return _getBytes(value, name, true);
+}
+
+export function isHexString(value: unknown, length?: number | boolean): value is `0x${string}` {
+    if (typeof value !== "string" || !value.match(/^0x[0-9A-Fa-f]*$/)) return false;
+    if (typeof length === "number" && value.length !== 2 + 2 * length) return false;
+    if (length === true && value.length % 2 !== 0) return false;
+    return true;
+}
+
+function isBytesLike(value: unknown): value is BytesLike {
+    return isHexString(value, true) || value instanceof Uint8Array;
+}
+
+export function hexlify(data: BytesLike): Hex {
+    const bytes = getBytes(data);
+    let result = "0x";
+    for (let i = 0; i < bytes.length; i++) {
+        const v = bytes[i];
+        result += HexCharacters[(v & 0xf0) >> 4] + HexCharacters[v & 0x0f];
+    }
+    return result as Hex;
+}
+
+export function concat(datas: ReadonlyArray<BytesLike>): Hex {
+    return ("0x" + datas.map((d) => hexlify(d).substring(2)).join("")) as Hex;
+}
+
+export function dataLength(data: BytesLike): number {
+    if (isHexString(data, true)) return (data.length - 2) / 2;
+    return getBytes(data).length;
+}
+
+function zeroPad(data: BytesLike, length: number, left: boolean): Hex {
+    const bytes = getBytes(data);
+    assertCheck(length >= bytes.length, "padding exceeds data length");
+    const result = new Uint8Array(length);
+    result.fill(0);
+    if (left) result.set(bytes, length - bytes.length);
+    else result.set(bytes, 0);
+    return hexlify(result);
+}
+
+function zeroPadValue(data: BytesLike, length: number): Hex {
+    return zeroPad(data, length, true);
+}
+
+function zeroPadBytes(data: BytesLike, length: number): Hex {
+    return zeroPad(data, length, false);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Math helpers (src.ts/utils/maths.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BN_0 = 0n;
+const BN_1 = 1n;
+const maxValue = 0x1fffffffffffff; // 2^53 - 1 (IEEE 754 mantissa)
+
+function getBigInt(value: BigNumberish, name?: string): bigint {
+    switch (typeof value) {
+        case "bigint": return value;
+        case "number":
+            assertArgument(Number.isInteger(value), "underflow", name || "value", value);
+            assertArgument(value >= -maxValue && value <= maxValue, "overflow", name || "value", value);
+            return BigInt(value);
+        case "string":
+            try {
+                if (value === "") throw new Error("empty string");
+                if (value[0] === "-" && value[1] !== "-") return -BigInt(value.substring(1));
+                return BigInt(value);
+            } catch (e) {
+                assertArgument(false, `invalid BigNumberish string: ${(e as Error).message}`, name || "value", value);
+            }
+    }
+    assertArgument(false, "invalid BigNumberish value", name || "value", value);
+}
+
+function getUint(value: BigNumberish, name?: string): bigint {
+    const result = getBigInt(value, name);
+    assertCheck(result >= BN_0, "unsigned value cannot be negative");
+    return result;
+}
+
+function getNumber(value: BigNumberish, name?: string): number {
+    switch (typeof value) {
+        case "bigint":
+            assertArgument(value >= -maxValue && value <= maxValue, "overflow", name || "value", value);
+            return Number(value);
+        case "number":
+            assertArgument(Number.isInteger(value), "underflow", name || "value", value);
+            assertArgument(value >= -maxValue && value <= maxValue, "overflow", name || "value", value);
+            return value;
+        case "string":
+            try {
+                if (value === "") throw new Error("empty string");
+                return getNumber(BigInt(value), name);
+            } catch (e) {
+                assertArgument(false, `invalid numeric string: ${(e as Error).message}`, name || "value", value);
+            }
+    }
+    assertArgument(false, "invalid numeric value", name || "value", value);
+}
+
+const Nibbles = "0123456789abcdef";
+
+function toBigInt(value: BigNumberish | Uint8Array): bigint {
+    if (value instanceof Uint8Array) {
+        let result = "0x0";
+        for (const v of value) {
+            result += Nibbles[v >> 4];
+            result += Nibbles[v & 0x0f];
+        }
+        return BigInt(result);
+    }
+    return getBigInt(value);
+}
+
+function toNumber(value: BigNumberish | Uint8Array): number {
+    return getNumber(toBigInt(value));
+}
+
+function mask(_value: BigNumberish, _bits: Numeric): bigint {
+    const value = getUint(_value, "value");
+    const bits = BigInt(getNumber(_bits, "bits"));
+    return value & ((BN_1 << bits) - BN_1);
+}
+
+function toTwos(_value: BigNumberish, _width: Numeric): bigint {
+    let value = getBigInt(_value, "value");
+    const width = BigInt(getNumber(_width, "width"));
+    const limit = BN_1 << (width - BN_1);
+    if (value < BN_0) {
+        value = -value;
+        assertCheck(value <= limit, "toTwos: too low");
+        const m = (BN_1 << width) - BN_1;
+        return ((~value) & m) + BN_1;
+    }
+    assertCheck(value < limit, "toTwos: too high");
+    return value;
+}
+
+function fromTwos(_value: BigNumberish, _width: Numeric): bigint {
+    const value = getUint(_value, "value");
+    const width = BigInt(getNumber(_width, "width"));
+    assertCheck((value >> width) === BN_0, "fromTwos: overflow");
+    if (value >> (width - BN_1)) {
+        const m = (BN_1 << width) - BN_1;
+        return -(((~value) & m) + BN_1);
+    }
+    return value;
+}
+
+function toBeHex(_value: BigNumberish, _width?: Numeric): Hex {
+    const value = getUint(_value, "value");
+    let result = value.toString(16);
+    if (_width == null) {
+        if (result.length % 2) result = "0" + result;
+    } else {
+        const width = getNumber(_width, "width");
+        if (width === 0 && value === BN_0) return "0x" as Hex;
+        assertCheck(width * 2 >= result.length, `value exceeds width (${width} bytes)`);
+        while (result.length < width * 2) result = "0" + result;
+    }
+    return ("0x" + result) as Hex;
+}
+
+export function toBeArray(_value: BigNumberish, _width?: Numeric): Uint8Array {
+    const value = getUint(_value, "value");
+    if (value === BN_0) {
+        const width = _width != null ? getNumber(_width, "width") : 0;
+        return new Uint8Array(width);
+    }
+    let hex = value.toString(16);
+    if (hex.length % 2) hex = "0" + hex;
+    if (_width != null) {
+        const width = getNumber(_width, "width");
+        while (hex.length < width * 2) hex = "00" + hex;
+        assertCheck(width * 2 === hex.length, `value exceeds width (${width} bytes)`);
+    }
+    const result = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < result.length; i++) {
+        const offset = i * 2;
+        result[i] = parseInt(hex.substring(offset, offset + 2), 16);
+    }
+    return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UTF-8 (src.ts/utils/utf8.ts — encoding only)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function toUtf8Bytes(str: string): Uint8Array {
+    assertArgument(typeof str === "string", "invalid string value", "str", str);
+    const result: number[] = [];
+    for (let i = 0; i < str.length; i++) {
+        const c = str.charCodeAt(i);
+        if (c < 0x80) {
+            result.push(c);
+        } else if (c < 0x800) {
+            result.push((c >> 6) | 0xc0);
+            result.push((c & 0x3f) | 0x80);
+        } else if ((c & 0xfc00) === 0xd800) {
+            i++;
+            const c2 = str.charCodeAt(i);
+            assertArgument(i < str.length && (c2 & 0xfc00) === 0xdc00, "invalid surrogate pair", "str", str);
+            const pair = 0x10000 + ((c & 0x03ff) << 10) + (c2 & 0x03ff);
+            result.push((pair >> 18) | 0xf0);
+            result.push(((pair >> 12) & 0x3f) | 0x80);
+            result.push(((pair >> 6) & 0x3f) | 0x80);
+            result.push((pair & 0x3f) | 0x80);
+        } else {
+            result.push((c >> 12) | 0xe0);
+            result.push(((c >> 6) & 0x3f) | 0x80);
+            result.push((c & 0x3f) | 0x80);
+        }
+    }
+    return new Uint8Array(result);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Crypto: keccak256 (src.ts/crypto/keccak.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function keccak256(_data: BytesLike): Hex {
+    const data = getBytes(_data, "data");
+    return hexlify(keccak_256(data));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hash: id, hashMessage (src.ts/hash/{id,message}.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function id(value: string): Hex {
+    return keccak256(toUtf8Bytes(value));
+}
+
+const MessagePrefix = "\x19Ethereum Signed Message:\n";
+
+export function hashMessage(message: Uint8Array | string): Hex {
+    if (typeof message === "string") message = toUtf8Bytes(message);
+    return keccak256(concat([
+        toUtf8Bytes(MessagePrefix),
+        toUtf8Bytes(String(message.length)),
+        message,
+    ]));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Address: getAddress, isAddress (src.ts/address/{address,checks}.ts)
+//   ICAP/Base36 dropped — abstractionkit never passes ICAP addresses.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getChecksumAddress(address: string): Hex {
+    address = address.toLowerCase();
+    const chars = address.substring(2).split("");
+    const expanded = new Uint8Array(40);
+    for (let i = 0; i < 40; i++) expanded[i] = chars[i].charCodeAt(0);
+    const hashed = getBytes(keccak256(expanded));
+    for (let i = 0; i < 40; i += 2) {
+        if ((hashed[i >> 1] >> 4) >= 8) chars[i] = chars[i].toUpperCase();
+        if ((hashed[i >> 1] & 0x0f) >= 8) chars[i + 1] = chars[i + 1].toUpperCase();
+    }
+    return ("0x" + chars.join("")) as Hex;
+}
+
+export function getAddress(address: string): Hex {
+    assertArgument(typeof address === "string", "invalid address", "address", address);
+    if (address.match(/^(0x)?[0-9a-fA-F]{40}$/)) {
+        if (!address.startsWith("0x")) address = "0x" + address;
+        const result = getChecksumAddress(address);
+        assertArgument(
+            !address.match(/([A-F].*[a-f])|([a-f].*[A-F])/) || result === address,
+            "bad address checksum", "address", address,
+        );
+        return result;
+    }
+    assertArgument(false, "invalid address", "address", address);
+}
+
+export function isAddress(value: unknown): value is string {
+    try {
+        getAddress(value as string);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Solidity packed (src.ts/hash/solidity.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const regexBytes = /^bytes([0-9]+)$/;
+const regexNumber = /^(u?int)([0-9]*)$/;
+const regexArray = /^(.*)\[([0-9]*)\]$/;
+
+function _pack(type: string, value: unknown, isArray?: boolean): Uint8Array {
+    switch (type) {
+        case "address":
+            if (isArray) return getBytes(zeroPadValue(value as string, 32));
+            return getBytes(getAddress(value as string));
+        case "string":
+            return toUtf8Bytes(value as string);
+        case "bytes":
+            return getBytes(value as BytesLike);
+        case "bool": {
+            const v: Hex = value ? "0x01" : "0x00";
+            if (isArray) return getBytes(zeroPadValue(v, 32));
+            return getBytes(v);
+        }
+    }
+
+    let match = type.match(regexNumber);
+    if (match) {
+        const signed = match[1] === "int";
+        let size = parseInt(match[2] || "256");
+        assertArgument(
+            (!match[2] || match[2] === String(size)) && size % 8 === 0 && size !== 0 && size <= 256,
+            "invalid number type", "type", type,
+        );
+        if (isArray) size = 256;
+        const v = signed ? toTwos(value as BigNumberish, size) : (value as BigNumberish);
+        return getBytes(zeroPadValue(toBeArray(v), size / 8));
+    }
+
+    match = type.match(regexBytes);
+    if (match) {
+        const size = parseInt(match[1]);
+        assertArgument(String(size) === match[1] && size !== 0 && size <= 32, "invalid bytes type", "type", type);
+        assertArgument(dataLength(value as BytesLike) === size, `invalid value for ${type}`, "value", value);
+        if (isArray) return getBytes(zeroPadBytes(value as BytesLike, 32));
+        return getBytes(value as BytesLike);
+    }
+
+    match = type.match(regexArray);
+    if (match && Array.isArray(value)) {
+        const baseType = match[1];
+        const count = parseInt(match[2] || String(value.length));
+        assertArgument(count === value.length, `invalid array length for ${type}`, "value", value);
+        const result: Uint8Array[] = [];
+        for (const v of value) result.push(_pack(baseType, v, true));
+        return getBytes(concat(result));
+    }
+
+    assertArgument(false, "invalid type", "type", type);
+}
+
+export function solidityPacked(types: ReadonlyArray<string>, values: ReadonlyArray<unknown>): Hex {
+    assertArgument(types.length === values.length, "wrong number of values", "values", values);
+    const tight: Uint8Array[] = [];
+    types.forEach((type, index) => tight.push(_pack(type, values[index])));
+    return hexlify(concat(tight));
+}
+
+export function solidityPackedKeccak256(types: ReadonlyArray<string>, values: ReadonlyArray<unknown>): Hex {
+    return keccak256(solidityPacked(types, values));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RLP encode (src.ts/utils/rlp-encode.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function arrayifyInteger(value: number): number[] {
+    const result: number[] = [];
+    while (value) {
+        result.unshift(value & 0xff);
+        value >>= 8;
+    }
+    return result;
+}
+
+function _rlpEncode(object: RlpStructuredDataish): number[] {
+    if (Array.isArray(object)) {
+        let payload: number[] = [];
+        object.forEach((child) => {
+            payload = payload.concat(_rlpEncode(child));
+        });
+        if (payload.length <= 55) {
+            payload.unshift(0xc0 + payload.length);
+            return payload;
+        }
+        const length = arrayifyInteger(payload.length);
+        length.unshift(0xf7 + length.length);
+        return length.concat(payload);
+    }
+    const data: number[] = Array.prototype.slice.call(getBytes(object as BytesLike, "object"));
+    if (data.length === 1 && data[0] <= 0x7f) return data;
+    if (data.length <= 55) {
+        data.unshift(0x80 + data.length);
+        return data;
+    }
+    const length = arrayifyInteger(data.length);
+    length.unshift(0xb7 + length.length);
+    return length.concat(data);
+}
+
+export function encodeRlp(object: RlpStructuredDataish): Hex {
+    let result = "0x";
+    for (const v of _rlpEncode(object)) {
+        result += Nibbles[v >> 4];
+        result += Nibbles[v & 0xf];
+    }
+    return result as Hex;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ABI codec (src.ts/abi/* — class hierarchy collapsed into recursive functions)
+//
+// Type grammar (subset used by abstractionkit):
+//   address | bool | string | bytes | bytes<1..32> | uint<8..256> | int<8..256>
+//   T[] | T[<n>] | (T1,T2,...) (tuples)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AbiType =
+    | { kind: "uint"; bits: number; signed: boolean }
+    | { kind: "address" }
+    | { kind: "bool" }
+    | { kind: "bytesN"; size: number }
+    | { kind: "bytes" }
+    | { kind: "string" }
+    | { kind: "array"; child: AbiType; size: number /* -1 = dynamic */ }
+    | { kind: "tuple"; components: AbiType[] };
+
+function splitTopLevel(s: string): string[] {
+    const out: string[] = [];
+    let depth = 0, start = 0;
+    for (let i = 0; i < s.length; i++) {
+        const c = s[i];
+        if (c === "(" || c === "[") depth++;
+        else if (c === ")" || c === "]") depth--;
+        else if (c === "," && depth === 0) { out.push(s.slice(start, i)); start = i + 1; }
+    }
+    if (start < s.length) out.push(s.slice(start));
+    return out.map((x) => x.trim()).filter((x) => x.length > 0);
+}
+
+function parseType(s: string): AbiType {
+    s = s.trim();
+    const m = s.match(/^(.+?)((?:\[\d*\])*)$/);
+    assertArgument(!!m, `invalid type`, "type", s);
+    const base = m![1], suffix = m![2];
+
+    let t: AbiType;
+    if (base.startsWith("(")) {
+        assertArgument(base.endsWith(")"), `unbalanced tuple`, "type", s);
+        t = { kind: "tuple", components: splitTopLevel(base.slice(1, -1)).map(parseType) };
+    } else if (base === "address") t = { kind: "address" };
+    else if (base === "bool") t = { kind: "bool" };
+    else if (base === "string") t = { kind: "string" };
+    else if (base === "bytes") t = { kind: "bytes" };
+    else if (base === "uint" || base === "int") t = { kind: "uint", bits: 256, signed: base === "int" };
+    else {
+        const um = base.match(regexNumber);
+        if (um) {
+            const bits = parseInt(um[2] || "256");
+            assertArgument(bits !== 0 && bits <= 256 && bits % 8 === 0, "invalid number type", "type", base);
+            t = { kind: "uint", bits, signed: um[1] === "int" };
+        } else {
+            const bm = base.match(regexBytes);
+            assertArgument(!!bm, `unknown type ${base}`, "type", base);
+            const size = parseInt(bm![1]);
+            assertArgument(size !== 0 && size <= 32, "invalid bytes type", "type", base);
+            t = { kind: "bytesN", size };
+        }
+    }
+
+    for (const ap of suffix.matchAll(/\[(\d*)\]/g)) {
+        t = { kind: "array", child: t, size: ap[1] ? parseInt(ap[1]) : -1 };
+    }
+    return t;
+}
+
+function isDynamic(t: AbiType): boolean {
+    switch (t.kind) {
+        case "bytes": case "string": return true;
+        case "array": return t.size === -1 || isDynamic(t.child);
+        case "tuple": return t.components.some(isDynamic);
+        default: return false;
+    }
+}
+
+function staticSize(t: AbiType): number {
+    switch (t.kind) {
+        case "uint": case "address": case "bool": case "bytesN": return 32;
+        case "array": return t.size * staticSize(t.child);
+        case "tuple": return t.components.reduce((s, c) => s + staticSize(c), 0);
+        default: throw new Error(`staticSize: dynamic type ${t.kind}`);
+    }
+}
+
+const WordSize = 32;
+const Padding = new Uint8Array(WordSize);
+
+function padLeft(b: Uint8Array, size: number): Uint8Array {
+    assertCheck(b.length <= size, "padLeft: overflow");
+    const out = new Uint8Array(size);
+    out.set(b, size - b.length);
+    return out;
+}
+
+function padRight(b: Uint8Array, size: number): Uint8Array {
+    assertCheck(b.length <= size, "padRight: overflow");
+    const out = new Uint8Array(size);
+    out.set(b, 0);
+    return out;
+}
+
+function padTo32(len: number): number {
+    return Math.ceil(len / WordSize) * WordSize;
+}
+
+const BN_MAX_UINT256 = (1n << 256n) - 1n;
+
+function encodeValue(t: AbiType, v: unknown): Uint8Array {
+    switch (t.kind) {
+        case "uint": {
+            let value = getBigInt(v as BigNumberish, "value");
+            const maxUintValue = mask(BN_MAX_UINT256, WordSize * 8);
+            if (t.signed) {
+                const bounds = mask(maxUintValue, t.bits - 1);
+                assertCheck(value <= bounds && value >= -(bounds + 1n), `int${t.bits}: value out-of-bounds`);
+                value = toTwos(value, 8 * WordSize);
+            } else {
+                assertCheck(value >= 0n && value <= mask(maxUintValue, t.bits), `uint${t.bits}: out-of-bounds`);
+            }
+            return padLeft(toBeArray(value), WordSize);
+        }
+        case "address": {
+            const bytes = getBytes(getAddress(v as string));
+            return padLeft(bytes, WordSize);
+        }
+        case "bool":
+            return padLeft(new Uint8Array([v ? 1 : 0]), WordSize);
+        case "bytesN": {
+            const bytes = getBytes(v as BytesLike);
+            assertCheck(bytes.length === t.size, `bytes${t.size}: wrong length`);
+            return padRight(bytes, WordSize);
+        }
+        case "bytes": {
+            const bytes = getBytes(v as BytesLike);
+            return concatBytes([padLeft(toBeArray(bytes.length), WordSize), padRight(bytes, padTo32(bytes.length))]);
+        }
+        case "string": {
+            const bytes = toUtf8Bytes(v as string);
+            return concatBytes([padLeft(toBeArray(bytes.length), WordSize), padRight(bytes, padTo32(bytes.length))]);
+        }
+        case "array": {
+            const arr = v as unknown[];
+            assertCheck(t.size === -1 || arr.length === t.size, "array: length mismatch");
+            const types = Array<AbiType>(arr.length).fill(t.child);
+            const inner = encodeTuple(types, arr);
+            return t.size === -1
+                ? concatBytes([padLeft(toBeArray(arr.length), WordSize), inner])
+                : inner;
+        }
+        case "tuple":
+            return encodeTuple(t.components, v as unknown[]);
+    }
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+    const total = parts.reduce((s, p) => s + p.length, 0);
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) { out.set(p, off); off += p.length; }
+    return out;
+}
+
+function encodeTuple(types: AbiType[], values: unknown[]): Uint8Array {
+    assertCheck(types.length === values.length, "tuple: length mismatch");
+    const heads: Uint8Array[] = [];
+    const tails: Uint8Array[] = [];
+    const headSize = types.reduce((s, t) => s + (isDynamic(t) ? WordSize : staticSize(t)), 0);
+    let tailOff = headSize;
+    for (let i = 0; i < types.length; i++) {
+        const enc = encodeValue(types[i], values[i]);
+        if (isDynamic(types[i])) {
+            heads.push(padLeft(toBeArray(tailOff), WordSize));
+            tails.push(enc);
+            tailOff += enc.length;
+        } else {
+            heads.push(enc);
+        }
+    }
+    return concatBytes([...heads, ...tails]);
+}
+
+function decodeValue(t: AbiType, data: Uint8Array, base: number): unknown {
+    switch (t.kind) {
+        case "uint": {
+            const raw = toBigInt(data.slice(base, base + WordSize));
+            const masked = mask(raw, t.bits);
+            return t.signed ? fromTwos(masked, t.bits) : masked;
+        }
+        case "address": return getAddress(hexlify(data.slice(base + 12, base + WordSize)));
+        case "bool": return data[base + 31] !== 0;
+        case "bytesN": return hexlify(data.slice(base, base + t.size));
+        case "bytes": {
+            const len = toNumber(data.slice(base, base + WordSize));
+            return hexlify(data.slice(base + WordSize, base + WordSize + len));
+        }
+        case "string": {
+            const len = toNumber(data.slice(base, base + WordSize));
+            return new TextDecoder().decode(data.slice(base + WordSize, base + WordSize + len));
+        }
+        case "array": {
+            if (t.size === -1) {
+                const len = toNumber(data.slice(base, base + WordSize));
+                return decodeTupleAt(Array<AbiType>(len).fill(t.child), data, base + WordSize);
+            }
+            return decodeTupleAt(Array<AbiType>(t.size).fill(t.child), data, base);
+        }
+        case "tuple":
+            return decodeTupleAt(t.components, data, base);
+    }
+}
+
+function decodeTupleAt(types: AbiType[], data: Uint8Array, base: number): unknown[] {
+    const out: unknown[] = [];
+    let head = 0;
+    for (const t of types) {
+        if (isDynamic(t)) {
+            const off = toNumber(data.slice(base + head, base + head + WordSize));
+            out.push(decodeValue(t, data, base + off));
+            head += WordSize;
+        } else {
+            out.push(decodeValue(t, data, base + head));
+            head += staticSize(t);
+        }
+    }
+    return out;
+}
+
+export function encodeAbiParameters(
+    types: ReadonlyArray<string>,
+    values: ReadonlyArray<unknown>,
+): Hex {
+    assertCheck(types.length === values.length, "encodeAbiParameters: length mismatch");
+    return hexlify(encodeTuple(types.map(parseType), values as unknown[]));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function decodeAbiParameters(types: ReadonlyArray<string>, data: BytesLike): any[] {
+    return decodeTupleAt(types.map(parseType), getBytes(data), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EIP-712 typed data (src.ts/hash/typed-data.ts — TypedDataEncoder collapsed)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const hexTrue = toBeHex(BN_1, 32);
+const hexFalse = toBeHex(BN_0, 32);
+
+function hexPadRight(value: BytesLike): Hex {
+    const bytes = getBytes(value);
+    const padOffset = bytes.length % WordSize;
+    if (padOffset) return concat([bytes, Padding.slice(padOffset)]);
+    return hexlify(bytes);
+}
+
+function getBaseEncoder(type: string): null | ((value: unknown) => Hex) {
+    {
+        const match = type.match(/^(u?)int(\d+)$/);
+        if (match) {
+            const signed = match[1] === "";
+            const width = parseInt(match[2]);
+            assertArgument(
+                width % 8 === 0 && width !== 0 && width <= 256 && match[2] === String(width),
+                "invalid numeric width", "type", type,
+            );
+            const boundsUpper = mask(BN_MAX_UINT256, signed ? width - 1 : width);
+            const boundsLower = signed ? (boundsUpper + BN_1) * -1n : BN_0;
+            return (v: unknown) => {
+                const value = getBigInt(v as BigNumberish, "value");
+                assertCheck(value >= boundsLower && value <= boundsUpper, `value out-of-bounds for ${type}`);
+                return toBeHex(signed ? toTwos(value, 256) : value, 32);
+            };
+        }
+    }
+    {
+        const match = type.match(/^bytes(\d+)$/);
+        if (match) {
+            const width = parseInt(match[1]);
+            assertArgument(width !== 0 && width <= 32 && match[1] === String(width), "invalid bytes width", "type", type);
+            return (v: unknown) => {
+                const bytes = getBytes(v as BytesLike);
+                assertCheck(bytes.length === width, `invalid length for ${type}`);
+                return hexPadRight(v as BytesLike);
+            };
+        }
+    }
+    switch (type) {
+        case "address": return (v: unknown) => zeroPadValue(getAddress(v as string), 32);
+        case "bool":    return (v: unknown) => (!v ? hexFalse : hexTrue);
+        case "bytes":   return (v: unknown) => keccak256(v as BytesLike);
+        case "string":  return (v: unknown) => id(v as string);
+    }
+    return null;
+}
+
+type ArrayResult = { base: string; index?: string; array?: { base: string; prefix: string; count: number } };
+
+function splitArray(type: string): ArrayResult {
+    //const match = type.match(/^([^\[]*)((\[\d*\])*)(\[(\d*)\])$/);
+    const match = type.match(/^([^\x5b]*)((\x5b\d*\x5d)*)(\x5b(\d*)\x5d)$/);    
+    if (match) {
+        return {
+            base: match[1],
+            index: match[2] + match[4],
+            array: { base: match[1], prefix: match[1] + match[2], count: match[5] ? parseInt(match[5]) : -1 },
+        };
+    }
+    return { base: type };
+}
+
+function encodeType(name: string, fields: ReadonlyArray<TypedDataField>): string {
+    return `${name}(${fields.map(({ name, type }) => type + " " + name).join(",")})`;
+}
+
+/**
+ * Build a recursive encoder for `primaryType` that produces the EIP-712
+ * `encodeData` for a struct value. Internal `fullTypes` map captures the
+ * fully-described type string for each struct (`MyStruct(...)NestedStruct(...)`).
+ */
+function buildTypedDataState(_types: Record<string, ReadonlyArray<TypedDataField>>) {
+    const fullTypes = new Map<string, string>();
+    const links = new Map<string, Set<string>>();
+    const parents = new Map<string, string[]>();
+    const subtypes = new Map<string, Set<string>>();
+
+    const types: Record<string, TypedDataField[]> = {};
+    for (const type of Object.keys(_types)) {
+        types[type] = _types[type].map(({ name, type }) => {
+            let { base, index } = splitArray(type);
+            if (base === "int" && !_types["int"]) base = "int256";
+            if (base === "uint" && !_types["uint"]) base = "uint256";
+            return { name, type: base + (index || "") };
+        });
+        links.set(type, new Set());
+        parents.set(type, []);
+        subtypes.set(type, new Set());
+    }
+
+    for (const name in types) {
+        const uniqueNames = new Set<string>();
+        for (const field of types[name]) {
+            assertArgument(!uniqueNames.has(field.name), `duplicate variable name ${JSON.stringify(field.name)} in ${JSON.stringify(name)}`, "types", _types);
+            uniqueNames.add(field.name);
+            const baseType = splitArray(field.type).base;
+            assertArgument(baseType !== name, `circular type reference to ${JSON.stringify(baseType)}`, "types", _types);
+            if (getBaseEncoder(baseType)) continue;
+            assertArgument(parents.has(baseType), `unknown type ${JSON.stringify(baseType)}`, "types", _types);
+            parents.get(baseType)!.push(name);
+            links.get(name)!.add(baseType);
+        }
+    }
+
+    const primaryTypes = Array.from(parents.keys()).filter((n) => parents.get(n)!.length === 0);
+    assertArgument(primaryTypes.length !== 0, "missing primary type", "types", _types);
+    assertArgument(primaryTypes.length === 1, `ambiguous primary types or unused types: ${primaryTypes.map((t) => JSON.stringify(t)).join(", ")}`, "types", _types);
+    const primaryType = primaryTypes[0];
+
+    function checkCircular(type: string, found: Set<string>): void {
+        assertArgument(!found.has(type), `circular type reference to ${JSON.stringify(type)}`, "types", _types);
+        found.add(type);
+        for (const child of links.get(type)!) {
+            if (!parents.has(child)) continue;
+            checkCircular(child, found);
+            for (const subtype of found) subtypes.get(subtype)!.add(child);
+        }
+        found.delete(type);
+    }
+    checkCircular(primaryType, new Set());
+
+    for (const [name, set] of subtypes) {
+        const st = Array.from(set);
+        st.sort();
+        fullTypes.set(name, encodeType(name, types[name]) + st.map((t) => encodeType(t, types[t])).join(""));
+    }
+
+    const encoderCache = new Map<string, (value: unknown) => Hex>();
+    function getEncoder(type: string): (value: unknown) => Hex {
+        const cached = encoderCache.get(type);
+        if (cached) return cached;
+        const built = buildEncoder(type);
+        encoderCache.set(type, built);
+        return built;
+    }
+    function buildEncoder(type: string): (value: unknown) => Hex {
+        const base = getBaseEncoder(type);
+        if (base) return base;
+        const arr = splitArray(type).array;
+        if (arr) {
+            const subtype = arr.prefix;
+            const subEncoder = getEncoder(subtype);
+            return (value: unknown) => {
+                const arrVal = value as unknown[];
+                assertCheck(arr.count === -1 || arr.count === arrVal.length, `array length mismatch; expected ${arr.count}`);
+                let result = arrVal.map(subEncoder) as Hex[];
+                if (fullTypes.has(subtype)) result = result.map(keccak256);
+                return keccak256(concat(result));
+            };
+        }
+        const fields = types[type];
+        if (fields) {
+            const encodedType = id(fullTypes.get(type)!);
+            return (value: unknown) => {
+                const obj = value as Record<string, unknown>;
+                const values = fields.map(({ name, type }) => {
+                    const r = getEncoder(type)(obj[name]);
+                    return fullTypes.has(type) ? keccak256(r) : r;
+                });
+                values.unshift(encodedType);
+                return concat(values);
+            };
+        }
+        assertArgument(false, `unknown type: ${type}`, "type", type);
+    }
+
+    function hashStruct(name: string, value: Record<string, unknown>): Hex {
+        return keccak256(getEncoder(name)(value));
+    }
+
+    return { primaryType, hashStruct };
+}
+
+const domainFieldTypes: Record<string, string> = {
+    name: "string",
+    version: "string",
+    chainId: "uint256",
+    verifyingContract: "address",
+    salt: "bytes32",
+};
+const domainFieldNames = ["name", "version", "chainId", "verifyingContract", "salt"];
+
+function hashDomain(domain: TypedDataDomain): Hex {
+    const domainFields: TypedDataField[] = [];
+    for (const name in domain) {
+        const v = (domain as Record<string, unknown>)[name];
+        if (v == null) continue;
+        const type = domainFieldTypes[name];
+        assertArgument(!!type, `invalid typed-data domain key: ${JSON.stringify(name)}`, "domain", domain);
+        domainFields.push({ name, type });
+    }
+    domainFields.sort((a, b) => domainFieldNames.indexOf(a.name) - domainFieldNames.indexOf(b.name));
+    const { hashStruct } = buildTypedDataState({ EIP712Domain: domainFields });
+    return hashStruct("EIP712Domain", domain as Record<string, unknown>);
+}
+
+export function hashTypedData(
+    domain: TypedDataDomain,
+    types: Record<string, ReadonlyArray<TypedDataField>>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value: Record<string, any>,
+): Hex {
+    // Strip EIP712Domain from user types (ethers does this implicitly).
+    const userTypes: Record<string, ReadonlyArray<TypedDataField>> = {};
+    for (const [k, v] of Object.entries(types)) if (k !== "EIP712Domain") userTypes[k] = v;
+    const { primaryType, hashStruct } = buildTypedDataState(userTypes);
+    return keccak256(concat(["0x1901", hashDomain(domain), hashStruct(primaryType, value)]));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Signing (src.ts/crypto/{signing-key,signature}.ts + transaction/address.ts)
+//   Class-free: privateKeyToAddress + signHash + signTypedData functions only.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function computePublicKey(privateKey: BytesLike): Hex {
+    const bytes = getBytes(privateKey, "key");
+    assertCheck(bytes.length === 32, "invalid private key");
+    return hexlify(secp256k1.getPublicKey(bytes, false));
+}
+
+// Mirrors `Wallet` constructor (src.ts/wallet/wallet.ts:42-44): accept
+// unprefixed hex at the public signing API while keeping internal `getBytes`
+// strict.
+function normalizePrivateKey(key: string): string {
+    return key.startsWith("0x") ? key : "0x" + key;
+}
+
+export function privateKeyToAddress(privateKey: string): Hex {
+    const pub = computePublicKey(normalizePrivateKey(privateKey));
+    return getAddress(keccak256(("0x" + pub.substring(4)) as Hex).substring(26));
+}
+
+export function signHash(privateKey: string, hash: BytesLike): Signature {
+    assertCheck(dataLength(hash) === 32, "invalid digest length");
+    const sig = secp256k1.sign(getBytesCopy(hash), getBytesCopy(normalizePrivateKey(privateKey)), { lowS: true });
+    const r = toBeHex(sig.r, 32);
+    const s = toBeHex(sig.s, 32);
+    const yParity = (sig.recovery & 1) as 0 | 1;
+    const v = (27 + yParity) as 27 | 28;
+    return {
+        r,
+        s,
+        v,
+        yParity,
+        serialized: concat([r, s, new Uint8Array([v])]),
+    };
+}
+
+export function signTypedData(
+    privateKey: string,
+    domain: TypedDataDomain,
+    types: Record<string, ReadonlyArray<TypedDataField>>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    message: Record<string, any>,
+): Hex {
+    return signHash(privateKey, hashTypedData(domain, types, message)).serialized;
+}

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -758,7 +758,7 @@ export function encodeAbiParameters(
     return hexlify(encodeTuple(types.map(parseType), values as unknown[]));
 }
 
-export function decodeAbiParameters(types: ReadonlyArray<string>, data: BytesLike): unknown[] {
+export function decodeAbiParameters(types: ReadonlyArray<string>, data: BytesLike): any[] {
     return decodeTupleAt(types.map(parseType), getBytes(data), 0);
 }
 

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -758,8 +758,13 @@ export function encodeAbiParameters(
     return hexlify(encodeTuple(types.map(parseType), values as unknown[]));
 }
 
-export function decodeAbiParameters(types: ReadonlyArray<string>, data: BytesLike): any[] {
-    return decodeTupleAt(types.map(parseType), getBytes(data), 0);
+// Caller-asserted return shape: the generic T is not validated against `types`
+// at compile time or runtime. Mismatched (types, T) pairs will mistype values.
+export function decodeAbiParameters<T extends readonly unknown[] = unknown[]>(
+    types: ReadonlyArray<string>,
+    data: BytesLike,
+): T {
+    return decodeTupleAt(types.map(parseType), getBytes(data), 0) as unknown as T;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -98,10 +98,6 @@ export function isHexString(value: unknown, length?: number | boolean): value is
     return true;
 }
 
-function isBytesLike(value: unknown): value is BytesLike {
-    return isHexString(value, true) || value instanceof Uint8Array;
-}
-
 export function hexlify(data: BytesLike): Hex {
     const bytes = getBytes(data);
     let result = "0x";

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -1,4 +1,4 @@
-import {isAddress} from "ethers";
+import {isAddress} from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {ENTRYPOINT_V6, ENTRYPOINT_V7, ENTRYPOINT_V8} from "src/constants";
 import {AbstractionKitError, ensureError} from "src/errors";

--- a/src/paymaster/WorldIdPermissionlessPaymaster.ts
+++ b/src/paymaster/WorldIdPermissionlessPaymaster.ts
@@ -1,4 +1,4 @@
-import {AbiCoder, keccak256, solidityPacked} from "ethers";
+import {encodeAbiParameters, keccak256, solidityPacked} from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {ENTRYPOINT_V7, ENTRYPOINT_V8} from "src/constants";
 import type {Transport} from "src/transport";
@@ -91,11 +91,10 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 			`0x${proof.slice(448, 512)}`,
 		];
 
-		const abiCoder = AbiCoder.defaultAbiCoder();
 		const paymasterData =
-			abiCoder.encode(["uint256"], [root]) +
-			abiCoder.encode(["uint256"], [nullifierHash]).slice(2) +
-			abiCoder.encode(["uint256[8]"], [proofArr]).slice(2);
+			encodeAbiParameters(["uint256"], [root]) +
+			encodeAbiParameters(["uint256"], [nullifierHash]).slice(2) +
+			encodeAbiParameters(["uint256[8]"], [proofArr]).slice(2);
 
 		userOperation.paymaster = this.address;
 		userOperation.paymasterData = paymasterData;

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -1,4 +1,4 @@
-import { getAddress, Wallet } from "ethers";
+import { privateKeyToAddress, signHash, signTypedData } from "../ethereUtils";
 import type { Signer, TypedData } from "./types";
 
 // Structural types for well-known signers. NO imports from viem / ethers
@@ -90,12 +90,10 @@ export interface EthersWalletLike {
  * userOp.signature = await safe.signUserOperationWithSigners(userOp, [signer], chainId);
  */
 export function fromPrivateKey(privateKey: string): Signer<unknown> {
-	const wallet = new Wallet(privateKey);
 	return {
-		address: getAddress(wallet.address) as `0x${string}`,
-		signHash: async (hash) => wallet.signingKey.sign(hash).serialized as `0x${string}`,
-		signTypedData: async (td) =>
-			(await wallet.signTypedData(td.domain, td.types, td.message)) as `0x${string}`,
+		address: privateKeyToAddress(privateKey),
+		signHash: (hash) => signHash(privateKey, hash).serialized,
+		signTypedData: (td) => signTypedData(privateKey, td.domain, td.types, td.message),
 	};
 }
 

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -83,6 +83,10 @@ interface SignerBase {
  * Sign a 32-byte hash raw (no EIP-191 prefix). Required for Simple7702 /
  * Calibur; acceptable fallback for Safe.
  *
+ * Return type widens to `Hex | Promise<Hex>` so local-key signers (which
+ * do ECDSA over a precomputed digest with no I/O) can be sync, while
+ * remote signers (HSM, JSON-RPC wallet) stay async. `await` works on both.
+ *
  * Generic over the context type the SDK will pass. Defaults to
  * {@link SignContext} (single-op) — set explicitly to
  * {@link MultiOpSignContext} for multi-op signers, or to `unknown` for
@@ -91,18 +95,19 @@ interface SignerBase {
 export type SignHashFn<C = SignContext> = (
 	hash: `0x${string}`,
 	context: C,
-) => Promise<`0x${string}`>;
+) => `0x${string}` | Promise<`0x${string}`>;
 
 /**
  * Sign an EIP-712 typed data payload. Preferred for Safe because wallets
  * can display structured fields instead of a hex blob.
  *
- * Generic over context — see {@link SignHashFn}.
+ * Generic over context — see {@link SignHashFn}. Same sync/async dual
+ * return shape.
  */
 export type SignTypedDataFn<C = SignContext> = (
 	data: TypedData,
 	context: C,
-) => Promise<`0x${string}`>;
+) => `0x${string}` | Promise<`0x${string}`>;
 
 /**
  * A capability-oriented signer. Must declare at least one of `signHash` or

--- a/src/transport/JsonRpcNode.ts
+++ b/src/transport/JsonRpcNode.ts
@@ -376,7 +376,7 @@ export class JsonRpcNode implements Transport {
 			options,
 		);
 		try {
-			const decoded = decodeAbiParameters(
+			const decoded = decodeAbiParameters<[bigint, boolean, bigint, bigint, bigint]>(
 				["uint256", "bool", "uint112", "uint32", "uint48"],
 				callResult,
 			);

--- a/src/transport/JsonRpcNode.ts
+++ b/src/transport/JsonRpcNode.ts
@@ -1,4 +1,4 @@
-import {AbiCoder, getAddress} from "ethers";
+import {decodeAbiParameters, encodeAbiParameters, getAddress} from "../ethereUtils";
 import {
 	AbstractionKitError,
 	type BasicErrorCode,
@@ -322,8 +322,7 @@ export class JsonRpcNode implements Transport {
 	): Promise<bigint> {
 		// getNonce(address,uint192) selector
 		const getNonceSelector = "0x35567e1a";
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const params = abiCoder.encode(["address", "uint192"], [account, key]);
+		const params = encodeAbiParameters(["address", "uint192"], [account, key]);
 		const data = getNonceSelector + params.slice(2);
 
 		const callResult = await this.call(
@@ -367,8 +366,7 @@ export class JsonRpcNode implements Transport {
 	): Promise<DepositInfo> {
 		// getDepositInfo(address) selector
 		const getDepositInfoSelector = "0x5287ce12";
-		const abiCoder = AbiCoder.defaultAbiCoder();
-		const params = abiCoder.encode(["address"], [address]);
+		const params = encodeAbiParameters(["address"], [address]);
 		const data = getDepositInfoSelector + params.slice(2);
 
 		const callResult = await this.call(
@@ -378,7 +376,7 @@ export class JsonRpcNode implements Transport {
 			options,
 		);
 		try {
-			const decoded = abiCoder.decode(
+			const decoded = decodeAbiParameters(
 				["uint256", "bool", "uint112", "uint32", "uint48"],
 				callResult,
 			);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import {AbiCoder, id, keccak256, TypedDataEncoder} from "ethers";
+import {encodeAbiParameters, hashTypedData, id, keccak256} from "./ethereUtils";
 import {ENTRYPOINT_V6, ENTRYPOINT_V7, ENTRYPOINT_V8, ENTRYPOINT_V9} from "./constants";
 import {AbstractionKitError, ensureError} from "./errors";
 import type {TypedData} from "./signer/types";
@@ -29,8 +29,7 @@ function buildDomainSeparator(chainId: bigint, entrypoint: string): string {
 	// TYPE_HASH = keccak("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 	const type_hash = "0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f";
 
-	const abiCoder = AbiCoder.defaultAbiCoder();
-	const encodedUserOperationHash = abiCoder.encode(
+	const encodedUserOperationHash = encodeAbiParameters(
 		["(bytes32,bytes32,bytes32,uint256,address)"],
 		[[type_hash, hashed_name, hashed_version, chainId, entrypoint]],
 	);
@@ -53,13 +52,12 @@ export function createUserOperationHash(
 	chainId: bigint,
 ): string {
 	let packedUserOperationHash: string;
-	const abiCoder = AbiCoder.defaultAbiCoder();
 	let userOperationHash: string;
 	if (entrypointAddress.toLowerCase() === ENTRYPOINT_V6.toLowerCase()) {
 		packedUserOperationHash = keccak256(
 			createPackedUserOperationV6(useroperation as UserOperationV6),
 		);
-		const encodedUserOperationHash = abiCoder.encode(
+		const encodedUserOperationHash = encodeAbiParameters(
 			["bytes32", "address", "uint256"],
 			[packedUserOperationHash, entrypointAddress, chainId],
 		);
@@ -68,7 +66,7 @@ export function createUserOperationHash(
 		packedUserOperationHash = keccak256(
 			createPackedUserOperationV7(useroperation as UserOperationV7),
 		);
-		const encodedUserOperationHash = abiCoder.encode(
+		const encodedUserOperationHash = encodeAbiParameters(
 			["bytes32", "address", "uint256"],
 			[packedUserOperationHash, entrypointAddress, chainId],
 		);
@@ -129,11 +127,10 @@ export function buildPackedInitCodeV8V9(useroperation: UserOperationV8 | UserOpe
  * `PackedUserOperation.accountGasLimits` layout used by EntryPoint v0.7+.
  */
 function packAccountGasLimits(verificationGasLimit: bigint, callGasLimit: bigint): string {
-	const abiCoder = AbiCoder.defaultAbiCoder();
 	return (
 		"0x" +
-		abiCoder.encode(["uint128"], [verificationGasLimit]).slice(34) +
-		abiCoder.encode(["uint128"], [callGasLimit]).slice(34)
+		encodeAbiParameters(["uint128"], [verificationGasLimit]).slice(34) +
+		encodeAbiParameters(["uint128"], [callGasLimit]).slice(34)
 	);
 }
 
@@ -144,11 +141,10 @@ function packAccountGasLimits(verificationGasLimit: bigint, callGasLimit: bigint
  * `PackedUserOperation.gasFees` layout used by EntryPoint v0.7+.
  */
 function packGasFees(maxPriorityFeePerGas: bigint, maxFeePerGas: bigint): string {
-	const abiCoder = AbiCoder.defaultAbiCoder();
 	return (
 		"0x" +
-		abiCoder.encode(["uint128"], [maxPriorityFeePerGas]).slice(34) +
-		abiCoder.encode(["uint128"], [maxFeePerGas]).slice(34)
+		encodeAbiParameters(["uint128"], [maxPriorityFeePerGas]).slice(34) +
+		encodeAbiParameters(["uint128"], [maxFeePerGas]).slice(34)
 	);
 }
 
@@ -175,17 +171,18 @@ export function buildPaymasterAndData(
 	stripV9PaymasterSig: boolean = false,
 ): string {
 	if (useroperation.paymaster == null) return "0x";
-	const abiCoder = AbiCoder.defaultAbiCoder();
 	let paymasterAndData = useroperation.paymaster;
 	if (useroperation.paymasterVerificationGasLimit != null) {
-		paymasterAndData += abiCoder
-			.encode(["uint128"], [useroperation.paymasterVerificationGasLimit])
-			.slice(34);
+		paymasterAndData += encodeAbiParameters(
+			["uint128"],
+			[useroperation.paymasterVerificationGasLimit],
+		).slice(34);
 	}
 	if (useroperation.paymasterPostOpGasLimit != null) {
-		paymasterAndData += abiCoder
-			.encode(["uint128"], [useroperation.paymasterPostOpGasLimit])
-			.slice(34);
+		paymasterAndData += encodeAbiParameters(
+			["uint128"],
+			[useroperation.paymasterPostOpGasLimit],
+		).slice(34);
 	}
 	if (useroperation.paymasterData != null) {
 		const PAYMASTER_SIG_MAGIC = "22e325a297439656";
@@ -300,7 +297,7 @@ export function getUserOperationEip712HashV8V9(
 	chainId: bigint,
 ): string {
 	const data = getUserOperationEip712DataV8V9(userOperation, entrypointAddress, chainId);
-	return TypedDataEncoder.hash(data.domain, data.types, data.message);
+	return hashTypedData(data.domain, data.types, data.message);
 }
 
 /**
@@ -324,8 +321,7 @@ export function createPackedUserOperationV6(useroperation: UserOperationV6): str
 		keccak256(useroperation.paymasterAndData),
 	];
 
-	const abiCoder = AbiCoder.defaultAbiCoder();
-	const packedUserOperation = abiCoder.encode(
+	const packedUserOperation = encodeAbiParameters(
 		[
 			"address",
 			"uint256",
@@ -351,8 +347,6 @@ export function createPackedUserOperationV6(useroperation: UserOperationV6): str
  * @returns ABI-encoded packed UserOperation as a hex string
  */
 export function createPackedUserOperationV7(useroperation: UserOperationV7): string {
-	const abiCoder = AbiCoder.defaultAbiCoder();
-
 	let initCode = "0x";
 	if (useroperation.factory != null) {
 		initCode = useroperation.factory;
@@ -379,7 +373,7 @@ export function createPackedUserOperationV7(useroperation: UserOperationV7): str
 		keccak256(paymasterAndData),
 	];
 
-	const packedUserOperation = abiCoder.encode(
+	const packedUserOperation = encodeAbiParameters(
 		["address", "uint256", "bytes32", "bytes32", "bytes32", "uint256", "bytes32", "bytes32"],
 		useroperationValuesArrayWithHashedByteValues,
 	);
@@ -416,8 +410,6 @@ function baseCreatePackedUserOperationV8V9(
 	useroperation: UserOperationV8 | UserOperationV9,
 	is_v9: boolean,
 ): string {
-	const abiCoder = AbiCoder.defaultAbiCoder();
-
 	const initCode = buildPackedInitCodeV8V9(useroperation);
 	const accountGasLimits = packAccountGasLimits(
 		useroperation.verificationGasLimit,
@@ -439,7 +431,7 @@ function baseCreatePackedUserOperationV8V9(
 		keccak256(paymasterAndData),
 	];
 
-	const packedUserOperation = abiCoder.encode(
+	const packedUserOperation = encodeAbiParameters(
 		[
 			"bytes32",
 			"address",
@@ -476,8 +468,7 @@ export function createCallData(
 	functionInputAbi: string[],
 	functionInputParameters: AbiInputValue[],
 ): string {
-	const abiCoder = AbiCoder.defaultAbiCoder();
-	const params: string = abiCoder.encode(functionInputAbi, functionInputParameters);
+	const params: string = encodeAbiParameters(functionInputAbi, functionInputParameters);
 	const callData = functionSelector + params.slice(2);
 
 	return callData;

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -1,7 +1,13 @@
 //https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md
 //rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, value, data, access_list, authorization_list, yParity, r, s])
 //authorization_list = [[chain_id, address, nonce, yParity, r, s], ...]
-import { encodeRlp, getBytes, keccak256, toBeArray, Wallet } from "ethers";
+import {
+	encodeRlp,
+	getBytes,
+	keccak256,
+	signHash as ecdsaSignHash,
+	toBeArray,
+} from "./ethereUtils";
 
 const SET_CODE_TX_TYPE = "0x04";
 
@@ -91,8 +97,7 @@ export function createAndSignLegacyRawTransaction(
 
 	const txHash = keccak256(encodeRlp(payload));
 
-	const eoa = new Wallet(eoaPrivateKey);
-	const signature = eoa.signingKey.sign(txHash);
+	const signature = ecdsaSignHash(eoaPrivateKey, txHash);
 
 	payload = [
 		bigintToBytes(nonce),
@@ -227,8 +232,7 @@ export function signHash(
 	authHash: string,
 	eoaPrivateKey: string,
 ): { yParity: 0 | 1; r: bigint; s: bigint } {
-	const eoa = new Wallet(eoaPrivateKey);
-	const signature = eoa.signingKey.sign(authHash);
+	const signature = ecdsaSignHash(eoaPrivateKey, authHash);
 	return {
 		yParity: signature.yParity,
 		r: BigInt(signature.r),

--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -1,4 +1,4 @@
-import {AbiCoder} from "ethers";
+import {encodeAbiParameters} from "./ethereUtils";
 import {AbstractionKitError, ensureError} from "./errors";
 import type {
 	SingleTransactionTenderlySimulationResult,
@@ -142,7 +142,6 @@ export async function simulateUserOperationWithTenderly(
 ): Promise<SingleTransactionTenderlySimulationResult> {
 	const entrypointAddressLowerCase = entrypointAddress.toLowerCase();
 	let callData: string | null = null;
-	const abiCoder = AbiCoder.defaultAbiCoder();
 	const isV6UserOperation = "initCode" in userOperation;
 	const isV6Entrypoint =
 		entrypointAddressLowerCase === "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789";
@@ -167,7 +166,7 @@ export async function simulateUserOperationWithTenderly(
 			userOperation.signature,
 		];
 
-		const encodedUserOperation = abiCoder.encode(
+		const encodedUserOperation = encodeAbiParameters(
 			[
 				"(address,uint256,bytes,bytes,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[]",
 				"address",
@@ -187,26 +186,28 @@ export async function simulateUserOperationWithTenderly(
 
 		const accountGasLimits =
 			"0x" +
-			abiCoder.encode(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
-			abiCoder.encode(["uint128"], [userOperation.callGasLimit]).slice(34);
+			encodeAbiParameters(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
+			encodeAbiParameters(["uint128"], [userOperation.callGasLimit]).slice(34);
 
 		const gasFees =
 			"0x" +
-			abiCoder.encode(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
-			abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
+			encodeAbiParameters(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
+			encodeAbiParameters(["uint128"], [userOperation.maxFeePerGas]).slice(34);
 
 		let paymasterAndData = "0x";
 		if (userOperation.paymaster != null) {
 			paymasterAndData = userOperation.paymaster;
 			if (userOperation.paymasterVerificationGasLimit != null) {
-				paymasterAndData += abiCoder
-					.encode(["uint128"], [userOperation.paymasterVerificationGasLimit])
-					.slice(34);
+				paymasterAndData += encodeAbiParameters(
+					["uint128"],
+					[userOperation.paymasterVerificationGasLimit],
+				).slice(34);
 			}
 			if (userOperation.paymasterPostOpGasLimit != null) {
-				paymasterAndData += abiCoder
-					.encode(["uint128"], [userOperation.paymasterPostOpGasLimit])
-					.slice(34);
+				paymasterAndData += encodeAbiParameters(
+					["uint128"],
+					[userOperation.paymasterPostOpGasLimit],
+				).slice(34);
 			}
 			if (userOperation.paymasterData != null) {
 				paymasterAndData += userOperation.paymasterData.slice(2);
@@ -225,7 +226,7 @@ export async function simulateUserOperationWithTenderly(
 			userOperation.signature,
 		];
 
-		const encodedUserOperation = abiCoder.encode(
+		const encodedUserOperation = encodeAbiParameters(
 			["(address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes)[]", "address"],
 			[[useroperationValuesArray], "0x1000000000000000000000000000000000000000"],
 		);
@@ -498,8 +499,6 @@ export async function simulateUserOperationCallDataWithTenderly(
 		// sender.call(callData). Replicate here.
 		const EXECUTE_USEROP_SELECTOR = "0x8dd7712f";
 		if (callData.toLowerCase().startsWith(EXECUTE_USEROP_SELECTOR)) {
-			const abiCoder = AbiCoder.defaultAbiCoder();
-
 			let initCode = "0x";
 			if (userOperation.factory != null) {
 				initCode = userOperation.factory;
@@ -510,26 +509,28 @@ export async function simulateUserOperationCallDataWithTenderly(
 
 			const accountGasLimits =
 				"0x" +
-				abiCoder.encode(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
-				abiCoder.encode(["uint128"], [userOperation.callGasLimit]).slice(34);
+				encodeAbiParameters(["uint128"], [userOperation.verificationGasLimit]).slice(34) +
+				encodeAbiParameters(["uint128"], [userOperation.callGasLimit]).slice(34);
 
 			const gasFees =
 				"0x" +
-				abiCoder.encode(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
-				abiCoder.encode(["uint128"], [userOperation.maxFeePerGas]).slice(34);
+				encodeAbiParameters(["uint128"], [userOperation.maxPriorityFeePerGas]).slice(34) +
+				encodeAbiParameters(["uint128"], [userOperation.maxFeePerGas]).slice(34);
 
 			let paymasterAndData = "0x";
 			if (userOperation.paymaster != null) {
 				paymasterAndData = userOperation.paymaster;
 				if (userOperation.paymasterVerificationGasLimit != null) {
-					paymasterAndData += abiCoder
-						.encode(["uint128"], [userOperation.paymasterVerificationGasLimit])
-						.slice(34);
+					paymasterAndData += encodeAbiParameters(
+						["uint128"],
+						[userOperation.paymasterVerificationGasLimit],
+					).slice(34);
 				}
 				if (userOperation.paymasterPostOpGasLimit != null) {
-					paymasterAndData += abiCoder
-						.encode(["uint128"], [userOperation.paymasterPostOpGasLimit])
-						.slice(34);
+					paymasterAndData += encodeAbiParameters(
+						["uint128"],
+						[userOperation.paymasterPostOpGasLimit],
+					).slice(34);
 				}
 				if (userOperation.paymasterData != null) {
 					paymasterAndData += userOperation.paymasterData.slice(2);
@@ -554,7 +555,7 @@ export async function simulateUserOperationCallDataWithTenderly(
 				userOperation.signature,
 			];
 
-			const encodedParams = abiCoder.encode(
+			const encodedParams = encodeAbiParameters(
 				["(address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes)", "bytes32"],
 				[packedUserOp, userOpHash],
 			);

--- a/test/_loadEthereUtils.cjs
+++ b/test/_loadEthereUtils.cjs
@@ -1,0 +1,29 @@
+// Loads src/ethereUtils.ts directly so tests always run against the current
+// source rather than a possibly-stale build artifact. We use TypeScript's
+// `transpileModule` to strip types (no type-checking) and compile the result
+// inline as a CommonJS module — fast (~50ms) and zero-config.
+
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+const ts = require('typescript');
+
+const srcPath = path.resolve(__dirname, '../src/ethereUtils.ts');
+const source = fs.readFileSync(srcPath, 'utf8');
+
+const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+        esModuleInterop: true,
+        removeComments: true,
+    },
+    fileName: srcPath,
+});
+
+const m = new Module(srcPath);
+m.filename = srcPath;
+m.paths = Module._nodeModulePaths(path.dirname(srcPath));
+m._compile(outputText, srcPath);
+
+module.exports = m.exports;

--- a/test/ethereUtils.test.js
+++ b/test/ethereUtils.test.js
@@ -1,0 +1,1261 @@
+// Comprehensive parity tests for every exported function in src/ethereUtils.ts.
+//
+// Strategy:
+//   1. Deterministic spec vectors / known fixtures (EIP-55 addresses, EIP-712
+//      Mail example, EIP-7702 authorization tuple, …).
+//   2. Property tests: a seeded PRNG (mulberry32) generates ~100 random inputs
+//      per function. We then assert byte-identical output between our impl,
+//      ethers v6 and viem v2. A fixed seed (env var SEED to override) makes
+//      every failure reproducible.
+//
+// We import ethereUtils directly from `dist/ethereUtils.cjs`: the top-level
+// abstractionkit bundle does not re-export the namespace, and the standalone
+// CJS file is the only consumer-facing artifact for these helpers.
+//
+// Run: yarn build && yarn jest --runTestsByPath test/ethereUtils.test.js
+
+const u = require('./_loadEthereUtils.cjs');
+const ethers = require('ethers');
+const viem = require('viem');
+const viemAccounts = require('viem/accounts');
+
+// ---------------------------------------------------------------------------
+// Deterministic PRNG (mulberry32) + helpers
+// ---------------------------------------------------------------------------
+
+const SEED = Number(process.env.SEED || 0xCAFEBEEF);
+let _state = SEED >>> 0;
+function rng() {
+    // mulberry32 — small, fast, good enough for property tests.
+    _state = (_state + 0x6D2B79F5) >>> 0;
+    let t = _state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng(seed = SEED) { _state = seed >>> 0; }
+
+function randInt(maxExclusive) {
+    return Math.floor(rng() * maxExclusive);
+}
+function randIntRange(min, maxInclusive) {
+    return min + Math.floor(rng() * (maxInclusive - min + 1));
+}
+function pick(arr) {
+    return arr[randInt(arr.length)];
+}
+function randomBytes(length) {
+    const out = new Uint8Array(length);
+    for (let i = 0; i < length; i++) out[i] = randInt(256);
+    return out;
+}
+function randomHex(byteLength) {
+    return ('0x' +
+        Array.from(randomBytes(byteLength))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join(''));
+}
+function randomBigUint(bits) {
+    // Uniformly random bigint in [0, 2^bits).
+    let v = 0n;
+    const fullBytes = Math.floor(bits / 8);
+    const trailingBits = bits % 8;
+    for (let i = 0; i < fullBytes; i++) {
+        v = (v << 8n) | BigInt(randInt(256));
+    }
+    if (trailingBits) {
+        const mask = (1 << trailingBits) - 1;
+        v = (v << BigInt(trailingBits)) | BigInt(randInt(256) & mask);
+    }
+    return v;
+}
+function randomSignedBigInt(bits) {
+    // Uniformly random signed bigint in [-2^(bits-1), 2^(bits-1)).
+    const unsigned = randomBigUint(bits);
+    const limit = 1n << BigInt(bits - 1);
+    return unsigned < limit ? unsigned : unsigned - (1n << BigInt(bits));
+}
+function randomAddress() {
+    // Returns the EIP-55 checksummed address (deterministic via seed).
+    const bytes = randomBytes(20);
+    const lower = '0x' + Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+    return u.getAddress(lower);
+}
+function randomPrivateKey() {
+    // Any 32 random bytes is overwhelmingly likely to be in [1, n-1] for
+    // secp256k1 — n is within 2^-128 of 2^256 — so we just pick 32 random
+    // bytes and ensure non-zero high word.
+    while (true) {
+        const bytes = randomBytes(32);
+        if (bytes.some((b) => b !== 0)) {
+            return '0x' + Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+        }
+    }
+}
+function randomUtf8String(maxLen = 64) {
+    const len = randInt(maxLen + 1);
+    let s = '';
+    for (let i = 0; i < len; i++) {
+        // Mix of ASCII, Latin-1, BMP, and surrogate-pair (astral) code points.
+        const bucket = randInt(10);
+        if (bucket < 5) s += String.fromCharCode(0x20 + randInt(0x60));         // printable ASCII
+        else if (bucket < 7) s += String.fromCharCode(0x80 + randInt(0x300));   // Latin / accented
+        else if (bucket < 9) s += String.fromCharCode(0x1000 + randInt(0x7000)); // BMP
+        else {
+            const cp = 0x10000 + randInt(0x100000);
+            s += String.fromCodePoint(cp);
+        }
+    }
+    return s;
+}
+
+const ITER = 100;
+const SIGN_ITER = 30; // signing/recover tests do real EC math — keep lower.
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const PK = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318';
+const PK_NO_PREFIX = PK.slice(2);
+const ADDR_LOWER = '0xb6e1ae1f3b1c8c0e7e9c7e7c2fcd5e7d3b6c5a4d';
+const ADDR_CHECKSUMMED = ethers.getAddress(ADDR_LOWER);
+const DIGEST_32 = '0x' + 'ab'.repeat(32);
+
+function bigintReplacer(_k, v) {
+    return typeof v === 'bigint' ? `0x${v.toString(16)}` : v;
+}
+
+// ===========================================================================
+//                              keccak256
+// ===========================================================================
+
+describe('keccak256', () => {
+    test.each([
+        ['empty', '0x'],
+        ['single byte', '0x00'],
+        ['short', '0x1234'],
+        ['32 bytes', '0x' + '01'.repeat(32)],
+        ['64 bytes', '0x' + 'cd'.repeat(64)],
+        ['136 bytes (Keccak rate boundary)', '0x' + 'ef'.repeat(136)],
+        ['137 bytes (crosses rate boundary)', '0x' + 'ef'.repeat(137)],
+    ])('matches ethers + viem on %s', (_label, input) => {
+        const ours = u.keccak256(input);
+        expect(ours).toBe(ethers.keccak256(input));
+        expect(ours).toBe(viem.keccak256(input));
+    });
+
+    test('throws on invalid bytes-like input', () => {
+        expect(() => u.keccak256('not-hex')).toThrow(/invalid BytesLike value/);
+    });
+
+    test(`property: ${ITER} random hex inputs match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const len = randInt(513); // 0..512 bytes — spans Keccak rate boundaries
+            const hex = randomHex(len);
+            const ours = u.keccak256(hex);
+            expect(ours).toBe(ethers.keccak256(hex));
+            expect(ours).toBe(viem.keccak256(hex));
+        }
+    });
+
+    test(`property: ${ITER} random Uint8Array inputs match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const bytes = randomBytes(randInt(513));
+            const ours = u.keccak256(bytes);
+            expect(ours).toBe(ethers.keccak256(bytes));
+            expect(ours).toBe(viem.keccak256(bytes));
+        }
+    });
+});
+
+// ===========================================================================
+//                              id (keccak256(utf8))
+// ===========================================================================
+
+describe('id', () => {
+    test.each([
+        '',
+        'transfer(address,uint256)',
+        'Hello, world!',
+        'Üñîçødé 🐉 string with multi-byte chars',
+    ])('matches ethers.id and viem keccak256(toBytes) on %j', (text) => {
+        const ours = u.id(text);
+        expect(ours).toBe(ethers.id(text));
+        expect(ours).toBe(viem.keccak256(viem.stringToBytes(text)));
+    });
+
+    test('ERC-20 selector sanity check', () => {
+        expect(u.id('transfer(address,uint256)').slice(0, 10)).toBe('0xa9059cbb');
+    });
+
+    test(`property: ${ITER} random UTF-8 strings match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const s = randomUtf8String(128);
+            const ours = u.id(s);
+            expect(ours).toBe(ethers.id(s));
+            expect(ours).toBe(viem.keccak256(viem.stringToBytes(s)));
+        }
+    });
+});
+
+// ===========================================================================
+//                              hashMessage (EIP-191)
+// ===========================================================================
+
+describe('hashMessage', () => {
+    test.each([
+        '',
+        'hello',
+        'a longer message that spans more than a single keccak block boundary, hopefully',
+        '1234567890'.repeat(100),
+    ])('string input matches ethers + viem on %j', (msg) => {
+        const ours = u.hashMessage(msg);
+        expect(ours).toBe(ethers.hashMessage(msg));
+        expect(ours).toBe(viem.hashMessage(msg));
+    });
+
+    test('Uint8Array input matches ethers + viem raw-bytes mode', () => {
+        const bytes = new TextEncoder().encode('hello');
+        const ours = u.hashMessage(bytes);
+        expect(ours).toBe(ethers.hashMessage(bytes));
+        expect(ours).toBe(viem.hashMessage({ raw: viem.toHex(bytes) }));
+    });
+
+    test(`property: ${ITER} random strings match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const s = randomUtf8String(256);
+            const ours = u.hashMessage(s);
+            expect(ours).toBe(ethers.hashMessage(s));
+            expect(ours).toBe(viem.hashMessage(s));
+        }
+    });
+
+    test(`property: ${ITER} random Uint8Array inputs match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const bytes = randomBytes(randInt(257));
+            const ours = u.hashMessage(bytes);
+            expect(ours).toBe(ethers.hashMessage(bytes));
+            expect(ours).toBe(viem.hashMessage({ raw: viem.toHex(bytes) }));
+        }
+    });
+});
+
+// ===========================================================================
+//                              getBytes
+// ===========================================================================
+
+describe('getBytes', () => {
+    test.each(['0x', '0x00', '0x1234', '0xABCDEF', '0xaBcDeF', '0x' + 'ab'.repeat(32)])(
+        'matches ethers.getBytes on %s',
+        (hex) => {
+            expect(Array.from(u.getBytes(hex))).toEqual(Array.from(ethers.getBytes(hex)));
+        },
+    );
+
+    test('returns same Uint8Array reference (ethers v6 semantics)', () => {
+        const src = Uint8Array.from([1, 2, 3]);
+        expect(u.getBytes(src)).toBe(src);
+    });
+
+    test.each(['0xzz', '0x1', 'deadbeef', '', '0x12g4'])(
+        'rejects malformed %j with `invalid BytesLike value`',
+        (bad) => {
+            expect(() => u.getBytes(bad)).toThrow(/invalid BytesLike value/);
+        },
+    );
+
+    test('includes name in error message', () => {
+        expect(() => u.getBytes('bad', 'myField')).toThrow(/myField/);
+    });
+
+    test(`property: ${ITER} random hex strings parse identically to ethers`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const hex = randomHex(randInt(129));
+            expect(Array.from(u.getBytes(hex))).toEqual(Array.from(ethers.getBytes(hex)));
+        }
+    });
+});
+
+// ===========================================================================
+//                              isHexString
+// ===========================================================================
+
+describe('isHexString', () => {
+    test.each([
+        ['0x', true],
+        ['0xdeadbeef', true],
+        ['0xABCDEF', true],
+        ['0x1', true],
+        ['deadbeef', false],
+        ['0xzz', false],
+        [123, false],
+        [null, false],
+        [undefined, false],
+    ])('isHexString(%j) === %j', (v, expected) => {
+        expect(u.isHexString(v)).toBe(expected);
+    });
+
+    test('length parameter constrains byte length', () => {
+        expect(u.isHexString('0xdeadbeef', 4)).toBe(true);
+        expect(u.isHexString('0xdeadbeef', 5)).toBe(false);
+    });
+
+    test('length=true requires even nibble count', () => {
+        expect(u.isHexString('0xdeadbeef', true)).toBe(true);
+        expect(u.isHexString('0xdea', true)).toBe(false);
+    });
+
+    test(`property: ${ITER} random valid hex strings return true`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            expect(u.isHexString(randomHex(randInt(65)))).toBe(true);
+        }
+    });
+
+    test(`property: ${ITER} random matches ethers.isHexString`, () => {
+        resetRng();
+        const garbage = ['0x', '0xZZ', 'no-prefix', '0x123', 'random', '0xabcde'];
+        for (let i = 0; i < ITER; i++) {
+            const v = i % 2 === 0 ? randomHex(randInt(65)) : pick(garbage);
+            expect(u.isHexString(v)).toBe(ethers.isHexString(v));
+        }
+    });
+});
+
+// ===========================================================================
+//                              hexlify
+// ===========================================================================
+
+describe('hexlify', () => {
+    test.each([
+        ['empty', new Uint8Array()],
+        ['single byte', Uint8Array.from([0])],
+        ['short', Uint8Array.from([0xde, 0xad, 0xbe, 0xef])],
+        ['32 bytes', Uint8Array.from({ length: 32 }, (_, i) => i)],
+    ])('matches ethers + viem on %s', (_label, bytes) => {
+        const ours = u.hexlify(bytes);
+        expect(ours).toBe(ethers.hexlify(bytes));
+        expect(ours).toBe(viem.toHex(bytes));
+    });
+
+    test('round-trips hex strings unchanged (lowercase)', () => {
+        expect(u.hexlify('0xABCDEF')).toBe('0xabcdef');
+    });
+
+    test(`property: ${ITER} random Uint8Arrays match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const bytes = randomBytes(randInt(129));
+            const ours = u.hexlify(bytes);
+            expect(ours).toBe(ethers.hexlify(bytes));
+            expect(ours).toBe(viem.toHex(bytes));
+        }
+    });
+});
+
+// ===========================================================================
+//                              concat
+// ===========================================================================
+
+describe('concat', () => {
+    test('empty array returns "0x"', () => {
+        expect(u.concat([])).toBe('0x');
+    });
+
+    test(`property: ${ITER} random mixed-input arrays match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const n = randInt(7); // 0..6 chunks
+            const items = [];
+            for (let j = 0; j < n; j++) {
+                if (rng() < 0.5) items.push(randomHex(randInt(32)));
+                else items.push(randomBytes(randInt(32)));
+            }
+            const ours = u.concat(items);
+            expect(ours).toBe(ethers.concat(items));
+            if (items.length > 0) {
+                const hexItems = items.map((it) =>
+                    it instanceof Uint8Array ? viem.bytesToHex(it) : it,
+                );
+                expect(ours).toBe(viem.concat(hexItems));
+            }
+        }
+    });
+});
+
+// ===========================================================================
+//                              dataLength
+// ===========================================================================
+
+describe('dataLength', () => {
+    test.each([
+        ['0x', 0],
+        ['0x12', 1],
+        ['0xdeadbeef', 4],
+        ['0x' + 'ab'.repeat(32), 32],
+    ])('matches ethers + viem on %s (expect %i)', (hex, expected) => {
+        expect(u.dataLength(hex)).toBe(expected);
+        expect(u.dataLength(hex)).toBe(ethers.dataLength(hex));
+        expect(u.dataLength(hex)).toBe(viem.size(hex));
+    });
+
+    test(`property: ${ITER} random hex strings match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const byteLen = randInt(257);
+            const hex = randomHex(byteLen);
+            expect(u.dataLength(hex)).toBe(byteLen);
+            expect(u.dataLength(hex)).toBe(ethers.dataLength(hex));
+            expect(u.dataLength(hex)).toBe(viem.size(hex));
+        }
+    });
+
+    test(`property: ${ITER} random Uint8Arrays match ethers`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const bytes = randomBytes(randInt(257));
+            expect(u.dataLength(bytes)).toBe(bytes.length);
+            expect(u.dataLength(bytes)).toBe(ethers.dataLength(bytes));
+        }
+    });
+});
+
+// ===========================================================================
+//                              toBeArray
+// ===========================================================================
+
+describe('toBeArray', () => {
+    test.each([0n, 1n, 255n, 256n, 0xfffn, 0x1234567890abcdefn, (1n << 200n) + 7n, (1n << 256n) - 1n])(
+        'matches ethers.toBeArray on %s',
+        (v) => {
+            expect(Array.from(u.toBeArray(v))).toEqual(Array.from(ethers.toBeArray(v)));
+        },
+    );
+
+    test('accepts number and string inputs', () => {
+        expect(Array.from(u.toBeArray(256))).toEqual(Array.from(ethers.toBeArray(256)));
+        expect(Array.from(u.toBeArray('0x100'))).toEqual(Array.from(ethers.toBeArray('0x100')));
+        expect(Array.from(u.toBeArray('1024'))).toEqual(Array.from(ethers.toBeArray('1024')));
+    });
+
+    test('rejects negative values', () => {
+        expect(() => u.toBeArray(-1n)).toThrow();
+    });
+
+    test('rejects non-integer numbers', () => {
+        expect(() => u.toBeArray(1.5)).toThrow();
+    });
+
+    test(`property: ${ITER} random bigints across all widths match ethers`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const bits = randIntRange(1, 256);
+            const v = randomBigUint(bits);
+            expect(Array.from(u.toBeArray(v))).toEqual(Array.from(ethers.toBeArray(v)));
+        }
+    });
+});
+
+// ===========================================================================
+//                              getAddress (EIP-55)
+// ===========================================================================
+
+describe('getAddress', () => {
+    test.each([
+        '0x52908400098527886E0F7030069857D2E4169EE7',
+        '0x8617E340B3D01FA5F11F306F4090FD50E238070D',
+        '0xde709f2102306220921060314715629080e2fb77',
+        '0x27b1fdb04752bbc536007a920d24acb045561c26',
+        '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+        '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+        '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB',
+        '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+    ])('EIP-55 spec vector %s — all casings agree', (vec) => {
+        const lower = vec.toLowerCase();
+        const upper = '0x' + vec.slice(2).toUpperCase();
+        for (const variant of [lower, upper, vec]) {
+            const ours = u.getAddress(variant);
+            expect(ours).toBe(ethers.getAddress(variant));
+            expect(ours).toBe(viem.getAddress(variant));
+        }
+    });
+
+    test('accepts address without 0x prefix', () => {
+        const naked = ADDR_LOWER.slice(2);
+        expect(u.getAddress(naked)).toBe(ADDR_CHECKSUMMED);
+        expect(u.getAddress(naked)).toBe(ethers.getAddress(naked));
+    });
+
+    test('rejects malformed input', () => {
+        expect(() => u.getAddress('0x123')).toThrow();
+        expect(() => u.getAddress('not hex')).toThrow();
+        expect(() => u.getAddress('0x' + 'z'.repeat(40))).toThrow();
+        expect(() => u.getAddress(123)).toThrow();
+        expect(() => u.getAddress(null)).toThrow();
+    });
+
+    test(`property: ${ITER} random addresses checksum identically across libs`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const lower = '0x' + Array.from(randomBytes(20))
+                .map((b) => b.toString(16).padStart(2, '0')).join('');
+            const upper = '0x' + lower.slice(2).toUpperCase();
+            const checksum = u.getAddress(lower);
+            expect(checksum).toBe(ethers.getAddress(lower));
+            expect(checksum).toBe(viem.getAddress(lower));
+            // Round-trip from uppercase / checksummed / naked.
+            expect(u.getAddress(upper)).toBe(checksum);
+            expect(u.getAddress(checksum)).toBe(checksum);
+            expect(u.getAddress(lower.slice(2))).toBe(checksum);
+        }
+    });
+
+    test(`property: ${ITER} mutated checksums are rejected`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const lower = '0x' + Array.from(randomBytes(20))
+                .map((b) => b.toString(16).padStart(2, '0')).join('');
+            const checksum = u.getAddress(lower);
+            // Find a hex letter to flip case; numeric chars have no case to break.
+            let pos = -1;
+            for (let j = 2; j < checksum.length; j++) {
+                if (/[A-Fa-f]/.test(checksum[j])) { pos = j; break; }
+            }
+            if (pos < 0) continue;
+            const flipped = checksum[pos] === checksum[pos].toUpperCase()
+                ? checksum[pos].toLowerCase()
+                : checksum[pos].toUpperCase();
+            const broken = checksum.slice(0, pos) + flipped + checksum.slice(pos + 1);
+            // ethers + ours reject a mixed-case-with-bad-checksum input.
+            // viem deliberately diverges: viem.getAddress just re-normalizes
+            // (its `isAddress(..., { strict: false })` check ignores the
+            // case), so a broken-checksum string round-trips silently
+            // — we don't assert anything against viem here.
+            expect(() => u.getAddress(broken)).toThrow(/checksum/);
+            expect(() => ethers.getAddress(broken)).toThrow();
+        }
+    });
+});
+
+// ===========================================================================
+//                              isAddress
+// ===========================================================================
+
+describe('isAddress', () => {
+    test.each([
+        [ADDR_CHECKSUMMED, true],
+        [ADDR_LOWER, true],
+        ['0x' + ADDR_LOWER.slice(2).toUpperCase(), true],
+        ['0x123', false],
+        ['not an address', false],
+        ['', false],
+        [null, false],
+        [undefined, false],
+        [12345, false],
+    ])('matches ethers on %j', (input, expected) => {
+        expect(u.isAddress(input)).toBe(expected);
+        expect(u.isAddress(input)).toBe(ethers.isAddress(input));
+    });
+
+    test(`property: ${ITER} random checksummed addresses → true (ethers+viem)`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const a = randomAddress();
+            expect(u.isAddress(a)).toBe(true);
+            expect(ethers.isAddress(a)).toBe(true);
+            expect(viem.isAddress(a)).toBe(true);
+        }
+    });
+
+    test(`property: ${ITER} random non-addresses → false (ethers parity)`, () => {
+        resetRng();
+        const generators = [
+            () => randomHex(randInt(20)),                  // too short
+            () => randomHex(randIntRange(21, 64)),         // too long
+            () => 'not-an-address-' + randInt(1e6),        // junk
+            () => '0xZZZ' + randomHex(20).slice(2),        // bad nibbles
+            () => randInt(1e6),                            // non-string
+        ];
+        for (let i = 0; i < ITER; i++) {
+            const v = generators[i % generators.length]();
+            expect(u.isAddress(v)).toBe(ethers.isAddress(v));
+        }
+    });
+});
+
+// ===========================================================================
+//                              encodeAbiParameters / decodeAbiParameters
+// ===========================================================================
+
+describe('encodeAbiParameters / decodeAbiParameters', () => {
+    // Fixed spec/edge fixtures (preserved for regression value).
+    const cases = [
+        ['address + uint256', ['address', 'uint256'], [ADDR_CHECKSUMMED, 1234567890n]],
+        ['bool + bytes32', ['bool', 'bytes32'], [true, '0x' + '11'.repeat(32)]],
+        ['bytes (dynamic)', ['bytes'], ['0xdeadbeefcafe']],
+        ['empty bytes', ['bytes'], ['0x']],
+        ['string', ['string'], ['hello, ABI world!']],
+        ['empty string', ['string'], ['']],
+        ['unicode string', ['string'], ['日本語 🦀']],
+        ['address[] dynamic', ['address[]'], [[ADDR_CHECKSUMMED, ADDR_LOWER]]],
+        ['empty address[]', ['address[]'], [[]]],
+        ['uint256[5] fixed', ['uint256[5]'], [[1n, 2n, 3n, 4n, 5n]]],
+        ['bytes32[]', ['bytes32[]'], [['0x' + 'aa'.repeat(32), '0x' + 'bb'.repeat(32)]]],
+        ['tuple', ['(uint8,bytes)'], [[7, '0xabcd']]],
+        ['nested tuple', ['(bytes32,bytes32,bytes32,uint256,address)'],
+            [['0x' + 'aa'.repeat(32), '0x' + 'bb'.repeat(32), '0x' + 'cc'.repeat(32), 99n, ADDR_CHECKSUMMED]],
+        ],
+        ['multiple uint widths',
+            ['uint8', 'uint48', 'uint64', 'uint128', 'uint192', 'uint256'],
+            [255n, 0x010203040506n, 0x1122334455667788n, 1n << 100n, 1n << 150n, 1n << 250n],
+        ],
+        ['int signed positive', ['int256'], [12345n]],
+        ['int signed negative', ['int256'], [-12345n]],
+        ['int8 boundary low', ['int8'], [-128n]],
+        ['int8 boundary high', ['int8'], [127n]],
+        ['uint256 max', ['uint256'], [(1n << 256n) - 1n]],
+    ];
+
+    test.each(cases)('encodes %s identically to ethers + viem', (_label, types, values) => {
+        const ours = u.encodeAbiParameters(types, values);
+        expect(ours).toBe(ethers.AbiCoder.defaultAbiCoder().encode(types, values));
+        const viemParams = viem.parseAbiParameters(types.join(','));
+        expect(ours).toBe(viem.encodeAbiParameters(viemParams, values));
+    });
+
+    test.each(cases)('round-trips %s through decodeAbiParameters', (_label, types, values) => {
+        const encoded = u.encodeAbiParameters(types, values);
+        const decoded = u.decodeAbiParameters(types, encoded);
+        const ethersDecoded = ethers.AbiCoder.defaultAbiCoder().decode(types, encoded);
+        expect(JSON.stringify(decoded, bigintReplacer)).toBe(
+            JSON.stringify([...ethersDecoded], bigintReplacer),
+        );
+    });
+
+    test('decodes ethers-produced payloads (interop)', () => {
+        const types = ['address', 'uint256', 'bytes'];
+        const values = [ADDR_CHECKSUMMED, 999n, '0xc0ffeeee'];
+        const encoded = ethers.AbiCoder.defaultAbiCoder().encode(types, values);
+        const decoded = u.decodeAbiParameters(types, encoded);
+        expect(decoded[0]).toBe(ADDR_CHECKSUMMED);
+        expect(decoded[1]).toBe(999n);
+        expect(decoded[2]).toBe('0xc0ffeeee');
+    });
+
+    test('rejects type/value count mismatch', () => {
+        expect(() => u.encodeAbiParameters(['uint256', 'address'], [1n])).toThrow();
+    });
+    test('rejects uint overflow', () => {
+        expect(() => u.encodeAbiParameters(['uint8'], [256n])).toThrow(/uint8/);
+    });
+    test('rejects negative uint', () => {
+        expect(() => u.encodeAbiParameters(['uint256'], [-1n])).toThrow();
+    });
+    test('rejects int out-of-bounds', () => {
+        expect(() => u.encodeAbiParameters(['int8'], [128n])).toThrow(/int8/);
+        expect(() => u.encodeAbiParameters(['int8'], [-129n])).toThrow(/int8/);
+    });
+    test('rejects bytesN wrong length', () => {
+        expect(() => u.encodeAbiParameters(['bytes4'], ['0xdeadbeef00'])).toThrow();
+    });
+    test('rejects fixed-array length mismatch', () => {
+        expect(() => u.encodeAbiParameters(['uint256[3]'], [[1n, 2n]])).toThrow();
+    });
+
+    // Random parameter-list generator.
+    function genAtomicType() {
+        const buckets = [
+            () => 'address',
+            () => 'bool',
+            () => 'bytes',
+            () => 'string',
+            () => 'uint' + pick([8, 16, 32, 64, 128, 192, 256]),
+            () => 'int' + pick([8, 16, 32, 64, 128, 256]),
+            () => 'bytes' + pick([1, 2, 4, 8, 16, 20, 32]),
+        ];
+        return pick(buckets)();
+    }
+    function genType(depth = 0) {
+        // Optionally wrap in an array; cap nesting depth.
+        const base = genAtomicType();
+        if (depth >= 2) return base;
+        const r = rng();
+        if (r < 0.7) return base;
+        if (r < 0.85) return base + '[]';
+        return base + '[' + randIntRange(1, 4) + ']';
+    }
+    function genValue(type) {
+        const arrMatch = type.match(/^(.+?)(\[(\d*)\])$/);
+        if (arrMatch) {
+            const inner = arrMatch[1];
+            const fixed = arrMatch[3];
+            const len = fixed ? parseInt(fixed) : randInt(5);
+            return Array.from({ length: len }, () => genValue(inner));
+        }
+        if (type === 'address') return randomAddress();
+        if (type === 'bool') return rng() < 0.5;
+        if (type === 'bytes') return randomHex(randInt(65));
+        if (type === 'string') return randomUtf8String(64);
+        const um = type.match(/^(u?)int(\d+)$/);
+        if (um) {
+            const bits = parseInt(um[2]);
+            return um[1] === 'u' ? randomBigUint(bits) : randomSignedBigInt(bits);
+        }
+        const bm = type.match(/^bytes(\d+)$/);
+        if (bm) return randomHex(parseInt(bm[1]));
+        throw new Error('unsupported gen type ' + type);
+    }
+
+    test(`property: ${ITER} random parameter lists encode identically to ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const n = randIntRange(1, 5);
+            const types = Array.from({ length: n }, () => genType());
+            const values = types.map((t) => genValue(t));
+            const ours = u.encodeAbiParameters(types, values);
+            const refEthers = ethers.AbiCoder.defaultAbiCoder().encode(types, values);
+            expect(ours).toBe(refEthers);
+            const viemParams = viem.parseAbiParameters(types.join(','));
+            expect(ours).toBe(viem.encodeAbiParameters(viemParams, values));
+        }
+    });
+
+    test(`property: ${ITER} random parameter lists round-trip through decode`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const n = randIntRange(1, 5);
+            const types = Array.from({ length: n }, () => genType());
+            const values = types.map((t) => genValue(t));
+            const encoded = u.encodeAbiParameters(types, values);
+            const ours = u.decodeAbiParameters(types, encoded);
+            const ref = ethers.AbiCoder.defaultAbiCoder().decode(types, encoded);
+            expect(JSON.stringify(ours, bigintReplacer)).toBe(
+                JSON.stringify([...ref], bigintReplacer),
+            );
+        }
+    });
+});
+
+// ===========================================================================
+//                              solidityPacked / solidityPackedKeccak256
+// ===========================================================================
+
+describe('solidityPacked / solidityPackedKeccak256', () => {
+    const cases = [
+        ['mixed uint+address+bytes',
+            ['uint256', 'address', 'bytes'], [0xdeadbeefn, ADDR_CHECKSUMMED, '0xc0ffee']],
+        ['uint8 + uint48 + uint48 + bytes',
+            ['uint8', 'uint48', 'uint48', 'bytes'], [1, 100n, 200n, '0x1234']],
+        ['bytes1 + uint48 + uint48 + bytes',
+            ['bytes1', 'uint48', 'uint48', 'bytes'], ['0x01', 100n, 200n, '0xabcdef']],
+        ['bool packing', ['bool', 'bool'], [true, false]],
+        ['bytesN exact', ['bytes32'], ['0x' + '7e'.repeat(32)]],
+        ['string + bytes', ['string', 'bytes'], ['hello', '0xdead']],
+        ['int negative', ['int256'], [-1n]],
+    ];
+
+    test.each(cases)('solidityPacked %s matches ethers + viem', (_label, types, values) => {
+        const ours = u.solidityPacked(types, values);
+        expect(ours).toBe(ethers.solidityPacked(types, values));
+        expect(ours).toBe(viem.encodePacked(types, values));
+    });
+    test.each(cases)('solidityPackedKeccak256 %s matches ethers + viem', (_label, types, values) => {
+        const ours = u.solidityPackedKeccak256(types, values);
+        expect(ours).toBe(ethers.solidityPackedKeccak256(types, values));
+        expect(ours).toBe(viem.keccak256(viem.encodePacked(types, values)));
+    });
+    test('rejects type/value count mismatch', () => {
+        expect(() => u.solidityPacked(['uint256'], [1n, 2n])).toThrow();
+    });
+    test('rejects invalid type', () => {
+        expect(() => u.solidityPacked(['notatype'], ['0x'])).toThrow();
+    });
+    test('rejects bytesN wrong length', () => {
+        expect(() => u.solidityPacked(['bytes4'], ['0xdeadbeef00'])).toThrow();
+    });
+
+    // For solidityPacked, ethers and viem agree across atomic types; we skip
+    // arrays here because the two reference libs differ on packed array
+    // encoding of certain types (notably bytes-element arrays).
+    function genPackedType() {
+        return pick([
+            'address',
+            'bool',
+            'bytes',
+            'string',
+            'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256',
+            'int8', 'int16', 'int32', 'int64', 'int128', 'int256',
+            'bytes1', 'bytes4', 'bytes16', 'bytes32',
+        ]);
+    }
+    function genPackedValue(type) {
+        if (type === 'address') return randomAddress();
+        if (type === 'bool') return rng() < 0.5;
+        if (type === 'bytes') return randomHex(randInt(33));
+        if (type === 'string') return randomUtf8String(32);
+        const um = type.match(/^(u?)int(\d+)$/);
+        if (um) {
+            const bits = parseInt(um[2]);
+            return um[1] === 'u' ? randomBigUint(bits) : randomSignedBigInt(bits);
+        }
+        const bm = type.match(/^bytes(\d+)$/);
+        if (bm) return randomHex(parseInt(bm[1]));
+        throw new Error(type);
+    }
+
+    test(`property: ${ITER} random packed encodings match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const n = randIntRange(1, 6);
+            const types = Array.from({ length: n }, () => genPackedType());
+            const values = types.map((t) => genPackedValue(t));
+            const ours = u.solidityPacked(types, values);
+            expect(ours).toBe(ethers.solidityPacked(types, values));
+            expect(ours).toBe(viem.encodePacked(types, values));
+            const oursK = u.solidityPackedKeccak256(types, values);
+            expect(oursK).toBe(ethers.solidityPackedKeccak256(types, values));
+            expect(oursK).toBe(viem.keccak256(viem.encodePacked(types, values)));
+        }
+    });
+});
+
+// ===========================================================================
+//                              hashTypedData (EIP-712)
+// ===========================================================================
+
+describe('hashTypedData', () => {
+    const mailDomain = {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1n,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    };
+    const mailTypes = {
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' },
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person' },
+            { name: 'contents', type: 'string' },
+        ],
+    };
+    const mailMessage = {
+        from: { name: 'Cow', wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826' },
+        to: { name: 'Bob', wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' },
+        contents: 'Hello, Bob!',
+    };
+
+    test('Mail example matches ethers + viem', () => {
+        const ours = u.hashTypedData(mailDomain, mailTypes, mailMessage);
+        expect(ours).toBe(ethers.TypedDataEncoder.hash(mailDomain, mailTypes, mailMessage));
+        expect(ours).toBe(viem.hashTypedData({
+            domain: mailDomain, types: mailTypes, primaryType: 'Mail', message: mailMessage,
+        }));
+    });
+
+    test('strips EIP712Domain entry from types if present', () => {
+        const withDomainType = {
+            EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' },
+            ],
+            ...mailTypes,
+        };
+        expect(u.hashTypedData(mailDomain, withDomainType, mailMessage))
+            .toBe(u.hashTypedData(mailDomain, mailTypes, mailMessage));
+    });
+
+    test('Safe-style domain (chainId + verifyingContract only)', () => {
+        const d = { chainId: 11155111n, verifyingContract: '0x1234567890123456789012345678901234567890' };
+        const t = { SafeMessage: [{ name: 'message', type: 'bytes' }] };
+        const m = { message: '0xdeadbeef' };
+        expect(u.hashTypedData(d, t, m)).toBe(ethers.TypedDataEncoder.hash(d, t, m));
+        expect(u.hashTypedData(d, t, m)).toBe(
+            viem.hashTypedData({ domain: d, types: t, primaryType: 'SafeMessage', message: m }),
+        );
+    });
+
+    test('struct-array of nested structs (Person[])', () => {
+        const d = { name: 'Group', version: '1', chainId: 1n };
+        const t = {
+            Person: [{ name: 'name', type: 'string' }, { name: 'wallet', type: 'address' }],
+            Group: [{ name: 'members', type: 'Person[]' }],
+        };
+        const m = { members: [
+            { name: 'Alice', wallet: ADDR_CHECKSUMMED },
+            { name: 'Bob', wallet: ADDR_CHECKSUMMED },
+        ]};
+        expect(u.hashTypedData(d, t, m)).toBe(ethers.TypedDataEncoder.hash(d, t, m));
+    });
+
+    test('domain with salt', () => {
+        const d = {
+            name: 'Salted', version: '1', chainId: 1n,
+            verifyingContract: ADDR_CHECKSUMMED, salt: '0x' + '99'.repeat(32),
+        };
+        const t = { Tx: [{ name: 'op', type: 'uint256' }] };
+        expect(u.hashTypedData(d, t, { op: 7n })).toBe(
+            ethers.TypedDataEncoder.hash(d, t, { op: 7n }),
+        );
+    });
+
+    test('rejects ambiguous (multi-root) types', () => {
+        const d = { name: 'X', version: '1', chainId: 1n };
+        const t = { A: [{ name: 'x', type: 'uint256' }], B: [{ name: 'y', type: 'uint256' }] };
+        expect(() => u.hashTypedData(d, t, { x: 1n })).toThrow();
+    });
+
+    test('rejects circular type references', () => {
+        const d = { name: 'Cycle', version: '1', chainId: 1n };
+        const t = { Node: [{ name: 'next', type: 'Node' }] };
+        expect(() => u.hashTypedData(d, t, { next: null })).toThrow(/circular/);
+    });
+
+    // Property: random domain + random message with stable type schema.
+    function randomDomain() {
+        // Randomly include/exclude each domain field.
+        const d = {};
+        if (rng() < 0.7) d.name = randomUtf8String(20);
+        if (rng() < 0.7) d.version = String(randIntRange(1, 9));
+        if (rng() < 0.7) d.chainId = randomBigUint(64);
+        if (rng() < 0.7) d.verifyingContract = randomAddress();
+        if (rng() < 0.3) d.salt = randomHex(32);
+        // Ensure at least one domain field present.
+        if (Object.keys(d).length === 0) d.chainId = 1n;
+        return d;
+    }
+
+    test(`property: ${ITER} random Mail-shaped messages match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const d = randomDomain();
+            const m = {
+                from: { name: randomUtf8String(16), wallet: randomAddress() },
+                to:   { name: randomUtf8String(16), wallet: randomAddress() },
+                contents: randomUtf8String(64),
+            };
+            const ours = u.hashTypedData(d, mailTypes, m);
+            expect(ours).toBe(ethers.TypedDataEncoder.hash(d, mailTypes, m));
+            expect(ours).toBe(viem.hashTypedData({
+                domain: d, types: mailTypes, primaryType: 'Mail', message: m,
+            }));
+        }
+    });
+
+    test(`property: ${ITER} random Safe-style messages match ethers + viem`, () => {
+        resetRng();
+        const t = { SafeMessage: [{ name: 'message', type: 'bytes' }] };
+        for (let i = 0; i < ITER; i++) {
+            const d = randomDomain();
+            const m = { message: randomHex(randInt(65)) };
+            const ours = u.hashTypedData(d, t, m);
+            expect(ours).toBe(ethers.TypedDataEncoder.hash(d, t, m));
+            expect(ours).toBe(viem.hashTypedData({
+                domain: d, types: t, primaryType: 'SafeMessage', message: m,
+            }));
+        }
+    });
+
+    test(`property: ${ITER} random bytes32[] messages match ethers`, () => {
+        resetRng();
+        const t = { Wrapper: [{ name: 'leaves', type: 'bytes32[]' }] };
+        for (let i = 0; i < ITER; i++) {
+            const d = randomDomain();
+            const n = randInt(8);
+            const m = { leaves: Array.from({ length: n }, () => randomHex(32)) };
+            expect(u.hashTypedData(d, t, m)).toBe(ethers.TypedDataEncoder.hash(d, t, m));
+        }
+    });
+});
+
+// ===========================================================================
+//                              encodeRlp
+// ===========================================================================
+
+describe('encodeRlp', () => {
+    test.each([
+        ['empty string', '0x'],
+        ['single byte < 0x80', '0x7f'],
+        ['single byte = 0x80', '0x80'],
+        ['short string', '0x' + '01'.repeat(10)],
+        ['exactly 55 bytes', '0x' + 'ab'.repeat(55)],
+        ['56 bytes (long-form length prefix)', '0x' + 'ab'.repeat(56)],
+        ['256 bytes', '0x' + 'cd'.repeat(256)],
+        ['1024 bytes', '0x' + 'ef'.repeat(1024)],
+    ])('matches ethers + viem on %s', (_label, data) => {
+        const ours = u.encodeRlp(data);
+        expect(ours).toBe(ethers.encodeRlp(data));
+        expect(ours).toBe(viem.toRlp(data));
+    });
+
+    test('nested arrays match ethers + viem', () => {
+        const nested = ['0x01', ['0x02', '0x03'], '0x04'];
+        expect(u.encodeRlp(nested)).toBe(ethers.encodeRlp(nested));
+        expect(u.encodeRlp(nested)).toBe(viem.toRlp(nested));
+    });
+
+    test('deeply nested arrays match ethers', () => {
+        const deep = [[[['0x01']], '0x02'], ['0x03', [['0x04', '0x05']]]];
+        expect(u.encodeRlp(deep)).toBe(ethers.encodeRlp(deep));
+    });
+
+    test('empty list', () => {
+        expect(u.encodeRlp([])).toBe(ethers.encodeRlp([]));
+        expect(u.encodeRlp([])).toBe(viem.toRlp([]));
+    });
+
+    test('list payload exceeding 55 bytes', () => {
+        const big = Array.from({ length: 20 }, () => '0x' + 'ab'.repeat(4));
+        expect(u.encodeRlp(big)).toBe(ethers.encodeRlp(big));
+    });
+
+    test('EIP-7702 authorization-tuple shape', () => {
+        const tuple = ['0x01', '0x' + 'ab'.repeat(20), '0x'];
+        expect(u.encodeRlp(tuple)).toBe(ethers.encodeRlp(tuple));
+        expect(u.encodeRlp(tuple)).toBe(viem.toRlp(tuple));
+    });
+
+    function genRlp(depth = 0) {
+        // Generate a tree: leaves are short hex bytestrings; branches are
+        // arrays. Depth bounded to keep total size sane.
+        const isArray = depth < 3 && rng() < 0.4;
+        if (isArray) {
+            const n = randInt(5);
+            return Array.from({ length: n }, () => genRlp(depth + 1));
+        }
+        return randomHex(randInt(80));
+    }
+
+    test(`property: ${ITER} random RLP trees match ethers + viem`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const tree = genRlp();
+            const ours = u.encodeRlp(tree);
+            expect(ours).toBe(ethers.encodeRlp(tree));
+            expect(ours).toBe(viem.toRlp(tree));
+        }
+    });
+});
+
+// ===========================================================================
+//                              privateKeyToAddress
+// ===========================================================================
+
+describe('privateKeyToAddress', () => {
+    test('matches ethers Wallet.address and viem privateKeyToAddress', () => {
+        const ours = u.privateKeyToAddress(PK);
+        expect(ours).toBe(new ethers.Wallet(PK).address);
+        expect(ours).toBe(viemAccounts.privateKeyToAddress(PK));
+    });
+
+    test('accepts private key without 0x prefix', () => {
+        expect(u.privateKeyToAddress(PK_NO_PREFIX)).toBe(u.privateKeyToAddress(PK));
+    });
+
+    test('output is EIP-55 checksummed', () => {
+        const addr = u.privateKeyToAddress(PK);
+        expect(addr).toBe(u.getAddress(addr));
+    });
+
+    test(`property: ${ITER} random private keys → identical addresses across libs`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const pk = randomPrivateKey();
+            const ours = u.privateKeyToAddress(pk);
+            expect(ours).toBe(new ethers.Wallet(pk).address);
+            expect(ours).toBe(viemAccounts.privateKeyToAddress(pk));
+            // Also confirm prefix-stripping matches.
+            expect(u.privateKeyToAddress(pk.slice(2))).toBe(ours);
+        }
+    });
+});
+
+// ===========================================================================
+//                              signHash
+// ===========================================================================
+
+describe('signHash', () => {
+    test('r, s, yParity, v match ethers signingKey.sign', () => {
+        const ours = u.signHash(PK, DIGEST_32);
+        const ref = new ethers.Wallet(PK).signingKey.sign(DIGEST_32);
+        expect(ours.r).toBe(ref.r);
+        expect(ours.s).toBe(ref.s);
+        expect(ours.yParity).toBe(ref.yParity);
+        expect(ours.v).toBe(ref.v);
+        expect(ours.serialized).toBe(ref.serialized);
+    });
+
+    test('serialized signature matches viem sign + concatenated form', async () => {
+        const ours = u.signHash(PK, DIGEST_32);
+        const viemSig = await viemAccounts.sign({ hash: DIGEST_32, privateKey: PK });
+        const r = viemSig.r.slice(2);
+        const s = viemSig.s.slice(2);
+        const v = Number(viemSig.v).toString(16).padStart(2, '0');
+        expect(ours.serialized.toLowerCase()).toBe(('0x' + r + s + v).toLowerCase());
+    });
+
+    test('signature recovers to the correct address', () => {
+        const expected = u.privateKeyToAddress(PK);
+        const ours = u.signHash(PK, DIGEST_32);
+        expect(ethers.recoverAddress(DIGEST_32, ours.serialized)).toBe(expected);
+    });
+
+    test('accepts Uint8Array hash input', () => {
+        const hashBytes = u.getBytes(DIGEST_32);
+        expect(u.signHash(PK, hashBytes).serialized).toBe(u.signHash(PK, DIGEST_32).serialized);
+    });
+
+    test('accepts private key without 0x prefix', () => {
+        expect(u.signHash(PK_NO_PREFIX, DIGEST_32).serialized).toBe(
+            u.signHash(PK, DIGEST_32).serialized,
+        );
+    });
+
+    test('signatures are deterministic (RFC6979)', () => {
+        expect(u.signHash(PK, DIGEST_32).serialized).toBe(u.signHash(PK, DIGEST_32).serialized);
+    });
+
+    test('rejects hash that is not 32 bytes', () => {
+        expect(() => u.signHash(PK, '0xdeadbeef')).toThrow(/invalid digest length/);
+        expect(() => u.signHash(PK, '0x' + 'ab'.repeat(31))).toThrow(/invalid digest length/);
+    });
+
+    test('low-s normalization: produced s is always <= n/2', () => {
+        const N_HALF =
+            0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n;
+        for (let i = 0; i < 8; i++) {
+            const hash = u.keccak256('0x' + i.toString(16).padStart(2, '0'));
+            const sig = u.signHash(PK, hash);
+            expect(BigInt(sig.s) <= N_HALF).toBe(true);
+        }
+    });
+
+    test('yParity ∈ {0, 1} and v = 27 + yParity', () => {
+        for (let i = 0; i < 8; i++) {
+            const hash = u.keccak256('0x' + i.toString(16).padStart(2, '0'));
+            const sig = u.signHash(PK, hash);
+            expect([0, 1]).toContain(sig.yParity);
+            expect(sig.v).toBe(27 + sig.yParity);
+        }
+    });
+
+    test(`property: ${SIGN_ITER} random (pk, hash) pairs match ethers + recover correctly`, async () => {
+        resetRng();
+        const N_HALF =
+            0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n;
+        for (let i = 0; i < SIGN_ITER; i++) {
+            const pk = randomPrivateKey();
+            const hash = randomHex(32);
+            const ours = u.signHash(pk, hash);
+            const ref = new ethers.Wallet(pk).signingKey.sign(hash);
+            expect(ours.r).toBe(ref.r);
+            expect(ours.s).toBe(ref.s);
+            expect(ours.v).toBe(ref.v);
+            expect(ours.yParity).toBe(ref.yParity);
+            expect(ours.serialized).toBe(ref.serialized);
+            expect(BigInt(ours.s) <= N_HALF).toBe(true);
+            // Recover via both libs.
+            const expectedAddr = u.privateKeyToAddress(pk);
+            expect(ethers.recoverAddress(hash, ours.serialized)).toBe(expectedAddr);
+            const viemRecovered = await viem.recoverAddress({
+                hash, signature: ours.serialized,
+            });
+            expect(viemRecovered).toBe(expectedAddr);
+        }
+    });
+});
+
+// ===========================================================================
+//                              signTypedData
+// ===========================================================================
+
+describe('signTypedData', () => {
+    const domain = {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1n,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    };
+    const types = {
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' },
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person' },
+            { name: 'contents', type: 'string' },
+        ],
+    };
+    const message = {
+        from: { name: 'Cow', wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826' },
+        to: { name: 'Bob', wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' },
+        contents: 'Hello, Bob!',
+    };
+
+    test('matches ethers Wallet.signTypedData', async () => {
+        const ours = u.signTypedData(PK, domain, types, message);
+        const ref = await new ethers.Wallet(PK).signTypedData(domain, types, message);
+        expect(ours).toBe(ref);
+    });
+
+    test('matches viem privateKeyToAccount.signTypedData', async () => {
+        const ours = u.signTypedData(PK, domain, types, message);
+        const viemSig = await viemAccounts.privateKeyToAccount(PK).signTypedData({
+            domain, types, primaryType: 'Mail', message,
+        });
+        expect(ours).toBe(viemSig);
+    });
+
+    test('signature recovers to the signer address (ethers + viem)', async () => {
+        const expected = u.privateKeyToAddress(PK);
+        const sig = u.signTypedData(PK, domain, types, message);
+        const digest = u.hashTypedData(domain, types, message);
+        expect(ethers.recoverAddress(digest, sig)).toBe(expected);
+        const viemRec = await viem.recoverTypedDataAddress({
+            domain, types, primaryType: 'Mail', message, signature: sig,
+        });
+        expect(viemRec).toBe(expected);
+    });
+
+    test('accepts private key without 0x prefix', () => {
+        expect(u.signTypedData(PK_NO_PREFIX, domain, types, message))
+            .toBe(u.signTypedData(PK, domain, types, message));
+    });
+
+    test(`property: ${SIGN_ITER} random typed-data signings match ethers + viem`, async () => {
+        resetRng();
+        for (let i = 0; i < SIGN_ITER; i++) {
+            const pk = randomPrivateKey();
+            const d = {
+                name: randomUtf8String(16),
+                version: String(randIntRange(1, 9)),
+                chainId: randomBigUint(64),
+                verifyingContract: randomAddress(),
+            };
+            const m = {
+                from: { name: randomUtf8String(16), wallet: randomAddress() },
+                to:   { name: randomUtf8String(16), wallet: randomAddress() },
+                contents: randomUtf8String(64),
+            };
+            const ours = u.signTypedData(pk, d, types, m);
+            const refEthers = await new ethers.Wallet(pk).signTypedData(d, types, m);
+            expect(ours).toBe(refEthers);
+            const refViem = await viemAccounts.privateKeyToAccount(pk).signTypedData({
+                domain: d, types, primaryType: 'Mail', message: m,
+            });
+            expect(ours).toBe(refViem);
+        }
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,7 +639,7 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/curves@^1.9.1", "@noble/curves@~1.9.0":
+"@noble/curves@^1.2.0", "@noble/curves@~1.9.0":
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
   integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
@@ -651,7 +651,7 @@
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
-"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.3.2", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,7 +639,7 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/curves@~1.9.0":
+"@noble/curves@^1.9.1", "@noble/curves@~1.9.0":
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
   integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==


### PR DESCRIPTION
## Summary
Move ethers from a runtime dependency to a dev dependency only. The new src/ethereUtils.ts copies the relevant ethers v6 surface used across the codebase (keccak256, id, hashMessage, ABI codec, solidityPacked, EIP-712 typed-data hashing, RLP, address checksum, secp256k1 sign/recover) with some modification, backed by @noble/curves and @noble/hashes. Every internal call site is migrated to import from ./ethereUtils.

Also drops the sharedAbiCoder wrapper in Calibur7702Account in favor of direct encodeAbiParameters / decodeAbiParameters calls, and adds comprehensive parity tests (test/ethereUtils.test.js) — deterministic spec fixtures plus seeded property tests asserting byte-identical output against ethers v6 and viem v2 across 100 random inputs per function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signer APIs now accept either synchronous or asynchronous signing results.

* **Tests**
  * Added an extensive test suite validating hashing, ABI encoding/decoding, packed/EIP‑712 hashing, RLP, and signing for parity with reference implementations.

* **Chores**
  * Replaced disparate crypto/ABI helpers with a unified, in-project implementation to standardize encoding, hashing, address derivation, and signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->