### PR TITLE
Mask Tenderly API key in error context to avoid leaking secrets

### DIFF
--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -58,7 +58,7 @@ export async function shareTenderlySimulationAndCreateLink(
 			context: {
 				tenderlyAccountSlug,
 				tenderlyProjectSlug,
-				tenderlyAccessKey,
+				hasTenderlyAccessKey: tenderlyAccessKey.length > 0,
 				tenderlySimulationId,
 				status,
 			},


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of the Tenderly API access key when an `AbstractionKitError` is thrown by removing the raw `tenderlyAccessKey` from the error context.

### Description
- Replace the `tenderlyAccessKey` field in the error context with a boolean `hasTenderlyAccessKey: tenderlyAccessKey.length > 0` in `src/utilsTenderly.ts` to avoid including the secret in logs.

### Testing
- Ran the existing automated test suite with `yarn test` and performed a TypeScript type check with `tsc`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2dada930832c82a2902a87278887)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting to prevent sensitive credentials from being included in error payloads, improving security of error logs and diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->