### PR TITLE
fix: handle simulation_results responses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -551,6 +551,9 @@ export async function sendJsonRpcRequest(
 	if ("result" in response) {
 		return response.result as JsonRpcResult;
 	}
+	if ("simulation_results" in response) {
+		return response.simulation_results as JsonRpcResult;
+	}
 	const err = response.error as JsonRpcError;
 	throw new TransportRpcError(err.code, err.message);
 }

--- a/test/transport/HttpTransport.test.js
+++ b/test/transport/HttpTransport.test.js
@@ -65,6 +65,24 @@ describe("HttpTransport", () => {
 		expect(new Set(ids).size).toBe(3); // all distinct
 	});
 
+	test("sendJsonRpcRequest returns non-standard simulation_results responses", async () => {
+		const originalFetch = global.fetch;
+		global.fetch = jest.fn(async () =>
+			jsonResponse({
+				jsonrpc: "2.0",
+				id: 1,
+				simulation_results: [{ transaction: { hash: "0x1" }, simulation: { id: "sim-1" } }],
+			}),
+		);
+
+		try {
+			const result = await ak.sendJsonRpcRequest("https://example.test/rpc", "tenderly_simulateBundle", []);
+			expect(result).toEqual([{ transaction: { hash: "0x1" }, simulation: { id: "sim-1" } }]);
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+
 	test("throws TransportRpcError on JSON-RPC error response", async () => {
 		const fetch = makeMockFetch(() =>
 			jsonResponse({


### PR DESCRIPTION
Restores the low-level JSON-RPC helper's compatibility with non-standard responses that return `simulation_results` instead of `result`.

Without this branch, those responses fall through to `response.error`; when `error` is absent the helper throws a TypeError instead of returning the payload.

Checked with:
- `corepack yarn install --ignore-scripts --frozen-lockfile`
- `corepack yarn build`
- `corepack yarn test test/transport/HttpTransport.test.js --runInBand`
- `corepack yarn lint`
- `git diff --check`

Closes #182.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * JSON-RPC requests now correctly handle responses with alternative result formats.

* **Tests**
  * Added test coverage for extended JSON-RPC response handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->