### PR TITLE
fix(utils): correct self-funded v0.6 verification gas multiplier (0 -> 1)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -648,7 +648,7 @@ export function calculateUserOperationMaxGasCost(
 	if ("initCode" in useroperation) {
 		const isPaymasterAndData =
 			useroperation.paymasterAndData !== "0x" && useroperation.paymasterAndData != null;
-		const mul = isPaymasterAndData ? 3n : 0n;
+		const mul = isPaymasterAndData ? 3n : 1n;
 		const requiredGas =
 			useroperation.callGasLimit +
 			useroperation.verificationGasLimit * mul +

--- a/test/utils/calculateUserOperationMaxGasCost.test.js
+++ b/test/utils/calculateUserOperationMaxGasCost.test.js
@@ -1,0 +1,32 @@
+const { calculateUserOperationMaxGasCost } = require('../../dist/index.cjs');
+
+describe('calculateUserOperationMaxGasCost (v0.6)', () => {
+  // Minimal v0.6 UserOperation. The presence of `initCode` selects the v0.6 branch.
+  const baseV6 = {
+    sender: '0x0000000000000000000000000000000000000001',
+    nonce: 0n,
+    initCode: '0x',
+    callData: '0x',
+    callGasLimit: 100_000n,
+    verificationGasLimit: 500_000n,
+    preVerificationGas: 60_000n,
+    maxFeePerGas: 10_000_000n,
+    maxPriorityFeePerGas: 1_000_000n,
+    paymasterAndData: '0x',
+    signature: '0x',
+  };
+
+  it('includes verificationGasLimit for a self-funded operation (EntryPoint v0.6 mul = 1)', () => {
+    // requiredGas = callGasLimit + verificationGasLimit * 1 + preVerificationGas
+    //             = 100_000 + 500_000 + 60_000 = 660_000
+    // maxCost     = 660_000 * 10_000_000 = 6_600_000_000_000
+    expect(calculateUserOperationMaxGasCost(baseV6)).toBe(6_600_000_000_000n);
+  });
+
+  it('applies the 3x verification multiplier when a paymaster is set (EntryPoint v0.6 mul = 3)', () => {
+    const withPaymaster = { ...baseV6, paymasterAndData: '0x' + '11'.repeat(20) };
+    // requiredGas = 100_000 + 500_000 * 3 + 60_000 = 1_660_000
+    // maxCost     = 1_660_000 * 10_000_000 = 16_600_000_000_000
+    expect(calculateUserOperationMaxGasCost(withPaymaster)).toBe(16_600_000_000_000n);
+  });
+});


### PR DESCRIPTION
Fixes #188.

`calculateUserOperationMaxGasCost` used a verification-gas multiplier of `0n` when no paymaster is set, which drops the `verificationGasLimit` term entirely from the **v0.6** prefund formula.

```diff
- const mul = isPaymasterAndData ? 3n : 0n;
+ const mul = isPaymasterAndData ? 3n : 1n;
```

EntryPoint v0.6 `_getRequiredPrefund` uses `mul = mUserOp.paymaster != address(0) ? 3 : 1`, so the no-paymaster case must be `1`. With `0n`, a self-funded v0.6 op's max gas cost was under-estimated (e.g. `verificationGasLimit=500k`, `maxFeePerGas=10M` → `1.6e12` reported vs `6.6e12` correct, ≈4.1×). The v0.7+ branch already sums all components correctly.

Downstream, this also under-estimates `CandidePaymaster`'s ERC-20 approve amount when the cost is computed before `paymasterAndData` is set, which can revert the operation on-chain.

### Tests
Adds `test/utils/calculateUserOperationMaxGasCost.test.js` covering the self-funded (mul=1) and paymaster (mul=3) v0.6 cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated maximum gas cost calculations for transaction operations to ensure accurate fee estimation across different transaction types and funding scenarios.

* **Tests**
  * Added comprehensive test suite validating gas cost calculations, covering scenarios with and without paymaster services to verify accuracy and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->