### PR TITLE
Add Safe instance manual signing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ See [CHANGELOG.md](./CHANGELOG.md) for the full list of new features, renames, t
 
 ### Which account class to use?
 
-| Class | EntryPoint | Account Type | When to use |
+Default EntryPoint is class-specific. Override `entrypointAddress` only when your account/module deployment matches that EntryPoint.
+
+| Class | Default EntryPoint | Account Type | When to use |
 |---|---|---|---|
 | `SafeAccountV0_3_0` | EP v0.7 | Safe (counterfactual) | Recommended for most new projects |
 | `SafeAccountV1_5_0_M_0_3_0` | EP v0.7 | Safe v1.5.0 (counterfactual) | Safe v1.5.0 with EIP-7951 / Daimo P256 verifier for WebAuthn |

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -602,7 +602,7 @@ export class SafeAccount extends SmartAccount {
 		} = {},
 	): string {
 		const data = this.getUserOperationEip712Data(useroperation, chainId, overrides);
-		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+		return hashTypedData(data.domain, data.types, data.messageValue);
 	}
 
 	/**

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -548,6 +548,83 @@ export class SafeAccount extends SmartAccount {
 	}
 
 	/**
+	 * Get the EIP-712 typed data for this account's configured EntryPoint and
+	 * Safe 4337 module. Prefer this instance method for manual signing so
+	 * custom constructor overrides are carried through automatically.
+	 *
+	 * @param useroperation - UserOperation to get typed data for
+	 * @param chainId - target chain ID
+	 * @param overrides - optional validity window and explicit address overrides
+	 * @returns Object with domain, types, and messageValue for EIP-712 signing
+	 */
+	public getUserOperationEip712Data(
+		useroperation: UserOperationV6 | UserOperationV7 | UserOperationV9,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			entrypointAddress?: string;
+			safe4337ModuleAddress?: string;
+		} = {},
+	): {
+		domain: SafeUserOperationTypedDataDomain;
+		types: Record<string, { name: string; type: string }[]>;
+		messageValue:
+			| SafeUserOperationV6TypedMessageValue
+			| SafeUserOperationV7TypedMessageValue
+			| SafeUserOperationV9TypedMessageValue;
+	} {
+		return SafeAccount.getUserOperationEip712Data(useroperation, chainId, {
+			...overrides,
+			entrypointAddress: overrides.entrypointAddress ?? this.entrypointAddress,
+			safe4337ModuleAddress: overrides.safe4337ModuleAddress ?? this.safe4337ModuleAddress,
+		});
+	}
+
+	/**
+	 * Hash the EIP-712 typed data for this account's configured EntryPoint and
+	 * Safe 4337 module. Prefer this instance method for manual signing so
+	 * custom constructor overrides are carried through automatically.
+	 *
+	 * @param useroperation - UserOperation to hash
+	 * @param chainId - target chain ID
+	 * @param overrides - optional validity window and explicit address overrides
+	 * @returns EIP-712 digest as a hex string
+	 */
+	public getUserOperationEip712Hash(
+		useroperation: UserOperationV6 | UserOperationV7 | UserOperationV9,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			entrypointAddress?: string;
+			safe4337ModuleAddress?: string;
+		} = {},
+	): string {
+		const data = this.getUserOperationEip712Data(useroperation, chainId, overrides);
+		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+	}
+
+	/**
+	 * Format signer/signature pairs for this account's signature encoding.
+	 * Prefer this instance method for manual signing so account-level module
+	 * context is applied automatically.
+	 *
+	 * @param signerSignaturePairs - signer/signature pairs to encode
+	 * @param options - optional validity window, multi-chain, module, and WebAuthn encoding overrides
+	 * @returns formatted UserOperation signature
+	 */
+	public formatUserOperationSignature(
+		signerSignaturePairs: SignerSignaturePair[],
+		options: SafeSignatureOptions & WebAuthnSignatureOverrides = {},
+	): string {
+		return SafeAccount.formatSignaturesToUseroperationSignature(signerSignaturePairs, {
+			...options,
+			safe4337ModuleAddress: options.safe4337ModuleAddress ?? this.safe4337ModuleAddress,
+		});
+	}
+
+	/**
 	 * create a v0.07 or v0.06 useroperation eip712 data
 	 * @param useroperation - useroperation to hash
 	 * @param chainId - target chain id
@@ -956,7 +1033,14 @@ export class SafeAccount extends SmartAccount {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated Use `account.formatUserOperationSignature([{ signer, signature }], options)`
+	 * when an account instance is available, or
+	 * `SafeAccount.formatSignaturesToUseroperationSignature([{ signer, signature }], options)`
+	 * for static formatting. For `SafeMultiChainSigAccountV1`, prefer the
+	 * instance method so `isMultiChainSignature` is applied automatically; if
+	 * using the lower-level static formatter directly, pass
+	 * `isMultiChainSignature: true`.
+	 *
 	 * format an eip712 signature to a useroperation signature
 	 * @param signature - an eip712 signature
 	 * @param overrides - overrides for the default values

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -13,7 +13,7 @@ import {
 import {invokeSigner, pickScheme} from "src/signer/negotiate";
 import type {MultiOpSignContext, SignContext, Signer as AkSigner, TypedData} from "src/signer/types";
 import type {JsonRpcNode, Transport} from "src/transport";
-import type {MetaTransaction, OnChainIdentifierParamsType, UserOperationV9} from "../../types";
+import type {MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet, UserOperationV9} from "../../types";
 import {
 	DEFAULT_WEB_AUTHN_DAIMO_VERIFIER_V_0_2_1,
 	DEFAULT_WEB_AUTHN_PRECOMPILE_RIP_7951,
@@ -449,6 +449,132 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
+	 * Estimate gas limits for a multichain UserOperation using the bundler.
+	 * Applies the multichain dummy-signature encoding and Safe Passkey module
+	 * v0.2.1 WebAuthn defaults.
+	 *
+	 * @param userOperation - The UserOperation to estimate gas for
+	 * @param bundlerRpc - Bundler RPC URL, transport, or Bundler instance
+	 * @param overrides - State overrides, dummy signatures, and WebAuthn configuration
+	 * @returns A tuple of [preVerificationGas, verificationGasLimit, callGasLimit]
+	 */
+	public async estimateUserOperationGas(
+		userOperation: UserOperationV9,
+		bundlerRpc: string | Transport | Bundler,
+		overrides: {
+			stateOverrideSet?: StateOverrideSet;
+			dummySignerSignaturePairs?: SignerSignaturePair[];
+			expectedSigners?: Signer[];
+			webAuthnSharedSigner?: string;
+			webAuthnSignerFactory?: string;
+			webAuthnSignerSingleton?: string;
+			webAuthnSignerProxyCreationCode?: string;
+			eip7212WebAuthnPrecompileVerifier?: string;
+			eip7212WebAuthnContractVerifier?: string;
+		} = {},
+	): Promise<[bigint, bigint, bigint]> {
+		return this.baseEstimateUserOperationGas(userOperation, bundlerRpc, {
+			...overrides,
+			isMultiChainSignature: true,
+			webAuthnSharedSigner:
+				overrides.webAuthnSharedSigner ??
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SHARED_SIGNER,
+			webAuthnSignerFactory:
+				overrides.webAuthnSignerFactory ??
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_FACTORY,
+			webAuthnSignerSingleton:
+				overrides.webAuthnSignerSingleton ??
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_SINGLETON,
+			webAuthnSignerProxyCreationCode:
+				overrides.webAuthnSignerProxyCreationCode ??
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_PROXY_CREATION_CODE,
+			eip7212WebAuthnPrecompileVerifier:
+				overrides.eip7212WebAuthnPrecompileVerifier ??
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_PRECOMPILE,
+			eip7212WebAuthnContractVerifier:
+				overrides.eip7212WebAuthnContractVerifier ??
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_CONTRACT_VERIFIER,
+		});
+	}
+
+	/**
+	 * Get the single-operation EIP-712 typed data for this multichain account.
+	 * Uses the instance EntryPoint and Safe 4337 module, and is the recommended
+	 * manual-signing path for length-1 multichain UserOperations.
+	 *
+	 * @param useroperation - UserOperation to get typed data for
+	 * @param chainId - target chain ID
+	 * @param overrides - optional validity window and explicit address overrides
+	 * @returns Object with domain, types, and messageValue for EIP-712 signing
+	 */
+	public getUserOperationEip712Data(
+		useroperation: UserOperationV9,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			entrypointAddress?: string;
+			safe4337ModuleAddress?: string;
+		} = {},
+	): {
+		domain: SafeUserOperationTypedDataDomain;
+		types: Record<string, { name: string; type: string }[]>;
+		messageValue: SafeUserOperationV9TypedMessageValue;
+	} {
+		return SafeMultiChainSigAccountV1.getUserOperationEip712Data(useroperation, chainId, {
+			...overrides,
+			entrypointAddress: overrides.entrypointAddress ?? this.entrypointAddress,
+			safe4337ModuleAddress: overrides.safe4337ModuleAddress ?? this.safe4337ModuleAddress,
+		});
+	}
+
+	/**
+	 * Hash the single-operation EIP-712 typed data for this multichain account.
+	 * Uses the instance EntryPoint and Safe 4337 module.
+	 *
+	 * @param useroperation - UserOperation to hash
+	 * @param chainId - target chain ID
+	 * @param overrides - optional validity window and explicit address overrides
+	 * @returns EIP-712 digest as a hex string
+	 */
+	public getUserOperationEip712Hash(
+		useroperation: UserOperationV9,
+		chainId: bigint,
+		overrides: {
+			validAfter?: bigint;
+			validUntil?: bigint;
+			entrypointAddress?: string;
+			safe4337ModuleAddress?: string;
+		} = {},
+	): string {
+		const data = this.getUserOperationEip712Data(useroperation, chainId, overrides);
+		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+	}
+
+	/**
+	 * Format signer/signature pairs for this multichain account. The multichain
+	 * signature flag, module address, and v0.2.1 WebAuthn defaults are applied
+	 * automatically.
+	 *
+	 * @param signerSignaturePairs - signer/signature pairs to encode
+	 * @param options - optional validity window, Merkle proof, module, and WebAuthn encoding overrides
+	 * @returns formatted UserOperation signature
+	 */
+	public formatUserOperationSignature(
+		signerSignaturePairs: SignerSignaturePair[],
+		options: SafeSignatureOptions & WebAuthnSignatureOverrides = {},
+	): string {
+		return SafeMultiChainSigAccountV1.formatSingleUserOperationSignature(
+			signerSignaturePairs,
+			{
+				...options,
+				safe4337ModuleAddress: options.safe4337ModuleAddress ?? this.safe4337ModuleAddress,
+			},
+			options,
+		);
+	}
+
+	/**
 	 * create a useroperation signature
 	 * @param useroperation - useroperation to sign
 	 * @param privateKeys - for the signers
@@ -858,6 +984,28 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		};
 	}
 
+	private static formatSingleUserOperationSignature(
+		signerSignaturePairs: SignerSignaturePair[],
+		options: SafeSignatureOptions = {},
+		webAuthnSignatureOverrides: WebAuthnSignatureOverrides = {},
+	): string {
+		return SafeAccount.formatSignaturesToUseroperationSignature(signerSignaturePairs, {
+			safe4337ModuleAddress: SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
+			eip7212WebAuthnPrecompileVerifier:
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_PRECOMPILE,
+			eip7212WebAuthnContractVerifier:
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_CONTRACT_VERIFIER,
+			webAuthnSignerFactory: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_FACTORY,
+			webAuthnSignerSingleton: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_SINGLETON,
+			webAuthnSignerProxyCreationCode:
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_PROXY_CREATION_CODE,
+			webAuthnSharedSigner: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SHARED_SIGNER,
+			...options,
+			...webAuthnSignatureOverrides,
+			isMultiChainSignature: true,
+		});
+	}
+
 	/**
 	 * format a list of eip712 signatures to a list of multi chain useroperations signatures
 	 * @param signerSignaturePairs - a list of a pair of a signer and it's signature
@@ -871,29 +1019,31 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		if (userOperationsToSign.length < 1) {
 			throw new RangeError("There should be at least one userOperationsToSign");
 		}
+		const defaultOptions: SafeSignatureOptions = {
+			safe4337ModuleAddress: SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
+		};
 		const defaultWebAuthnOverrides: WebAuthnSignatureOverrides = {
-			eip7212WebAuthnPrecompileVerifier: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_PRECOMPILE,
-			eip7212WebAuthnContractVerifier: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_CONTRACT_VERIFIER,
+			eip7212WebAuthnPrecompileVerifier:
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_PRECOMPILE,
+			eip7212WebAuthnContractVerifier:
+				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_CONTRACT_VERIFIER,
 			webAuthnSignerFactory: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_FACTORY,
 			webAuthnSignerSingleton: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_SINGLETON,
 			webAuthnSignerProxyCreationCode:
 				SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SIGNER_PROXY_CREATION_CODE,
 			webAuthnSharedSigner: SafeMultiChainSigAccountV1.DEFAULT_WEB_AUTHN_SHARED_SIGNER,
 		};
-		const defaultOptions: SafeSignatureOptions = {
-			safe4337ModuleAddress: SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS,
-		};
 		if (userOperationsToSign.length === 1) {
 			return [
-				SafeAccount.formatSignaturesToUseroperationSignature(signerSignaturePairs, {
-					...defaultOptions,
-					...defaultWebAuthnOverrides,
-					...userOperationsToSign[0].options,
-					...userOperationsToSign[0].webAuthnSignatureOverrides,
-					validAfter: userOperationsToSign[0].validAfter,
-					validUntil: userOperationsToSign[0].validUntil,
-					isMultiChainSignature: true,
-				}),
+				SafeMultiChainSigAccountV1.formatSingleUserOperationSignature(
+					signerSignaturePairs,
+					{
+						...userOperationsToSign[0].options,
+						validAfter: userOperationsToSign[0].validAfter,
+						validUntil: userOperationsToSign[0].validUntil,
+					},
+					userOperationsToSign[0].webAuthnSignatureOverrides,
+				),
 			];
 		}
 		const userOperationsHashes: string[] = [];

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -548,7 +548,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 		} = {},
 	): string {
 		const data = this.getUserOperationEip712Data(useroperation, chainId, overrides);
-		return TypedDataEncoder.hash(data.domain, data.types, data.messageValue);
+		return hashTypedData(data.domain, data.types, data.messageValue);
 	}
 
 	/**

--- a/test/signer/signer.test.js
+++ b/test/signer/signer.test.js
@@ -709,6 +709,38 @@ describe('SafeMultiChainSigAccountV1 signUserOperationWithSigners', () => {
         expect(hash).toBe(refHash);
     });
 
+    test('instance manual helpers inherit multichain account context', () => {
+        const customModule = '0x3333333333333333333333333333333333333333';
+        const customSafe = new ak.SafeMultiChainSigAccountV1(safe.accountAddress, {
+            safe4337ModuleAddress: customModule,
+        });
+        const customOp = buildSafeMultiChainOp(customSafe);
+        const typedData = customSafe.getUserOperationEip712Data(customOp, CHAIN_ID);
+
+        expect(typedData.domain.verifyingContract).toBe(customModule);
+        expect(typedData.messageValue.entryPoint).toBe(customSafe.entrypointAddress);
+        expect(customSafe.getUserOperationEip712Hash(customOp, CHAIN_ID)).toBe(
+            ak.SafeMultiChainSigAccountV1.getUserOperationEip712Hash(customOp, CHAIN_ID, {
+                entrypointAddress: customSafe.entrypointAddress,
+                safe4337ModuleAddress: customModule,
+            }),
+        );
+    });
+
+    test('instance manual formatter emits the same single-op multichain signature as signUserOperation', () => {
+        const wallet = new Wallet(PK1);
+        const digest = safe.getUserOperationEip712Hash(op, CHAIN_ID);
+        const signature = wallet.signingKey.sign(digest).serialized;
+        const manual = safe.formatUserOperationSignature([{ signer: wallet.address, signature }]);
+
+        expect(manual).toBe(safe.signUserOperation(op, [PK1], CHAIN_ID));
+        expect(manual).not.toBe(
+            ak.SafeAccountV0_3_0.formatSignaturesToUseroperationSignature([
+                { signer: wallet.address, signature },
+            ]),
+        );
+    });
+
     test('getMultiChainSingleSignatureUserOperationsEip712Hash length=2 returns the Merkle wrapper digest (distinct from any per-op hash)', () => {
         const op2 = { ...op, nonce: 1n };
         const ops = [

--- a/test/types/signer-api.ts
+++ b/test/types/signer-api.ts
@@ -4,6 +4,7 @@ import {
 	fromSafeWebauthn,
 	type ExternalSigner,
 	type MultiOpSignContext,
+	SafeMultiChainSigAccountV1,
 	type SignContext,
 	type TypedData,
 	type UserOperationV9,
@@ -95,3 +96,26 @@ const webauthnSigner: ExternalSigner<unknown> = fromSafeWebauthn({
 	}),
 });
 void webauthnSigner;
+
+const safe = SafeMultiChainSigAccountV1.initializeNewAccount([address]);
+const userOperationV9: UserOperationV9 = {
+	sender: address,
+	nonce: 0n,
+	factory: null,
+	factoryData: null,
+	callData: "0x",
+	callGasLimit: 1n,
+	verificationGasLimit: 1n,
+	preVerificationGas: 1n,
+	maxFeePerGas: 1n,
+	maxPriorityFeePerGas: 1n,
+	paymaster: null,
+	paymasterVerificationGasLimit: null,
+	paymasterPostOpGasLimit: null,
+	paymasterData: null,
+	signature: "0x",
+	eip7702Auth: null,
+};
+void safe.estimateUserOperationGas(userOperationV9, "http://localhost:4337", {
+	expectedSigners: [address],
+});


### PR DESCRIPTION
## Summary
- add instance-level Safe manual signing helpers for EIP-712 data, hashes, and signature formatting
- make SafeMultiChainSigAccountV1 helpers inherit the account's entrypoint/module context and force multichain signature encoding
- cover the multichain manual signing path with regression tests

## Tests
- yarn build
- yarn test:signer
- yarn test:types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safe accounts: instance helpers to build EIP‑712 typed data, compute its hash, and format UserOperation signatures.
  * Multichain Safe accounts: single-operation signing, enforced multichain signature semantics, multichain-aware gas estimation, and sensible passkey/WebAuthn defaults.

* **Documentation**
  * Quickstart clarified that each account class has a default EntryPoint and when to override entrypointAddress.

* **Tests**
  * Added tests validating instance builders/formatters, multichain signing behavior, and gas estimation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->