### PR TITLE
Handle HTTP transport status errors

### DIFF
--- a/src/transport/HttpTransport.ts
+++ b/src/transport/HttpTransport.ts
@@ -67,6 +67,9 @@ export class HttpTransport extends BaseRpcTransport {
 			redirect: "follow",
 			signal: options?.signal,
 		});
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
 		return await response.json();
 	}
 }

--- a/test/transport/HttpTransport.test.js
+++ b/test/transport/HttpTransport.test.js
@@ -93,6 +93,13 @@ describe("HttpTransport", () => {
 		});
 	});
 
+	test("throws on non-2xx HTTP responses before parsing JSON-RPC", async () => {
+		const fetch = makeMockFetch(() => jsonResponse({ error: "rate limited" }, 429));
+		const t = new ak.HttpTransport("https://example.test/rpc", { fetch });
+
+		await expect(t.request({ method: "eth_chainId" })).rejects.toThrow("HTTP 429");
+	});
+
 	test("merges user-supplied headers and pins Content-Type", async () => {
 		const fetch = makeMockFetch(() => jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x" }));
 		const t = new ak.HttpTransport("https://example.test/rpc", {


### PR DESCRIPTION
Fixes HTTP transport handling for non-2xx responses.

`HttpTransport` previously parsed every fetch response as JSON-RPC regardless of the HTTP status. For responses like `429` or `500` with a non-JSON-RPC body, callers would get a misleading malformed JSON-RPC error instead of the HTTP failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * HTTP transport now validates response status before parsing the response body. Non-successful HTTP responses now generate clear error messages with the specific status code, preventing misleading parsing errors and improving error diagnostics.

* **Tests**
  * Added test coverage for HTTP error response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->