### PR TITLE
Decode UserOperation revert reasons and expose the EntryPoint AA code

### DIFF
--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -4,6 +4,7 @@ import {
 	type BundlerErrorCode,
 	BundlerErrorCodeDict,
 	ensureError,
+	parseAaCode,
 } from "./errors";
 import {
 	HttpTransport,
@@ -223,7 +224,6 @@ export class Bundler implements Transport {
 					res.receipt.effectiveGasPrice == null
 						? undefined
 						: BigInt(res.receipt.effectiveGasPrice),
-				logs: JSON.stringify(res.receipt.logs),
 			};
 
 			return {
@@ -231,7 +231,6 @@ export class Bundler implements Transport {
 				nonce: BigInt(res.nonce),
 				actualGasCost: BigInt(res.actualGasCost),
 				actualGasUsed: BigInt(res.actualGasUsed),
-				logs: JSON.stringify(res.logs),
 				receipt: userOperationReceipt,
 			};
 		} catch (err) {
@@ -287,6 +286,7 @@ function translateBundlerError(
 			cause: err,
 			errno: err.errno,
 			context,
+			aaCode: err.aaCode,
 		});
 	}
 	const code = (err as ProviderRpcError | undefined)?.code;
@@ -294,9 +294,13 @@ function translateBundlerError(
 	const innerCode: BundlerErrorCode | BasicErrorCode =
 		codeString in BundlerErrorCodeDict ? BundlerErrorCodeDict[codeString] : "UNKNOWN_ERROR";
 	const error = ensureError(err);
+	// The EntryPoint AAxx code lives only inside the message text. Parse it once
+	// here so callers can branch on a stable code instead of matching the message.
+	const aaCode = parseAaCode(error.message);
 	return new AbstractionKitError("BUNDLER_ERROR", `bundler ${method} rpc call failed`, {
-		cause: new AbstractionKitError(innerCode, error.message, { errno: code }),
+		cause: new AbstractionKitError(innerCode, error.message, { errno: code, aaCode }),
 		errno: code,
 		context,
+		aaCode,
 	});
 }

--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -82,7 +82,7 @@ export {
 	SAFE_FALLBACK_HANDLER_STORAGE_SLOT,
 	ZeroAddress,
 } from "./constants";
-export { AbstractionKitError } from "./errors";
+export { AbstractionKitError, parseAaCode } from "./errors";
 export { SafeAccountFactory } from "./factory/SafeAccountFactory";
 export { SmartAccountFactory } from "./factory/SmartAccountFactory";
 export { ExperimentalAllowAllParallelPaymaster } from "./paymaster/AllowAllPaymaster";
@@ -142,6 +142,7 @@ export type {
 	JsonRpcParam,
 	JsonRpcResponse,
 	JsonRpcResult,
+	Log,
 	MetaTransaction,
 	ParallelPaymasterInitValues,
 	SponsorInfo,
@@ -185,6 +186,8 @@ export {
 	getFunctionSelector,
 	sendJsonRpcRequest,
 } from "./utils";
+export type { UserOperationRevert } from "./userOperationRevert";
+export { decodeUserOperationRevertReason } from "./userOperationRevert";
 export type { Authorization7702, Authorization7702Hex } from "./utils7702";
 export {
 	createAndSignEip7702DelegationAuthorization,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -99,18 +99,25 @@ export class AbstractionKitError extends Error {
 	public readonly code: BundlerErrorCode | BasicErrorCode | JsonRpcErrorCode;
 	public readonly context?: Jsonable;
 	public readonly errno?: number;
+	/**
+	 * The EntryPoint FailedOp revert code parsed from the message (e.g. "AA21"),
+	 * when present. EntryPoint codes are contract-defined and stable across
+	 * bundlers, so they are a reliable signal for classifying a failure without
+	 * matching the human-readable message text.
+	 */
+	public readonly aaCode?: string;
 
 	/**
 	 * @param code - Error code identifying the category of failure
 	 * @param message - Human-readable error description
-	 * @param options - Optional cause, numeric errno, and JSON-serializable context
+	 * @param options - Optional cause, numeric errno, JSON-serializable context, and AAxx code
 	 */
 	constructor(
 		code: BundlerErrorCode | BasicErrorCode | JsonRpcErrorCode,
 		message: string,
-		options: { cause?: Error; errno?: number; context?: Jsonable } = {},
+		options: { cause?: Error; errno?: number; context?: Jsonable; aaCode?: string } = {},
 	) {
-		const { cause, errno, context } = options;
+		const { cause, errno, context, aaCode } = options;
 
 		super(message, { cause });
 		this.name = this.constructor.name;
@@ -118,17 +125,26 @@ export class AbstractionKitError extends Error {
 		this.code = code;
 		this.errno = errno;
 		this.context = context;
+		this.aaCode = aaCode;
 	}
 
 	/**
 	 * Returns a JSON string representation of this error including name, code,
-	 * message, cause, errno, and context. Useful in React Native where the
-	 * Error "cause" property is not shown in stack traces.
+	 * message, cause, errno, context, and aaCode. Useful in React Native where
+	 * the Error "cause" property is not shown in stack traces.
 	 * @returns JSON string of the error
 	 */
 	stringify(): string {
-		return JSON.stringify(this, ["name", "code", "message", "cause", "errno", "context"]);
+		return JSON.stringify(this, ["name", "code", "message", "cause", "errno", "context", "aaCode"]);
 	}
+}
+
+/**
+ * Parse the EntryPoint FailedOp revert code (e.g. "AA21") from a bundler error
+ * message, if one is present. Returns the uppercased code or undefined.
+ */
+export function parseAaCode(message: string): string | undefined {
+	return message.match(/AA\d\d/i)?.[0].toUpperCase();
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,28 @@ export type UserOperationByHashResult = {
 	transactionHash: string | null;
 } | null;
 
+/** A single EVM event log, as returned by the node and bundler. */
+export type Log = {
+	/** Address of the contract that emitted the log */
+	address: string;
+	/** Indexed topics; topics[0] is the event signature hash */
+	topics: string[];
+	/** Non-indexed event data, ABI-encoded */
+	data: string;
+	/** Block number (hex), when present */
+	blockNumber?: string;
+	/** Hash of the block containing the log, when present */
+	blockHash?: string;
+	/** Hash of the transaction that produced the log, when present */
+	transactionHash?: string;
+	/** Transaction index in the block (hex), when present */
+	transactionIndex?: string;
+	/** Log index in the block (hex), when present */
+	logIndex?: string;
+	/** Whether the log was removed due to a chain reorg */
+	removed?: boolean;
+};
+
 /** On-chain transaction receipt for the bundle that included a UserOperation. */
 export type UserOperationReceipt = {
 	/** Hash of the block containing the transaction */
@@ -175,8 +197,8 @@ export type UserOperationReceipt = {
 	cumulativeGasUsed: bigint;
 	/** Gas used by this specific transaction */
 	gasUsed: bigint;
-	/** Encoded logs emitted during execution */
-	logs: string;
+	/** Logs emitted during the bundle transaction */
+	logs: Log[];
 	/** Bloom filter for the transaction logs */
 	logsBloom: string;
 	/** Hash of the bundle transaction */
@@ -205,8 +227,8 @@ export type UserOperationReceiptResult = {
 	actualGasUsed: bigint;
 	/** Whether the inner account execution succeeded */
 	success: boolean;
-	/** Encoded logs emitted during execution */
-	logs: string;
+	/** Logs emitted during this UserOperation's execution */
+	logs: Log[];
 	/** The underlying transaction receipt */
 	receipt: UserOperationReceipt;
 } | null;

--- a/src/userOperationRevert.ts
+++ b/src/userOperationRevert.ts
@@ -49,8 +49,17 @@ export function decodeUserOperationRevertReason(
 		return {reverted: false, outOfGas: false, revertData: "0x"};
 	}
 
+	// UserOperationRevertReason is indexed by userOpHash (topic[1]). A bundle can
+	// contain several reverted ops, so match this op's hash as well as the event
+	// topic; otherwise we could pick up another op's revert reason from the bundle
+	// logs. The guard keeps it working if a caller passes a receipt without the
+	// top-level userOpHash. (Inner-call logs of this op do not carry the hash and
+	// would have to be located by logIndex range, which is out of scope here.)
+	const userOpHash = (receipt as {userOpHash?: string}).userOpHash?.toLowerCase();
 	const log = collectLogs(receipt).find(
-		(l) => l?.topics?.[0]?.toLowerCase() === REVERT_REASON_TOPIC,
+		(l) =>
+			l?.topics?.[0]?.toLowerCase() === REVERT_REASON_TOPIC &&
+			(userOpHash == null || l?.topics?.[1]?.toLowerCase() === userOpHash),
 	);
 	if (log == null) {
 		return {reverted: true, outOfGas: false, revertData: "0x"};

--- a/src/userOperationRevert.ts
+++ b/src/userOperationRevert.ts
@@ -1,0 +1,96 @@
+import {decodeAbiParameters, id} from "./ethereUtils";
+import type {Log, UserOperationReceiptResult} from "./types";
+
+/**
+ * Why a mined UserOperation reverted, decoded from its receipt.
+ */
+export type UserOperationRevert = {
+	/** True when the receipt's `success` is false. */
+	reverted: boolean;
+	/**
+	 * The inner call left no revert data. Usually out-of-gas, though a bare
+	 * `revert()`/`assert` or a call to a non-contract also produce empty data.
+	 */
+	outOfGas: boolean;
+	/** Decoded `Error("...")` string, when the call reverted with a reason. */
+	errorMessage?: string;
+	/** Decoded `Panic(uint256)` code (0x11 overflow, 0x12 divide-by-zero, ...). */
+	panicCode?: number;
+	/** The raw revert data bytes, for custom errors or further decoding. */
+	revertData: string;
+};
+
+// EntryPoint event:
+//   UserOperationRevertReason(bytes32 userOpHash, address sender, uint256 nonce, bytes revertReason)
+const REVERT_REASON_TOPIC = id(
+	"UserOperationRevertReason(bytes32,address,uint256,bytes)",
+).toLowerCase();
+const ERROR_SELECTOR = "0x08c379a0"; // Error(string)
+const PANIC_SELECTOR = "0x4e487b71"; // Panic(uint256)
+
+/**
+ * Decode why a mined UserOperation reverted, using only its receipt.
+ *
+ * A receipt's `success: false` says the inner call reverted but not why. This
+ * reads the EntryPoint's `UserOperationRevertReason` log and decodes the revert
+ * data into a reason string, a panic code, or empty data (usually out-of-gas),
+ * with no extra RPC call.
+ *
+ * To be certain about out-of-gas (rather than a bare revert with no data), trace
+ * the bundle transaction with debug_traceTransaction or a simulation provider.
+ *
+ * @param receipt - A UserOperation receipt (non-null)
+ * @returns The decoded revert: reason string, panic code, or out-of-gas
+ */
+export function decodeUserOperationRevertReason(
+	receipt: NonNullable<UserOperationReceiptResult>,
+): UserOperationRevert {
+	if (receipt.success) {
+		return {reverted: false, outOfGas: false, revertData: "0x"};
+	}
+
+	const log = collectLogs(receipt).find(
+		(l) => l?.topics?.[0]?.toLowerCase() === REVERT_REASON_TOPIC,
+	);
+	if (log == null) {
+		return {reverted: true, outOfGas: false, revertData: "0x"};
+	}
+
+	// log.data is abi.encode(uint256 nonce, bytes revertReason)
+	const [, revertData] = decodeAbiParameters<[bigint, string]>(["uint256", "bytes"], log.data);
+	const data = revertData.toLowerCase();
+
+	if (data === "0x" || data === "") {
+		return {reverted: true, outOfGas: true, revertData: "0x"};
+	}
+	if (data.startsWith(ERROR_SELECTOR)) {
+		const [errorMessage] = decodeAbiParameters<[string]>(["string"], "0x" + data.slice(10));
+		return {reverted: true, outOfGas: false, errorMessage, revertData};
+	}
+	if (data.startsWith(PANIC_SELECTOR)) {
+		const [code] = decodeAbiParameters<[bigint]>(["uint256"], "0x" + data.slice(10));
+		return {reverted: true, outOfGas: false, panicCode: Number(code), revertData};
+	}
+	return {reverted: true, outOfGas: false, revertData};
+}
+
+/**
+ * Gather logs from the receipt. Logs are structured `Log[]`, but this also
+ * tolerates the legacy JSON-string form so it keeps working if a caller passes
+ * a receipt produced by an older SDK version.
+ */
+function collectLogs(receipt: NonNullable<UserOperationReceiptResult>): Log[] {
+	const out: Log[] = [];
+	const sources: unknown[] = [receipt.logs, receipt.receipt?.logs];
+	for (const src of sources) {
+		if (Array.isArray(src)) out.push(...(src as Log[]));
+		else if (typeof src === "string") {
+			try {
+				out.push(...(JSON.parse(src) as Log[]));
+			} catch {
+				/* ignore malformed legacy logs */
+			}
+		}
+	}
+	return out;
+}

--- a/test/userOperationRevert.test.js
+++ b/test/userOperationRevert.test.js
@@ -56,6 +56,24 @@ describe("decodeUserOperationRevertReason", () => {
 		const r = decodeUserOperationRevertReason(legacy);
 		expect(r.errorMessage).toBe("legacy");
 	});
+
+	it("picks this op's revert reason in a multi-op bundle", () => {
+		const mine = "0x" + "a".repeat(64);
+		const other = "0x" + "b".repeat(64);
+		const logFor = (hash, msg) => ({
+			topics: [REVERT_TOPIC, hash, "0xsender"],
+			data: coder.encode(["uint256", "bytes"], [0n, errorData(msg)]),
+		});
+		// The bundle reverted two ops; the other op's log comes first.
+		const receipt = {
+			success: false,
+			userOpHash: mine,
+			logs: [logFor(other, "other op error"), logFor(mine, "my op error")],
+			receipt: { logs: [], transactionHash: "0xtx" },
+		};
+		const r = decodeUserOperationRevertReason(receipt);
+		expect(r.errorMessage).toBe("my op error");
+	});
 });
 
 describe("parseAaCode", () => {

--- a/test/userOperationRevert.test.js
+++ b/test/userOperationRevert.test.js
@@ -1,0 +1,81 @@
+const { AbiCoder, id } = require("ethers");
+const ak = require("../dist/index.cjs");
+
+const { decodeUserOperationRevertReason, parseAaCode, AbstractionKitError } = ak;
+
+const coder = AbiCoder.defaultAbiCoder();
+const REVERT_TOPIC = id("UserOperationRevertReason(bytes32,address,uint256,bytes)");
+
+// Build a receipt whose UserOperationRevertReason log carries `revertReason` bytes.
+function receiptWithRevert(revertReason, success = false) {
+	const data = coder.encode(["uint256", "bytes"], [0n, revertReason]);
+	const log = { topics: [REVERT_TOPIC, "0xhash", "0xsender"], data };
+	return { success, logs: [log], receipt: { logs: [], transactionHash: "0xtx" } };
+}
+
+const errorData = (msg) => "0x08c379a0" + coder.encode(["string"], [msg]).slice(2);
+const panicData = (code) => "0x4e487b71" + coder.encode(["uint256"], [code]).slice(2);
+
+describe("decodeUserOperationRevertReason", () => {
+	it("decodes a revert reason string", () => {
+		const r = decodeUserOperationRevertReason(receiptWithRevert(errorData("ERC20: transfer amount exceeds balance")));
+		expect(r.reverted).toBe(true);
+		expect(r.outOfGas).toBe(false);
+		expect(r.errorMessage).toBe("ERC20: transfer amount exceeds balance");
+	});
+
+	it("decodes a panic code", () => {
+		const r = decodeUserOperationRevertReason(receiptWithRevert(panicData(0x11)));
+		expect(r.reverted).toBe(true);
+		expect(r.panicCode).toBe(0x11);
+		expect(r.errorMessage).toBeUndefined();
+	});
+
+	it("flags empty revert data as out-of-gas", () => {
+		const r = decodeUserOperationRevertReason(receiptWithRevert("0x"));
+		expect(r.reverted).toBe(true);
+		expect(r.outOfGas).toBe(true);
+	});
+
+	it("reports not reverted when success is true", () => {
+		const r = decodeUserOperationRevertReason({ success: true, logs: [], receipt: { logs: [] } });
+		expect(r.reverted).toBe(false);
+		expect(r.outOfGas).toBe(false);
+	});
+
+	it("reverted without a reason when there is no revert log", () => {
+		const r = decodeUserOperationRevertReason({ success: false, logs: [], receipt: { logs: [] } });
+		expect(r.reverted).toBe(true);
+		expect(r.outOfGas).toBe(false);
+		expect(r.errorMessage).toBeUndefined();
+	});
+
+	it("tolerates the legacy JSON-string logs form", () => {
+		const real = receiptWithRevert(errorData("legacy"));
+		const legacy = { success: false, logs: JSON.stringify(real.logs), receipt: { logs: "[]" } };
+		const r = decodeUserOperationRevertReason(legacy);
+		expect(r.errorMessage).toBe("legacy");
+	});
+});
+
+describe("parseAaCode", () => {
+	it("extracts an AAxx code", () => {
+		expect(parseAaCode("revert reason : AA21 didn't pay prefund")).toBe("AA21");
+	});
+
+	it("uppercases a lowercase code", () => {
+		expect(parseAaCode("aa24 signature error")).toBe("AA24");
+	});
+
+	it("returns undefined when there is no code", () => {
+		expect(parseAaCode("some unrelated bundler message")).toBeUndefined();
+	});
+});
+
+describe("AbstractionKitError.aaCode", () => {
+	it("carries the aaCode option", () => {
+		const err = new AbstractionKitError("SIMULATE_VALIDATION", "AA21 didn't pay prefund", { aaCode: "AA21" });
+		expect(err.aaCode).toBe("AA21");
+		expect(JSON.parse(err.stringify()).aaCode).toBe("AA21");
+	});
+});


### PR DESCRIPTION
Surfaces the decision-ready signals a wallet needs at the point a UserOperation fails, instead of leaving it to parse raw material.

- **`AbstractionKitError.aaCode`**: the EntryPoint FailedOp code (e.g. `AA21`) is parsed once and attached to the error (and its `.cause`), so callers branch on a stable, contract-defined code instead of regexing the message. Also exports `parseAaCode`.
- **`decodeUserOperationRevertReason(receipt)`**: reads the EntryPoint `UserOperationRevertReason` log from a mined receipt and returns `{ reverted, outOfGas, errorMessage?, panicCode?, revertData }`, with no extra RPC. Uses the SDK's own ABI decoder, no new dependency.

**BREAKING:** `UserOperationReceipt.logs` and `UserOperationReceiptResult.logs` are now structured `Log[]` instead of a JSON string. Callers that did `JSON.parse(receipt.logs)` should use the array directly (the decoder tolerates the old string form defensively).

Adds unit tests (`test/userOperationRevert.test.js`). Verified live on Arbitrum Sepolia: a real underfunded op carries `err.aaCode === 'AA21'`, and a real reverted receipt decodes to `ERC20: transfer amount exceeds balance`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Decode user-operation revert reasons from receipts to show root causes without extra network calls.
  * Receipt logs are now structured objects for clearer, richer event data.
  * Error reporting now surfaces extracted AAxx entrypoint codes for clearer diagnostics.

* **Tests**
  * Added comprehensive tests covering revert decoding, AA code extraction, and enhanced error serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->