### PR TITLE
fix verificationGasLimit multiplier for v6

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -639,7 +639,7 @@ export function calculateUserOperationMaxGasCost(
 	if ("initCode" in useroperation) {
 		const isPaymasterAndData =
 			useroperation.paymasterAndData !== "0x" && useroperation.paymasterAndData != null;
-		const mul = isPaymasterAndData ? 3n : 0n;
+		const mul = isPaymasterAndData ? 3n : 1n;
 		const requiredGas =
 			useroperation.callGasLimit +
 			useroperation.verificationGasLimit * mul +


### PR DESCRIPTION
## Summary
fix calculateUserOperationMaxGasCost verificationGasLimit multiplier for v6 