### PR TITLE
Fix min token cost

### DIFF
--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -661,7 +661,8 @@ export class CandidePaymaster extends Paymaster implements Transport {
 
 				const exchangeRate = await this.fetchTokenPaymasterExchangeRate(context.token, entrypoint);
 				const gasCostWei = calculateUserOperationMaxGasCost(userOp);
-				const tokenCost = (exchangeRate * gasCostWei) / 10n ** 18n;
+				let tokenCost = (exchangeRate * gasCostWei) / 10n ** 18n;
+				if (tokenCost === 0n) tokenCost = 1n;
 				tokenQuote = { token: context.token, exchangeRate, tokenCost };
 				const approveAmount = tokenCost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
 				callDataWithApprove = smartAccount.prependTokenPaymasterApproveToCallData(
@@ -723,7 +724,8 @@ export class CandidePaymaster extends Paymaster implements Transport {
 				entrypoint,
 			);
 			const cost = calculateUserOperationMaxGasCost(userOperation);
-			return (exchangeRate * cost) / BigInt(10 ** 18);
+			const tokenCost = (exchangeRate * cost) / BigInt(10 ** 18);
+			return tokenCost === 0n ? 1n : tokenCost;
 		} catch (err) {
 			const error = ensureError(err);
 

--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -724,7 +724,7 @@ export class CandidePaymaster extends Paymaster implements Transport {
 				entrypoint,
 			);
 			const cost = calculateUserOperationMaxGasCost(userOperation);
-			const tokenCost = (exchangeRate * cost) / BigInt(10 ** 18);
+			const tokenCost = (exchangeRate * cost) / 10n ** 18n;
 			return tokenCost === 0n ? 1n : tokenCost;
 		} catch (err) {
 			const error = ensureError(err);
@@ -773,9 +773,15 @@ export class CandidePaymaster extends Paymaster implements Transport {
 						},
 					},
 				);
-			} else {
-				return BigInt(gasToken.exchangeRate);
 			}
+			const exchangeRate = BigInt(gasToken.exchangeRate);
+			if (exchangeRate <= 0n) {
+				throw new AbstractionKitError(
+					"PAYMASTER_ERROR",
+					`pm_supportedERC20Tokens returned a non-positive exchangeRate for token ${erc20TokenAddress} (got ${exchangeRate})`,
+				);
+			}
+			return exchangeRate;
 		} catch (err) {
 			const error = ensureError(err);
 

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -41,6 +41,22 @@ const TOKENS_REQUIRING_ALLOWANCE_RESET: string[] = [
 const CANDIDE_TOKEN_QUOTE_TTL_MS = 45_000;
 
 /**
+ * Parse a raw exchange-rate value (bigint or hex/decimal string) into a
+ * positive bigint. Returns `null` if the value is missing, unparseable, or
+ * `<= 0` — callers throw with their own RPC-method-specific error context.
+ */
+function parsePositiveExchangeRate(raw: string | bigint | undefined | null): bigint | null {
+	if (raw == null) return null;
+	let value: bigint;
+	try {
+		value = BigInt(raw);
+	} catch {
+		return null;
+	}
+	return value > 0n ? value : null;
+}
+
+/**
  * Opaque context object forwarded to the paymaster RPC as the fourth argument
  * of `pm_getPaymasterStubData` / `pm_getPaymasterData`.
  *
@@ -52,9 +68,11 @@ const CANDIDE_TOKEN_QUOTE_TTL_MS = 45_000;
  * ## Reserved fields consumed by this class (not forwarded to the RPC)
  *
  * - `exchangeRate` - token-to-ETH exchange rate as a bigint or hex/decimal
- *   string, scaled by 10^18 (i.e. the value of 1 ETH expressed in the token's
- *   smallest unit). Used to calculate the ERC-20 approval amount when no
- *   provider is auto-detected. Not needed when `provider` is `"pimlico"` or
+ *   string. Represents the count of token smallest-units equivalent to 1 ETH
+ *   (10^18 wei) — e.g. for USDC ($1, 6 decimals) at $3000/ETH this is
+ *   `3000 * 10^6 = 3e9`. Used to calculate the ERC-20 approval amount when no
+ *   provider is auto-detected (floored to a minimum of 1 token smallest-unit
+ *   to handle cheap-gas chains). Not needed when `provider` is `"pimlico"` or
  *   `"candide"`; the class fetches the rate from the provider's RPC.
  */
 export type Erc7677Context = Record<string, unknown>;
@@ -566,9 +584,12 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 	 * Fetch token exchange rate and paymaster address via Pimlico's
 	 * `pimlico_getTokenQuotes` RPC.
 	 *
-	 * @returns `exchangeRate` as a bigint scaled by 10^18 (the value of 1 ETH
-	 *   expressed in the token's smallest unit). Used to compute the token
-	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`.
+	 * @returns `exchangeRate` as a bigint: the count of token smallest-units
+	 *   equivalent to 1 ETH (10^18 wei). E.g. for USDC ($1, 6 decimals) at
+	 *   $3000/ETH this is `3000 * 10^6 = 3e9`. Used to compute the token
+	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`, floored to
+	 *   a minimum of 1 token smallest-unit (see
+	 *   {@link Erc7677Paymaster.tokenFlow}).
 	 */
 	private async fetchPimlicoTokenQuote(
 		tokenAddress: string,
@@ -594,8 +615,15 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 				`pimlico_getTokenQuotes did not include token ${tokenAddress}`,
 			);
 		}
+		const exchangeRate = parsePositiveExchangeRate(quote.exchangeRate);
+		if (exchangeRate == null) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`pimlico_getTokenQuotes returned a non-positive exchangeRate for token ${tokenAddress} (got ${String(quote.exchangeRate)})`,
+			);
+		}
 		return {
-			exchangeRate: BigInt(quote.exchangeRate),
+			exchangeRate,
 			paymasterAddress: quote.paymaster,
 		};
 	}
@@ -635,9 +663,12 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 	 * Fetch token exchange rate and paymaster address via Candide's
 	 * `pm_supportedERC20Tokens` RPC.
 	 *
-	 * @returns `exchangeRate` as a bigint scaled by 10^18 (the value of 1 ETH
-	 *   expressed in the token's smallest unit). Used to compute the token
-	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`.
+	 * @returns `exchangeRate` as a bigint: the count of token smallest-units
+	 *   equivalent to 1 ETH (10^18 wei). E.g. for USDC ($1, 6 decimals) at
+	 *   $3000/ETH this is `3000 * 10^6 = 3e9`. Used to compute the token
+	 *   approval amount via `(exchangeRate * gasCostWei) / 10^18`, floored to
+	 *   a minimum of 1 token smallest-unit (see
+	 *   {@link Erc7677Paymaster.tokenFlow}).
 	 */
 	private async fetchCandideTokenQuote(
 		tokenAddress: string,
@@ -654,8 +685,15 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 				`${tokenAddress} token is not supported by the Candide paymaster`,
 			);
 		}
+		const exchangeRate = parsePositiveExchangeRate(token.exchangeRate);
+		if (exchangeRate == null) {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				`pm_supportedERC20Tokens returned a non-positive exchangeRate for token ${tokenAddress} (got ${String(token.exchangeRate)})`,
+			);
+		}
 		return {
-			exchangeRate: BigInt(token.exchangeRate),
+			exchangeRate,
 			paymasterAddress: result.paymasterMetadata.address,
 		};
 	}

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -825,7 +825,8 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 
 		// Step 5 — calculate real token cost.
 		const maxGasCostWei = calculateUserOperationMaxGasCost(userOp);
-		const tokenCost = (exchangeRate * maxGasCostWei) / 10n ** 18n;
+		let tokenCost = (exchangeRate * maxGasCostWei) / 10n ** 18n;
+		if (tokenCost === 0n) tokenCost = 1n;
 		const approveAmount = tokenCost * TOKEN_APPROVE_AMOUNT_MULTIPLIER;
 		const tokenQuote: TokenQuote = { token: tokenAddress, exchangeRate, tokenCost };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,9 +252,16 @@ export type SponsorMetadata = {
 export type TokenQuote = {
 	/** ERC-20 token contract address used to pay gas */
 	token: string;
-	/** Exchange rate scaled by 10^18 (1 ETH expressed in the token's smallest unit) */
+	/**
+	 * Count of token smallest-units equivalent to 1 ETH (10^18 wei). E.g. for
+	 * USDC ($1, 6 decimals) at $3000/ETH this is `3000 * 10^6 = 3e9`.
+	 */
 	exchangeRate: bigint;
-	/** Maximum token cost charged for this UserOperation (token's smallest unit) */
+	/**
+	 * Maximum token cost charged for this UserOperation, in the token's
+	 * smallest unit. Computed as `(exchangeRate * maxGasCostWei) / 10^18` and
+	 * floored to a minimum of `1n` so cheap-gas chains never quote `0n`.
+	 */
 	tokenCost: bigint;
 };
 

--- a/test/paymaster/erc7677Paymaster.test.js
+++ b/test/paymaster/erc7677Paymaster.test.js
@@ -944,6 +944,127 @@ describe('Erc7677Paymaster', () => {
     }
   });
 
+  // ── Token paymaster flow: sub-unit cost clamps to 1 ────────────────
+
+  test('sub-unit tokenCost clamps to 1n (cheap-gas chain scenario)', async () => {
+    // Reproduces the round-to-zero footgun on cheap-gas / low-rate chains:
+    // when (exchangeRate * maxGasCostWei) < 10^18, floor division would give
+    // 0n and the paymaster approval would also be 0n. The clamp at
+    // Erc7677Paymaster.ts:828 forces a minimum of 1 token smallest-unit.
+    const PAYMASTER_ADDR = '0x' + 'ee'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'ff'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_getPaymasterStubData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xstub',
+        paymasterVerificationGasLimit: '0x8000',
+        paymasterPostOpGasLimit: '0xa000',
+      }),
+      eth_estimateUserOperationGas: () => ({
+        callGasLimit: '0x1000',
+        verificationGasLimit: '0x2000',
+        preVerificationGas: '0x3000',
+      }),
+      pm_getPaymasterData: () => ({
+        paymaster: PAYMASTER_ADDR,
+        paymasterData: '0xfinal',
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: null });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+      // maxFeePerGas = 1n keeps maxGasCostWei tiny (~ requiredGas wei). With
+      // exchangeRate = 1n the numerator is ~1e5 < 1e18, so floor gives 0n.
+      const userOp = v7UserOp({ maxFeePerGas: 1n, maxPriorityFeePerGas: 1n });
+
+      const { tokenQuote } = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        server.url,
+        { token: TOKEN_ADDR, exchangeRate: 1n },
+      );
+
+      // Clamp fired: tokenCost is exactly 1n (not 0n, not "> 0n").
+      expect(tokenQuote.tokenCost).toBe(1n);
+
+      // approveAmount on the second prepend call = tokenCost * MULTIPLIER (= 2n).
+      // First call is approve(MAX) for gas estimation; second is the real one.
+      const realApproveCall = smartAccount.calls[smartAccount.calls.length - 1];
+      expect(realApproveCall.approveAmount).toBe(2n);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('Case A: non-positive exchangeRate from RPC throws', async () => {
+    const PAYMASTER_ADDR = '0x' + 'aa'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'bb'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pimlico_getTokenQuotes: () => ({
+        quotes: [{
+          paymaster: PAYMASTER_ADDR,
+          token: TOKEN_ADDR,
+          exchangeRate: '0x0',
+        }],
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'pimlico' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: TOKEN_ADDR },
+        ),
+      ).rejects.toThrow(/non-positive exchangeRate/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('Case B: non-positive exchangeRate from RPC throws', async () => {
+    const PAYMASTER_ADDR = '0x' + 'cc'.repeat(20);
+    const TOKEN_ADDR = '0x' + 'dd'.repeat(20);
+
+    const server = await makeMockRpcServer({
+      pm_supportedERC20Tokens: () => ({
+        tokens: [{ address: TOKEN_ADDR, exchangeRate: '0x0' }],
+        paymasterMetadata: {
+          address: PAYMASTER_ADDR,
+          dummyPaymasterAndData: {
+            paymaster: PAYMASTER_ADDR,
+            paymasterVerificationGasLimit: '0x8000',
+            paymasterPostOpGasLimit: '0xa000',
+            paymasterData: '0xdummy',
+          },
+        },
+      }),
+    });
+
+    try {
+      const paymaster = new Erc7677Paymaster(server.url, { chainId: CHAIN_ID, provider: 'candide' });
+      const smartAccount = makeTokenAccount(ENTRYPOINT_V7);
+
+      await expect(
+        paymaster.createPaymasterUserOperation(
+          smartAccount,
+          v7UserOp(),
+          server.url,
+          { token: TOKEN_ADDR },
+        ),
+      ).rejects.toThrow(/non-positive exchangeRate/);
+    } finally {
+      await server.close();
+    }
+  });
+
   // ── Token paymaster flow: USDT allowance reset ──────────────────────
 
   test('USDT-like token gets approve(0) prepended', async () => {


### PR DESCRIPTION
## Summary

fix: tokenCost can be zero if gas cost always is less than one whole)[fix: tokenCost can be zero if gas cost always is less than one whole token base unit