### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,33 @@
 
 ## [UNRELEASED]
 
+## 0.4.0
+
 ### New Features
 
 - **Safe ERC-4337 module migration helpers.** `SafeAccountV0_3_0.createMigrateToSafeMultiChainSigAccountV1MetaTransactions(nodeRpcUrl, overrides?)` builds the `disableModule` + `enableModule` + `setFallbackHandler` batch that migrates a deployed Safe from the EntryPoint v0.7 module to the v0.9 `Safe4337MultiChainSignatureModule`. Both modules are stateless, so no storage clearing is required. Unless `{ skipPreflight: true }` is passed, it first verifies on-chain that the account is actually a Safe running the old module (the module is enabled **and** is the current fallback handler) on a Safe version `>= 1.4.1`, turning a would-be cryptic on-chain `AA23`/`AA24` into a clear up-front error.
 - **New Safe / transport readers.** `SafeAccount.getFallbackHandler(nodeRpcUrl)` (the active 4337 module), `SafeAccount.getSafeVersion(nodeRpcUrl)` (reads `VERSION()`), `JsonRpcNode.getStorageAt(address, slot, blockTag?)`, and the exported `SAFE_FALLBACK_HANDLER_STORAGE_SLOT` constant.
+- **Safe instance manual signing helpers.** `SafeAccount` and `SafeMultiChainSigAccount` expose instance-level manual signing helpers that match the existing static EIP-712 helper API, so apps that already hold a Safe instance can sign without re-deriving the static call surface.
+- **UserOperation revert-reason decoding and AA-code parsing.** New `decodeUserOperationRevertReason(receipt)` reads the EntryPoint `UserOperationRevertReason` log directly from a mined receipt and returns the decoded reason (Error string, Panic code, or empty for likely out-of-gas) with no extra RPC call, matching the receipt's `userOpHash` so multi-op bundles return the right entry. EntryPoint `AAxx` revert codes (e.g. `AA21`) are parsed into `AbstractionKitError.aaCode` so callers can branch on a stable contract-defined code instead of message-text matching. `UserOperationRevert` type and `parseAaCode` helper are exported.
+- **`ethers` runtime dependency removed.** Account, paymaster, transport, signer, and utility surfaces now use an internal `ethereUtils` module for ABI encoding/decoding, keccak/hashing, typed-data, and `BigInt`-safe helpers, shrinking the install footprint. Public API shapes are unchanged.
+
+### Breaking Changes
+
+- **`UserOperationReceipt.logs` and `UserOperationReceiptResult.logs` are now structured `Log[]`** instead of a JSON-encoded string. Callers that previously did `JSON.parse(receipt.logs)` should drop the parse and read the array directly:
+  ```ts
+  // Before
+  const logs = JSON.parse(receipt.logs);
+
+  // After
+  const logs = receipt.logs;
+  ```
 
 ### Bug Fixes
 
 - **`SafeAccountV0_2_0.createMigrateToSafeAccountV0_3_0MetaTransactions` predecessor wiring.** When `safeV06ModuleAddress` was set explicitly, the v0.6 → v0.7 migration passed the module being disabled as its own linked-list predecessor, producing `disableModule(prev = module, module)`. It now exposes a dedicated `prevModuleAddress` override (defaulting to the on-chain lookup) and shares the generic migration implementation. Default callers are unaffected.
+- **v0.6 `verificationGasLimit` multiplier in `calculateUserOperationMaxGasCost`.** The paymaster multiplier was applied to the wrong factor on v0.6 UserOperations, undercounting the maximum gas cost. Fixed.
+- **ERC-7677 / Candide paymaster `tokenCost` rounds-to-zero on cheap-gas chains.** On chains where `exchangeRate * maxGasCostWei < 10^18`, the floor division collapsed `tokenCost` to `0n` and the prepended ERC-20 approval was also `0n`, causing the UserOperation to revert or the paymaster to absorb the full cost. The two `Erc7677Paymaster` / `CandidePaymaster` cost paths and the public `calculateUserOperationErc20TokenMaxGasCost` helper now floor `tokenCost` to a minimum of `1` token smallest-unit. `pimlico_getTokenQuotes` and `pm_supportedERC20Tokens` responses with a non-positive `exchangeRate` now throw `PAYMASTER_ERROR` instead of silently feeding a zero rate into the math.
+- **Tenderly API key masked in error context.** `callTenderlySimulateBundle` errors no longer surface the raw access key in their context payload.
 
 ## 0.3.8
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest stable version published to npm is supported with security updat
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.8   | :white_check_mark: |
+| 0.4.0   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.3.8",
+	"version": "0.4.0",
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -3442,7 +3442,7 @@ function generateOnChainIdentifier(
 	project: string,
 	platform: "Web" | "Mobile" | "Safe App" | "Widget" = "Web",
 	tool: string = "abstractionkit",
-	toolVersion: string = "0.3.8",
+	toolVersion: string = "0.4.0",
 ): string {
 	const identifierPrefix = "5afe"; // Safe identifier prefix
 	const identifierVersion = "00"; // First version


### PR DESCRIPTION
  ## Changelog coverage
  - Drop `ethers` runtime dependency; switch internal call surface to `ethereUtils` (#185)
  - Mask Tenderly access key in error context to avoid leaking secrets (#186)
  - Safe instance manual signing helpers on `SafeAccount` and `SafeMultiChainSigAccount` (#190)
  - Safe 4337 module migration helpers (`SafeAccountV0_3_0.createMigrateToSafeMultiChainSigAccountV1MetaTransactions`), `SafeAccount.getFallbackHandler` / `getSafeVersion`,
  `JsonRpcNode.getStorageAt`, `SAFE_FALLBACK_HANDLER_STORAGE_SLOT` export, plus the v0.6 → v0.7 `prevModuleAddress` wiring fix (#191)
  - Decode UserOperation revert reasons (`decodeUserOperationRevertReason`, `UserOperationRevert`) and parse EntryPoint `AAxx` codes into `AbstractionKitError.aaCode` (#193,
  breaking: `UserOperationReceipt.logs` is now `Log[]`)
  - Fix `verificationGasLimit` multiplier in `calculateUserOperationMaxGasCost` for v0.6 UserOperations (#194)
  - Clamp ERC-7677 / Candide paymaster `tokenCost` to a minimum of 1 token smallest-unit and reject non-positive `exchangeRate` responses, fixing rounds-to-zero on cheap-gas chains
  (#195)

  ## Verification
  - yarn build
  - yarn test:types
  - yarn test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Safe ERC-4337 module migration helpers
  * Added Safe and transport readers
  * Added instance manual signing helpers
  * Added EntryPoint revert-reason and AA-code decoding

* **Bug Fixes**
  * Fixed module migration predecessor wiring
  * Corrected v0.6 gas limit calculations
  * Improved token-cost rounding and exchange-rate handling
  * Enhanced error context security

* **Breaking Changes**
  * User operation receipt logs format changed from JSON strings to structured arrays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->