### PR TITLE
fix(compat): drop Buffer and TextDecoder for browser/React Native support

### DIFF
--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -1,7 +1,7 @@
 import {
 	decodeAbiParameters,
 	encodeAbiParameters,
-	fromUtf8Bytes,
+	hexlify,
 	keccak256,
 	privateKeyToAddress,
 	signHash,
@@ -1427,7 +1427,10 @@ export class Calibur7702Account
 		const decodedTransactions: SimpleMetaTransaction[] = existingCalls.map((call) => ({
 			to: call[0],
 			value: BigInt(call[1]),
-			data: typeof call[2] !== "string" ? fromUtf8Bytes(call[2]) : call[2],
+			// call[2] is the inner transaction calldata (binary). When the ABI
+			// decoder hands it back as bytes, hex-encode it (do NOT UTF-8 decode,
+			// which would corrupt the selector/arguments).
+			data: typeof call[2] !== "string" ? hexlify(call[2]) : call[2],
 		}));
 
 		// Prepend approve

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -1,6 +1,7 @@
 import {
 	decodeAbiParameters,
 	encodeAbiParameters,
+	fromUtf8Bytes,
 	keccak256,
 	privateKeyToAddress,
 	signHash,
@@ -1426,7 +1427,7 @@ export class Calibur7702Account
 		const decodedTransactions: SimpleMetaTransaction[] = existingCalls.map((call) => ({
 			to: call[0],
 			value: BigInt(call[1]),
-			data: typeof call[2] !== "string" ? new TextDecoder().decode(call[2]) : call[2],
+			data: typeof call[2] !== "string" ? fromUtf8Bytes(call[2]) : call[2],
 		}));
 
 		// Prepend approve

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -11,6 +11,7 @@ import {
 	signHash,
 	solidityPacked,
 	solidityPackedKeccak256,
+	toUtf8Bytes,
 } from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {AbstractionKitError, ensureError} from "src/errors";
@@ -3462,17 +3463,16 @@ function generateOnChainIdentifier(
 ): string {
 	const identifierPrefix = "5afe"; // Safe identifier prefix
 	const identifierVersion = "00"; // First version
-	const projectHash = keccak256(`0x${Buffer.from(project, "utf8").toString("hex")}`).slice(-20);
-	const platformHash = keccak256(`0x${Buffer.from(platform, "utf8").toString("hex")}`).slice(-3);
-	const toolHash = keccak256(`0x${Buffer.from(tool, "utf8").toString("hex")}`).slice(-3);
-	const toolVersionHash = keccak256(`0x${Buffer.from(toolVersion, "utf8").toString("hex")}`).slice(
-		-3,
-	);
+	const projectHash = keccak256(hexlify(toUtf8Bytes(project))).slice(-20);
+	const platformHash = keccak256(hexlify(toUtf8Bytes(platform))).slice(-3);
+	const toolHash = keccak256(hexlify(toUtf8Bytes(tool))).slice(-3);
+	const toolVersionHash = keccak256(hexlify(toUtf8Bytes(toolVersion))).slice(-3);
 
-	const projectHashEncoded = Buffer.from(projectHash, "utf8").toString("hex");
-	const platformHashEncoded = Buffer.from(platformHash, "utf8").toString("hex");
-	const toolHashEncoded = Buffer.from(toolHash, "utf8").toString("hex");
-	const toolVersionHashEncoded = Buffer.from(toolVersionHash, "utf8").toString("hex");
+	// hex of the UTF-8 bytes, no 0x prefix (Buffer is undefined in browsers / React Native)
+	const projectHashEncoded = hexlify(toUtf8Bytes(projectHash)).slice(2);
+	const platformHashEncoded = hexlify(toUtf8Bytes(platformHash)).slice(2);
+	const toolHashEncoded = hexlify(toUtf8Bytes(toolHash)).slice(2);
+	const toolVersionHashEncoded = hexlify(toUtf8Bytes(toolVersionHash)).slice(2);
 
 	const res = `${identifierPrefix}${identifierVersion}${projectHashEncoded}${platformHashEncoded}${toolHashEncoded}${toolVersionHashEncoded}`;
 	return res;

--- a/src/account/Safe/adapters.ts
+++ b/src/account/Safe/adapters.ts
@@ -1,4 +1,4 @@
-import { getBytes, hexlify } from "../../ethereUtils";
+import { fromUtf8Bytes, getBytes, hexlify, toUtf8Bytes } from "../../ethereUtils";
 import type { Signer } from "src/signer/types";
 import { SafeAccount } from "./SafeAccount";
 import type { WebauthnPublicKey, WebauthnSignatureData } from "./types";
@@ -389,8 +389,8 @@ function toArrayBuffer(input: ArrayBuffer | Uint8Array | string): ArrayBuffer {
 function toUtf8String(input: ArrayBuffer | Uint8Array | string): string {
 	if (typeof input === "string") return input;
 	const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
-	// TextDecoder is available in all modern browsers and Node 11+.
-	return new TextDecoder("utf-8").decode(bytes);
+	// Pure-JS decode so it works in React Native / Hermes too (no TextDecoder there).
+	return fromUtf8Bytes(bytes);
 }
 
 function toRSPair(
@@ -415,8 +415,8 @@ function toRSPair(
  * Robust to authenticators adding or reordering keys (e.g. Safari's
  * `crossOrigin`, future WebAuthn L3 fields) — parses JSON instead of
  * using a regex, validates the shape is a plain object, and emits hex
- * via `TextEncoder` (browser-safe; `Buffer` isn't defined in Vite /
- * Rollup / esbuild bundles without a polyfill).
+ * via the pure-JS `toUtf8Bytes` (works in browsers and React Native /
+ * Hermes; neither `Buffer` nor `TextEncoder` is defined there by default).
  */
 function extractClientDataFieldsHex(clientDataJSON: string): string {
 	let parsed: unknown;
@@ -440,7 +440,7 @@ function extractClientDataFieldsHex(clientDataJSON: string): string {
 	// `hexlify` mirrors what the prior hand-rolled hex loop produced —
 	// each byte gets exactly 2 lowercase hex chars, no separators, `0x`
 	// prefix. Confirmed identical for all input sizes via the test suite.
-	return hexlify(new TextEncoder().encode(fields));
+	return hexlify(toUtf8Bytes(fields));
 }
 
 /**

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -342,27 +342,72 @@ export function toUtf8Bytes(str: string): Uint8Array {
 /**
  * Decode UTF-8 bytes to a string. Pure JS so it works in every runtime,
  * including React Native / Hermes where `TextDecoder` is not defined by default.
- * Mirrors the encoder above; handles 1- to 4-byte sequences (surrogate pairs).
+ * Validates the encoding like `TextDecoder` in its default (non-fatal) mode:
+ * invalid lead bytes, missing/ malformed continuation bytes, overlong
+ * encodings, surrogate-range code points (U+D800..U+DFFF) and values above
+ * U+10FFFF are replaced with U+FFFD rather than being coerced into other
+ * characters. Never reads past the end of the buffer.
  */
 export function fromUtf8Bytes(bytes: Uint8Array): string {
     let result = "";
     let i = 0;
-    while (i < bytes.length) {
+    const n = bytes.length;
+    while (i < n) {
         const b0 = bytes[i++];
         if (b0 < 0x80) {
             result += String.fromCharCode(b0);
-        } else if (b0 >= 0xc0 && b0 < 0xe0) {
-            const b1 = bytes[i++] & 0x3f;
-            result += String.fromCharCode(((b0 & 0x1f) << 6) | b1);
-        } else if (b0 >= 0xe0 && b0 < 0xf0) {
-            const b1 = bytes[i++] & 0x3f;
-            const b2 = bytes[i++] & 0x3f;
-            result += String.fromCharCode(((b0 & 0x0f) << 12) | (b1 << 6) | b2);
+            continue;
+        }
+        // Sequence length, initial code-point bits, and the allowed range for
+        // the FIRST continuation byte. The tighter first-byte range is what
+        // rejects overlong encodings (0xe0/0xf0), surrogates (0xed) and code
+        // points above U+10FFFF (0xf4) at the earliest byte, matching the
+        // WHATWG / TextDecoder algorithm (including how many U+FFFD it emits).
+        let needed: number;
+        let cp: number;
+        let lower = 0x80;
+        let upper = 0xbf;
+        if (b0 >= 0xc2 && b0 <= 0xdf) {
+            needed = 1;
+            cp = b0 & 0x1f;
+        } else if (b0 >= 0xe0 && b0 <= 0xef) {
+            needed = 2;
+            cp = b0 & 0x0f;
+            if (b0 === 0xe0) lower = 0xa0;
+            else if (b0 === 0xed) upper = 0x9f;
+        } else if (b0 >= 0xf0 && b0 <= 0xf4) {
+            needed = 3;
+            cp = b0 & 0x07;
+            if (b0 === 0xf0) lower = 0x90;
+            else if (b0 === 0xf4) upper = 0x8f;
         } else {
-            const b1 = bytes[i++] & 0x3f;
-            const b2 = bytes[i++] & 0x3f;
-            const b3 = bytes[i++] & 0x3f;
-            const cp = (((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3) - 0x10000;
+            // 0x80..0xc1 (continuation byte as lead, or overlong 2-byte lead)
+            // and 0xf5..0xff (would exceed U+10FFFF) are never valid leads.
+            result += "\ufffd";
+            continue;
+        }
+        let valid = true;
+        for (let k = 0; k < needed; k++) {
+            const lo = k === 0 ? lower : 0x80;
+            const hi = k === 0 ? upper : 0xbf;
+            // Truncated, or a byte outside the allowed continuation range: emit
+            // one U+FFFD and leave the offending byte unconsumed so it is
+            // reprocessed as a fresh lead byte.
+            if (i >= n || bytes[i] < lo || bytes[i] > hi) {
+                valid = false;
+                break;
+            }
+            cp = (cp << 6) | (bytes[i] & 0x3f);
+            i++;
+        }
+        if (!valid) {
+            result += "\ufffd";
+            continue;
+        }
+        if (cp <= 0xffff) {
+            result += String.fromCharCode(cp);
+        } else {
+            cp -= 0x10000;
             result += String.fromCharCode(0xd800 + (cp >> 10), 0xdc00 + (cp & 0x3ff));
         }
     }

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -308,10 +308,10 @@ export function toBeArray(_value: BigNumberish, _width?: Numeric): Uint8Array {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// UTF-8 (src.ts/utils/utf8.ts — encoding only)
+// UTF-8 (src.ts/utils/utf8.ts — encoding + decoding)
 // ─────────────────────────────────────────────────────────────────────────────
 
-function toUtf8Bytes(str: string): Uint8Array {
+export function toUtf8Bytes(str: string): Uint8Array {
     assertArgument(typeof str === "string", "invalid string value", "str", str);
     const result: number[] = [];
     for (let i = 0; i < str.length; i++) {
@@ -337,6 +337,36 @@ function toUtf8Bytes(str: string): Uint8Array {
         }
     }
     return new Uint8Array(result);
+}
+
+/**
+ * Decode UTF-8 bytes to a string. Pure JS so it works in every runtime,
+ * including React Native / Hermes where `TextDecoder` is not defined by default.
+ * Mirrors the encoder above; handles 1- to 4-byte sequences (surrogate pairs).
+ */
+export function fromUtf8Bytes(bytes: Uint8Array): string {
+    let result = "";
+    let i = 0;
+    while (i < bytes.length) {
+        const b0 = bytes[i++];
+        if (b0 < 0x80) {
+            result += String.fromCharCode(b0);
+        } else if (b0 >= 0xc0 && b0 < 0xe0) {
+            const b1 = bytes[i++] & 0x3f;
+            result += String.fromCharCode(((b0 & 0x1f) << 6) | b1);
+        } else if (b0 >= 0xe0 && b0 < 0xf0) {
+            const b1 = bytes[i++] & 0x3f;
+            const b2 = bytes[i++] & 0x3f;
+            result += String.fromCharCode(((b0 & 0x0f) << 12) | (b1 << 6) | b2);
+        } else {
+            const b1 = bytes[i++] & 0x3f;
+            const b2 = bytes[i++] & 0x3f;
+            const b3 = bytes[i++] & 0x3f;
+            const cp = (((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3) - 0x10000;
+            result += String.fromCharCode(0xd800 + (cp >> 10), 0xdc00 + (cp & 0x3ff));
+        }
+    }
+    return result;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -745,7 +775,7 @@ function decodeValue(t: AbiType, data: Uint8Array, base: number): unknown {
             ensureRange(data, base, WordSize, "string length");
             const len = toNumber(data.slice(base, base + WordSize));
             ensureRange(data, base + WordSize, len, "string payload");
-            return new TextDecoder().decode(data.slice(base + WordSize, base + WordSize + len));
+            return fromUtf8Bytes(data.slice(base + WordSize, base + WordSize + len));
         }
         case "array": {
             if (t.size === -1) {

--- a/src/ethereUtils.ts
+++ b/src/ethereUtils.ts
@@ -342,75 +342,75 @@ export function toUtf8Bytes(str: string): Uint8Array {
 /**
  * Decode UTF-8 bytes to a string. Pure JS so it works in every runtime,
  * including React Native / Hermes where `TextDecoder` is not defined by default.
- * Validates the encoding like `TextDecoder` in its default (non-fatal) mode:
- * invalid lead bytes, missing/ malformed continuation bytes, overlong
- * encodings, surrogate-range code points (U+D800..U+DFFF) and values above
- * U+10FFFF are replaced with U+FFFD rather than being coerced into other
- * characters. Never reads past the end of the buffer.
+ *
+ * Throws on bad prefix, truncated sequences, missing or unexpected continuation bytes,
+ * overlong encodings, surrogate code points (U+D800..U+DFFF), and code
+ * points above U+10FFFF. For ABI string payloads this is the right policy —
+ * well-formed contracts never emit broken UTF-8, so an error signals a
+ * real problem rather than silently corrupting the decoded value.
+ *
+ * @throws Error when `bytes` is not a valid UTF-8 sequence.
  */
 export function fromUtf8Bytes(bytes: Uint8Array): string {
-    let result = "";
+    const codepoints: number[] = [];
     let i = 0;
-    const n = bytes.length;
-    while (i < n) {
-        const b0 = bytes[i++];
-        if (b0 < 0x80) {
-            result += String.fromCharCode(b0);
+    while (i < bytes.length) {
+        const c = bytes[i++];
+
+        // 1-byte ASCII.
+        if ((c & 0x80) === 0) {
+            codepoints.push(c);
             continue;
         }
-        // Sequence length, initial code-point bits, and the allowed range for
-        // the FIRST continuation byte. The tighter first-byte range is what
-        // rejects overlong encodings (0xe0/0xf0), surrogates (0xed) and code
-        // points above U+10FFFF (0xf4) at the earliest byte, matching the
-        // WHATWG / TextDecoder algorithm (including how many U+FFFD it emits).
-        let needed: number;
-        let cp: number;
-        let lower = 0x80;
-        let upper = 0xbf;
-        if (b0 >= 0xc2 && b0 <= 0xdf) {
-            needed = 1;
-            cp = b0 & 0x1f;
-        } else if (b0 >= 0xe0 && b0 <= 0xef) {
-            needed = 2;
-            cp = b0 & 0x0f;
-            if (b0 === 0xe0) lower = 0xa0;
-            else if (b0 === 0xed) upper = 0x9f;
-        } else if (b0 >= 0xf0 && b0 <= 0xf4) {
-            needed = 3;
-            cp = b0 & 0x07;
-            if (b0 === 0xf0) lower = 0x90;
-            else if (b0 === 0xf4) upper = 0x8f;
+
+        // Lead-byte classification per RFC 3629. Bytes 0xf8..0xff are not
+        // valid UTF-8 lead bytes and fall through to the error branch.
+        let extraLength: number;
+        let overlongMask: number;
+        if ((c & 0xe0) === 0xc0) {
+            extraLength = 1;
+            overlongMask = 0x7f;
+        } else if ((c & 0xf0) === 0xe0) {
+            extraLength = 2;
+            overlongMask = 0x7ff;
+        } else if ((c & 0xf8) === 0xf0) {
+            extraLength = 3;
+            overlongMask = 0xffff;
         } else {
-            // 0x80..0xc1 (continuation byte as lead, or overlong 2-byte lead)
-            // and 0xf5..0xff (would exceed U+10FFFF) are never valid leads.
-            result += "\ufffd";
-            continue;
+            const kind = (c & 0xc0) === 0x80 ? "unexpected continuation" : "bad prefix";
+            throw new Error(`invalid UTF-8: ${kind} byte 0x${c.toString(16)} at index ${i - 1}`);
         }
-        let valid = true;
-        for (let k = 0; k < needed; k++) {
-            const lo = k === 0 ? lower : 0x80;
-            const hi = k === 0 ? upper : 0xbf;
-            // Truncated, or a byte outside the allowed continuation range: emit
-            // one U+FFFD and leave the offending byte unconsumed so it is
-            // reprocessed as a fresh lead byte.
-            if (i >= n || bytes[i] < lo || bytes[i] > hi) {
-                valid = false;
-                break;
+
+        if (i + extraLength > bytes.length) {
+            throw new Error(`invalid UTF-8: truncated sequence at index ${i - 1}`);
+        }
+
+        let res = c & ((1 << (8 - extraLength - 1)) - 1);
+        for (let j = 0; j < extraLength; j++) {
+            const next = bytes[i++];
+            if ((next & 0xc0) !== 0x80) {
+                throw new Error(
+                    `invalid UTF-8: missing continuation byte 0x${next.toString(16)} at index ${i - 1}`,
+                );
             }
-            cp = (cp << 6) | (bytes[i] & 0x3f);
-            i++;
+            res = (res << 6) | (next & 0x3f);
         }
-        if (!valid) {
-            result += "\ufffd";
-            continue;
+
+        if (res <= overlongMask) {
+            throw new Error(`invalid UTF-8: overlong encoding of U+${res.toString(16).toUpperCase()}`);
         }
-        if (cp <= 0xffff) {
-            result += String.fromCharCode(cp);
-        } else {
-            cp -= 0x10000;
-            result += String.fromCharCode(0xd800 + (cp >> 10), 0xdc00 + (cp & 0x3ff));
+        if (res >= 0xd800 && res <= 0xdfff) {
+            throw new Error(`invalid UTF-8: surrogate code point U+${res.toString(16).toUpperCase()}`);
         }
+        if (res > 0x10ffff) {
+            throw new Error(`invalid UTF-8: code point U+${res.toString(16).toUpperCase()} out of range`);
+        }
+
+        codepoints.push(res);
     }
+
+    let result = "";
+    for (const cp of codepoints) result += String.fromCodePoint(cp);
     return result;
 }
 

--- a/test/calibur/caliburEip712.test.js
+++ b/test/calibur/caliburEip712.test.js
@@ -119,6 +119,128 @@ describe('Calibur7702Account.getUserOperationEip712Data', () => {
     });
 });
 
+// Regression for the executor-calldata decode in
+// prependTokenPaymasterApproveToCallDataStatic. Before the fix, the inner
+// `data` bytes of each BatchedCall were UTF-8-decoded (TextDecoder, then
+// fromUtf8Bytes), which corrupted any byte >= 0x80. The fix hex-encodes
+// instead. Randomized so the test covers a broad set of binary payloads
+// rather than a single hand-crafted vector.
+describe('Calibur prependTokenPaymasterApproveToCallDataStatic round-trip', () => {
+    const coder = AbiCoder.defaultAbiCoder();
+    const EXECUTE_USER_OP_SELECTOR = '0x8dd7712f';
+    const TOKEN = '0x' + '11'.repeat(20);
+    const PAYMASTER = '0x' + '22'.repeat(20);
+
+    // Seeded PRNG so failures are reproducible; mirrors the style used in
+    // test/ethereUtils.test.js. Mulberry32 — fine for property tests.
+    let _seed = 0x9e3779b1 >>> 0;
+    const resetRng = (s = 0x9e3779b1) => { _seed = s >>> 0; };
+    const randInt = (maxExclusive) => {
+        _seed = (_seed + 0x6d2b79f5) >>> 0;
+        let t = _seed;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) % maxExclusive;
+    };
+    const randomBytes = (n) => {
+        const out = new Uint8Array(n);
+        for (let i = 0; i < n; i++) out[i] = randInt(256);
+        return out;
+    };
+    const randomAddress = () =>
+        '0x' + Array.from(randomBytes(20), (b) => b.toString(16).padStart(2, '0')).join('');
+    const randomHex = (n) =>
+        '0x' + Array.from(randomBytes(n), (b) => b.toString(16).padStart(2, '0')).join('');
+
+    function buildExecuteUserOpCalldata(calls, revertOnFailure) {
+        const encoded = coder.encode(
+            ['tuple(tuple(address to, uint256 value, bytes data)[] calls, bool revertOnFailure)'],
+            [{ calls, revertOnFailure }],
+        );
+        return EXECUTE_USER_OP_SELECTOR + encoded.slice(2);
+    }
+
+    function decodeBatchedCallFromCalldata(callData) {
+        const body = '0x' + callData.slice(10);
+        const [decoded] = coder.decode(
+            ['tuple(tuple(address to, uint256 value, bytes data)[] calls, bool revertOnFailure)'],
+            body,
+        );
+        return { calls: decoded[0], revertOnFailure: decoded[1] };
+    }
+
+    const ITER = 25;
+    test(`property: ${ITER} random batches preserve binary data bytes through prepend`, () => {
+        resetRng();
+        for (let iter = 0; iter < ITER; iter++) {
+            // Build N random calls with random binary data payloads — sizes
+            // chosen so we hit empty, sub-32-byte, 32-byte aligned, and
+            // ragged (>32 with trailing partial word) shapes within the run.
+            const n = 1 + randInt(4);
+            const originals = [];
+            for (let i = 0; i < n; i++) {
+                const dataLen = randInt(80); // 0..79 bytes
+                originals.push({
+                    to: randomAddress(),
+                    value: BigInt(randInt(1_000_000)),
+                    data: randomHex(dataLen),
+                });
+            }
+
+            const revertOnFailure = randInt(2) === 1;
+            const calldata = buildExecuteUserOpCalldata(
+                originals.map((c) => [c.to, c.value, c.data]),
+                revertOnFailure,
+            );
+
+            const approveAmount = BigInt(randInt(1_000_000_000));
+            const out = ak.Calibur7702Account.prependTokenPaymasterApproveToCallDataStatic(
+                calldata,
+                TOKEN,
+                PAYMASTER,
+                approveAmount,
+            );
+
+            const { calls: outCalls, revertOnFailure: outRevert } =
+                decodeBatchedCallFromCalldata(out);
+
+            // First call is the prepended approve(token, paymaster, amount).
+            expect(outCalls.length).toBe(originals.length + 1);
+            expect(outCalls[0][0].toLowerCase()).toBe(TOKEN.toLowerCase());
+            expect(outCalls[0][1]).toBe(0n);
+            expect(outRevert).toBe(revertOnFailure);
+
+            // The N original calls are preserved at indices 1..n with binary
+            // data round-tripping bit-for-bit. This is what the bug broke:
+            // bytes >= 0x80 used to be UTF-8-decoded into multi-byte garbage.
+            for (let i = 0; i < originals.length; i++) {
+                const orig = originals[i];
+                const got = outCalls[i + 1];
+                expect(got[0].toLowerCase()).toBe(orig.to.toLowerCase());
+                expect(got[1]).toBe(orig.value);
+                expect(got[2].toLowerCase()).toBe(orig.data.toLowerCase());
+            }
+        }
+    });
+
+    // Explicit single-vector test pinning the exact byte ≥ 0x80 case that
+    // demonstrates the bug — keeps the regression obvious even if the
+    // randomized run happens to miss it on a future RNG change.
+    test('preserves a call whose data is all bytes >= 0x80 (the explicit bug case)', () => {
+        const trickyData = '0x' + Array.from({ length: 32 }, (_, i) => (0x80 + i).toString(16).padStart(2, '0')).join('');
+        const calldata = buildExecuteUserOpCalldata(
+            [['0x' + '33'.repeat(20), 0n, trickyData]],
+            false,
+        );
+
+        const out = ak.Calibur7702Account.prependTokenPaymasterApproveToCallDataStatic(
+            calldata, TOKEN, PAYMASTER, 1n,
+        );
+        const { calls } = decodeBatchedCallFromCalldata(out);
+        expect(calls[1][2].toLowerCase()).toBe(trickyData.toLowerCase());
+    });
+});
+
 describe('Calibur signTypedData / signHash byte-equivalence (root key)', () => {
     PERMUTATIONS.forEach(({ name, build }) => {
         test(`v0.8 — ${name}`, async () => {

--- a/test/ethereUtils.test.js
+++ b/test/ethereUtils.test.js
@@ -374,6 +374,49 @@ describe('isHexString', () => {
 });
 
 // ===========================================================================
+//                              fromUtf8Bytes
+// ===========================================================================
+
+describe('fromUtf8Bytes', () => {
+    const utf8 = (s) => new TextEncoder().encode(s);
+
+    test('round-trips ASCII', () => {
+        expect(u.fromUtf8Bytes(utf8('hello world'))).toBe('hello world');
+    });
+
+    test('round-trips multi-byte BMP and astral code points', () => {
+        // 2-byte Latin, 3-byte CJK, 4-byte emoji (surrogate-pair).
+        expect(u.fromUtf8Bytes(utf8('café 中文 😀'))).toBe('café 中文 😀');
+    });
+
+    test(`property: ${ITER} random UTF-8 strings round-trip via TextEncoder/TextDecoder`, () => {
+        resetRng();
+        for (let i = 0; i < ITER; i++) {
+            const s = randomUtf8String(64);
+            // Reference: TextEncoder.encode + ours == identity for valid strings.
+            expect(u.fromUtf8Bytes(utf8(s))).toBe(new TextDecoder().decode(utf8(s)));
+        }
+    });
+
+    // Strict-mode parity with ethers' default Utf8ErrorFuncs.error: throws on
+    // every malformed sequence, rather than silently emitting U+FFFD or junk.
+    describe('rejects malformed UTF-8 (strict, matches ethers default)', () => {
+        test.each([
+            ['stray continuation byte', Uint8Array.from([0x80])],
+            ['bad prefix (0xff)', Uint8Array.from([0xff])],
+            ['truncated 2-byte sequence', Uint8Array.from([0xc2])],
+            ['truncated 3-byte sequence', Uint8Array.from([0xe0, 0xa0])],
+            ['truncated 4-byte sequence', Uint8Array.from([0xf0, 0x9f, 0x98])],
+            ['missing continuation byte', Uint8Array.from([0xc2, 0x20])],
+            ['overlong "/" encoded as 2 bytes', Uint8Array.from([0xc0, 0xaf])],
+            ['surrogate U+D800 encoded as 3 bytes', Uint8Array.from([0xed, 0xa0, 0x80])],
+        ])('throws on %s', (_label, bytes) => {
+            expect(() => u.fromUtf8Bytes(bytes)).toThrow(/invalid UTF-8/);
+        });
+    });
+});
+
+// ===========================================================================
 //                              hexlify
 // ===========================================================================
 
@@ -821,27 +864,34 @@ describe('fromUtf8Bytes', () => {
         ['valid then truncated tail (hi + E4 BD)', [0x68, 0x69, 0xe4, 0xbd]],
         ['C1 BF (overlong lead)', [0xc1, 0xbf]],
     ];
-    test.each(malformed)('matches TextDecoder on malformed: %s', (_label, arr) => {
-        const out = dec(arr);
-        expect(out).toBe(td.decode(Uint8Array.from(arr)));
-        // none of the original bytes leak through as a non-replacement char
-        expect(out.replace(/\uFFFD/g, '')).toBe(td.decode(Uint8Array.from(arr)).replace(/\uFFFD/g, ''));
+    // Strict policy (matches ethers' default Utf8ErrorFuncs.error): malformed
+    // sequences throw rather than being replaced with U+FFFD. The vectors below
+    // are the cases TextDecoder-non-fatal would have silently FFFD'd.
+    test.each(malformed)('throws on malformed: %s', (_label, arr) => {
+        expect(() => dec(arr)).toThrow(/invalid UTF-8/);
     });
 
-    test('never reads past the end of the buffer', () => {
-        // Every prefix of a 4-byte sequence must decode without throwing.
-        for (const seq of [[0xf0], [0xf0, 0x9f], [0xf0, 0x9f, 0x98], [0xf0, 0x9f, 0x98, 0x80]]) {
-            expect(() => dec(seq)).not.toThrow();
-            expect(dec(seq)).toBe(td.decode(Uint8Array.from(seq)));
+    test('every partial prefix of a 4-byte sequence throws (no buffer over-read)', () => {
+        // Under strict policy each truncated prefix is invalid. The asserted
+        // property is that the throw is structured (`invalid UTF-8: ...`) \u2014
+        // not a TypeError on `undefined`, which would indicate reading past
+        // the end of the buffer.
+        for (const seq of [[0xf0], [0xf0, 0x9f], [0xf0, 0x9f, 0x98]]) {
+            expect(() => dec(seq)).toThrow(/invalid UTF-8/);
         }
+        // The complete 4-byte sequence decodes normally (sanity check).
+        expect(dec([0xf0, 0x9f, 0x98, 0x80])).toBe('\uD83D\uDE00');
     });
 
-    test('byte-for-byte parity with TextDecoder over random byte strings', () => {
+    test('5000 random valid UTF-8 strings round-trip byte-for-byte against TextEncoder/TextDecoder', () => {
+        // Random-byte-string parity isn't meaningful under strict policy \u2014
+        // most random byte strings are malformed, so the test would only
+        // exercise the throw path. Random valid strings keep the byte-for-byte
+        // spirit (large iteration count, all four UTF-8 byte-length classes).
+        const enc = new TextEncoder();
         for (let t = 0; t < 5000; t++) {
-            const len = randIntRange(0, 6);
-            const arr = [];
-            for (let j = 0; j < len; j++) arr.push(randIntRange(0, 255));
-            const bytes = Uint8Array.from(arr);
+            const s = randomUtf8String(8);
+            const bytes = enc.encode(s);
             expect(u.fromUtf8Bytes(bytes)).toBe(td.decode(bytes));
         }
     });

--- a/test/ethereUtils.test.js
+++ b/test/ethereUtils.test.js
@@ -788,6 +788,66 @@ describe('encodeAbiParameters / decodeAbiParameters', () => {
 });
 
 // ===========================================================================
+//                              fromUtf8Bytes
+// ===========================================================================
+
+describe('fromUtf8Bytes', () => {
+    // Default (non-fatal) TextDecoder is the reference: malformed input must be
+    // replaced with U+FFFD, never coerced into other characters.
+    const td = new TextDecoder('utf-8', { fatal: false });
+    const dec = (arr) => u.fromUtf8Bytes(Uint8Array.from(arr));
+
+    const valid = [
+        ['ascii', [...Buffer.from('hello, world!', 'utf8')]],
+        ['latin-1 (2-byte)', [...Buffer.from('héllo wörld', 'utf8')]],
+        ['cjk (3-byte)', [...Buffer.from('日本語 你好', 'utf8')]],
+        ['emoji / astral (4-byte, surrogate pairs)', [...Buffer.from('𝄞🦀🎉', 'utf8')]],
+        ['empty', []],
+    ];
+    test.each(valid)('decodes valid UTF-8 %s', (_label, arr) => {
+        expect(dec(arr)).toBe(td.decode(Uint8Array.from(arr)));
+    });
+
+    const malformed = [
+        ['overlong 2-byte (C0 AF) is not "/"', [0xc0, 0xaf]],
+        ['overlong 3-byte (E0 80 AF)', [0xe0, 0x80, 0xaf]],
+        ['overlong 4-byte (F0 80 80 80)', [0xf0, 0x80, 0x80, 0x80]],
+        ['surrogate half (ED A0 80)', [0xed, 0xa0, 0x80]],
+        ['above U+10FFFF (F4 90 80 80)', [0xf4, 0x90, 0x80, 0x80]],
+        ['invalid lead F5', [0xf5, 0x80, 0x80, 0x80]],
+        ['lone continuation byte 80', [0x80]],
+        ['truncated 3-byte at EOF (E2 82)', [0xe2, 0x82]],
+        ['valid lead, bad continuation (A + C3 28)', [0x41, 0xc3, 0x28]],
+        ['valid then truncated tail (hi + E4 BD)', [0x68, 0x69, 0xe4, 0xbd]],
+        ['C1 BF (overlong lead)', [0xc1, 0xbf]],
+    ];
+    test.each(malformed)('matches TextDecoder on malformed: %s', (_label, arr) => {
+        const out = dec(arr);
+        expect(out).toBe(td.decode(Uint8Array.from(arr)));
+        // none of the original bytes leak through as a non-replacement char
+        expect(out.replace(/\uFFFD/g, '')).toBe(td.decode(Uint8Array.from(arr)).replace(/\uFFFD/g, ''));
+    });
+
+    test('never reads past the end of the buffer', () => {
+        // Every prefix of a 4-byte sequence must decode without throwing.
+        for (const seq of [[0xf0], [0xf0, 0x9f], [0xf0, 0x9f, 0x98], [0xf0, 0x9f, 0x98, 0x80]]) {
+            expect(() => dec(seq)).not.toThrow();
+            expect(dec(seq)).toBe(td.decode(Uint8Array.from(seq)));
+        }
+    });
+
+    test('byte-for-byte parity with TextDecoder over random byte strings', () => {
+        for (let t = 0; t < 5000; t++) {
+            const len = randIntRange(0, 6);
+            const arr = [];
+            for (let j = 0; j < len; j++) arr.push(randIntRange(0, 255));
+            const bytes = Uint8Array.from(arr);
+            expect(u.fromUtf8Bytes(bytes)).toBe(td.decode(bytes));
+        }
+    });
+});
+
+// ===========================================================================
 //                              solidityPacked / solidityPackedKeccak256
 // ===========================================================================
 


### PR DESCRIPTION
generateOnChainIdentifier used Buffer.from and ABI string decoding used TextDecoder, both undefined in browsers (no polyfill) and React Native/Hermes. Replaced with the existing pure-JS toUtf8Bytes plus a new fromUtf8Bytes decoder, and moved the WebAuthn adapter and Calibur executor decode off TextEncoder/TextDecoder. Verified in headless Chrome, real Hermes, a real Android device (passkeys + live sponsored tx), and a real browser passkey sponsored tx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added and exported pure‑JS UTF‑8 encode/decode utilities.

* **Refactor**
  * Switched UTF‑8 handling across account modules to the new pure‑JS utilities for broader runtime compatibility (e.g., React Native/Hermes).

* **Bug Fixes**
  * Preserve raw binary payloads when encoding/decoding batched call data to avoid corruption.

* **Tests**
  * Added thorough tests covering strict UTF‑8 decoding edge cases and regression tests for batched calldata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->