### PR TITLE
fix(build): bundle @noble into the IIFE build for browser/CDN consumers

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,15 +1,33 @@
 import { defineConfig } from 'tsdown'
 
-export default defineConfig({
+const shared = {
   entry: ['src/index.ts'],
-  format: ['cjs', 'esm', 'iife'],
-  globalName: 'abstractionkit',
-  dts: true,
-  clean: true,
   sourcemap: false,
   target: 'es2022',
-  deps: { neverBundle: ['ethers'] },
-  outputOptions: {
-    globals: { ethers: 'ethers' },
+} as const
+
+export default defineConfig([
+  // Node / bundler builds (CJS + ESM). @noble/* stay external so npm consumers
+  // resolve and dedupe a single copy from node_modules.
+  {
+    ...shared,
+    format: ['cjs', 'esm'],
+    dts: true,
+    clean: true,
   },
-})
+  // Browser / CDN build (IIFE, the `unpkg` entry). A <script>/unpkg consumer
+  // has no module resolver, so the runtime deps must be bundled in. Otherwise
+  // @noble/hashes and @noble/curves are emitted as undefined globals
+  // (`_noble_hashes_sha3`, `_noble_curves_secp256k1`) and loading the script
+  // throws "ReferenceError: _noble_hashes_sha3 is not defined".
+  {
+    ...shared,
+    format: ['iife'],
+    globalName: 'abstractionkit',
+    noExternal: [/^@noble\//],
+    // Resolve the browser export conditions of @noble/* so its crypto shim uses
+    // the global `crypto` (Web Crypto) instead of importing `node:crypto`, which
+    // would otherwise be externalized as an undefined `node_crypto` global.
+    platform: 'browser',
+  },
+])


### PR DESCRIPTION
The IIFE (`unpkg`) build externalized `@noble/hashes` and `@noble/curves`, emitting them as undefined globals (`_noble_hashes_sha3`, `_noble_curves_secp256k1`). Loading the script via a CDN/`<script>` tag threw `ReferenceError: _noble_hashes_sha3 is not defined` and `window.abstractionkit` was never defined. Bundles `@noble/*` into the IIFE (with `platform: browser` so its crypto shim uses Web Crypto, not `node:crypto`) while keeping it external for CJS/ESM. Also drops the dead `ethers` external config. Verified in headless Chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored build configuration to use multiple separate targets with shared settings for improved maintainability.
  * Enhanced browser compatibility for dependencies by adjusting resolution strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->