### PR TITLE
chore(build): remove the unused IIFE/CDN build and unpkg field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
 	"description": "Account Abstraction 4337 SDK by Candidelabs",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",
-	"unpkg": "dist/index.iife.js",
 	"types": "dist/index.d.cts",
 	"exports": {
 		".": {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,33 +1,10 @@
 import { defineConfig } from 'tsdown'
 
-const shared = {
+export default defineConfig({
   entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
   sourcemap: false,
   target: 'es2022',
-} as const
-
-export default defineConfig([
-  // Node / bundler builds (CJS + ESM). @noble/* stay external so npm consumers
-  // resolve and dedupe a single copy from node_modules.
-  {
-    ...shared,
-    format: ['cjs', 'esm'],
-    dts: true,
-    clean: true,
-  },
-  // Browser / CDN build (IIFE, the `unpkg` entry). A <script>/unpkg consumer
-  // has no module resolver, so the runtime deps must be bundled in. Otherwise
-  // @noble/hashes and @noble/curves are emitted as undefined globals
-  // (`_noble_hashes_sha3`, `_noble_curves_secp256k1`) and loading the script
-  // throws "ReferenceError: _noble_hashes_sha3 is not defined".
-  {
-    ...shared,
-    format: ['iife'],
-    globalName: 'abstractionkit',
-    noExternal: [/^@noble\//],
-    // Resolve the browser export conditions of @noble/* so its crypto shim uses
-    // the global `crypto` (Web Crypto) instead of importing `node:crypto`, which
-    // would otherwise be externalized as an undefined `node_crypto` global.
-    platform: 'browser',
-  },
-])
+})


### PR DESCRIPTION
Follow-up to #200. The IIFE (`unpkg`) build targets `<script>`/CDN consumers, but that path is undocumented and unused -- abstractionkit consumers install via npm and use a bundler (ESM/CJS), both unaffected. Rather than maintain a second-class distribution (and ship a ~600 kB self-contained artifact) for a near-empty audience, this removes the `iife` format and the `unpkg` field. CJS, ESM and type outputs are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and distribution options. IIFE format is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->