### PR TITLE
fix: apply per-signer 55k verificationGasLimit compensation on all dummy-signature paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+### Bug Fixes
+
+- **`SafeAccount.baseEstimateUserOperationGas` per-signer `verificationGasLimit` compensation now applies on every dummy-signature path.** The ~55k-per-signer margin (covering signature verification cost that bundler simulation skips with short-circuiting dummy signatures) was only added when `dummySignerSignaturePairs` was passed explicitly. Calls using `expectedSigners` or the default single-EOA dummy got the raw bundler estimate back, underpricing `verificationGasLimit` for multi-signer Safes. Operations that already carry a caller-supplied signature are still returned uncompensated, since the signer count is unknown. (#152)
+
 ## 0.4.0
 
 ### New Features

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1360,6 +1360,13 @@ export class SafeAccount extends SmartAccount {
 
 	/**
 	 * estimate gas limits for a useroperation
+	 *
+	 * The returned verificationGasLimit includes ~55k gas per dummy signer
+	 * this method places on the operation (from dummySignerSignaturePairs,
+	 * expectedSigners, or the single-EOA default), compensating for the
+	 * per-signature verification cost bundler simulation skips. If the
+	 * operation already carries a signature, no compensation is added and
+	 * the caller is responsible for it.
 	 * @param userOperation - useroperation to estimate gas for
 	 * @param bundlerRpc - bundler rpc for gas estimation
 	 * @param overrides - overrides for the default values
@@ -1387,6 +1394,11 @@ export class SafeAccount extends SmartAccount {
 		const validAfter = 0xffffffffffffn;
 		const validUntil = 0xffffffffffffn;
 
+		// Number of dummy signatures this method placed on the operation.
+		// Zero when the caller supplied a ready-made signature, in which
+		// case the signer count is unknown here and per-signer gas
+		// compensation is left to the caller.
+		let dummySignersCount = 0;
 		if (overrides.dummySignerSignaturePairs != null) {
 			if (overrides.expectedSigners != null) {
 				throw new RangeError(
@@ -1396,6 +1408,7 @@ export class SafeAccount extends SmartAccount {
 			if (overrides.dummySignerSignaturePairs.length < 1) {
 				throw new RangeError("Number of dummy signers signature pairs can't be less than 1");
 			}
+			dummySignersCount = overrides.dummySignerSignaturePairs.length;
 			userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
 				overrides.dummySignerSignaturePairs,
 				{
@@ -1424,6 +1437,7 @@ export class SafeAccount extends SmartAccount {
 					webAuthnSignerSingleton: overrides.webAuthnSignerSingleton,
 					webAuthnSignerProxyCreationCode: overrides.webAuthnSignerProxyCreationCode,
 				});
+			dummySignersCount = dummySignerSignaturePairs.length;
 			userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
 				dummySignerSignaturePairs,
 				{
@@ -1433,6 +1447,7 @@ export class SafeAccount extends SmartAccount {
 				},
 			);
 		} else if (userOperation.signature.length < 3) {
+			dummySignersCount = 1;
 			userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
 				[EOADummySignerSignaturePair],
 				{
@@ -1459,14 +1474,13 @@ export class SafeAccount extends SmartAccount {
 
 		const preVerificationGas = BigInt(estimation.preVerificationGas);
 
-		let verificationGasLimit: bigint;
-		if (overrides.dummySignerSignaturePairs != null) {
-			verificationGasLimit =
-				BigInt(estimation.verificationGasLimit) +
-				BigInt(overrides.dummySignerSignaturePairs.length) * 55_000n;
-		} else {
-			verificationGasLimit = BigInt(estimation.verificationGasLimit);
-		}
+		// Compensate for per-signer signature verification cost the bundler
+		// skips during estimation: dummy signatures short-circuit validation,
+		// but Safe iterates owner signatures inside `validateUserOp`, so each
+		// real signature pays ~55k gas at inclusion that simulation never
+		// paid for.
+		const verificationGasLimit =
+			BigInt(estimation.verificationGasLimit) + BigInt(dummySignersCount) * 55_000n;
 
 		const callGasLimit = BigInt(estimation.callGasLimit);
 

--- a/test/safe/baseEstimateGasCompensation.test.js
+++ b/test/safe/baseEstimateGasCompensation.test.js
@@ -1,0 +1,90 @@
+// Unit tests for the per-signer ~55k verificationGasLimit compensation in
+// SafeAccount.baseEstimateUserOperationGas (issue #152). Uses a mock
+// Transport so no network is required.
+
+const ak = require("../../dist/index.cjs");
+
+const BUNDLER_VGL = 100000n;
+const PER_SIGNER = 55000n;
+
+function mockBundlerTransport() {
+	return {
+		request: async ({ method }) => {
+			if (method === "eth_estimateUserOperationGas") {
+				return {
+					callGasLimit: "0x100",
+					preVerificationGas: "0x200",
+					verificationGasLimit: "0x186a0", // 100000
+				};
+			}
+			throw new Error(`unexpected method ${method}`);
+		},
+	};
+}
+
+function makeUserOpV7(signature = "0x") {
+	return {
+		sender: "0x1111111111111111111111111111111111111111",
+		nonce: 0n,
+		factory: null,
+		factoryData: null,
+		callData: "0x",
+		callGasLimit: 0n,
+		verificationGasLimit: 0n,
+		preVerificationGas: 0n,
+		maxFeePerGas: 5n,
+		maxPriorityFeePerGas: 1n,
+		paymaster: null,
+		paymasterVerificationGasLimit: null,
+		paymasterPostOpGasLimit: null,
+		paymasterData: null,
+		signature,
+	};
+}
+
+const OWNER_A = "0x2222222222222222222222222222222222222222";
+const OWNER_B = "0x3333333333333333333333333333333333333333";
+
+describe("SafeAccount.baseEstimateUserOperationGas per-signer compensation", () => {
+	const account = new ak.SafeAccountV0_3_0("0x1111111111111111111111111111111111111111");
+
+	test("expectedSigners: adds 55k per expected signer", async () => {
+		const [, verificationGasLimit] = await account.baseEstimateUserOperationGas(
+			makeUserOpV7(),
+			mockBundlerTransport(),
+			{ expectedSigners: [OWNER_A, OWNER_B] },
+		);
+		expect(verificationGasLimit).toBe(BUNDLER_VGL + 2n * PER_SIGNER);
+	});
+
+	test("default single-EOA dummy: adds 55k once", async () => {
+		const [, verificationGasLimit] = await account.baseEstimateUserOperationGas(
+			makeUserOpV7(),
+			mockBundlerTransport(),
+		);
+		expect(verificationGasLimit).toBe(BUNDLER_VGL + PER_SIGNER);
+	});
+
+	test("explicit dummySignerSignaturePairs: adds 55k per pair", async () => {
+		const [, verificationGasLimit] = await account.baseEstimateUserOperationGas(
+			makeUserOpV7(),
+			mockBundlerTransport(),
+			{
+				dummySignerSignaturePairs: [
+					ak.EOADummySignerSignaturePair,
+					ak.EOADummySignerSignaturePair,
+				],
+			},
+		);
+		expect(verificationGasLimit).toBe(BUNDLER_VGL + 2n * PER_SIGNER);
+	});
+
+	test("caller-supplied signature: returns the raw bundler estimate", async () => {
+		const presetSignature = `0x${"ab".repeat(140)}`;
+		const [, verificationGasLimit] = await account.baseEstimateUserOperationGas(
+			makeUserOpV7(presetSignature),
+			mockBundlerTransport(),
+		);
+		expect(verificationGasLimit).toBe(BUNDLER_VGL);
+	});
+});


### PR DESCRIPTION
Fixes #152

Red/green verified: `test/safe/baseEstimateGasCompensation.test.js` (mock transport, no network) fails on pre-fix dev for the `expectedSigners` and default-dummy paths (2 failed, 2 passed) and passes fully with the fix (4 passed).