### PR TITLE
fix: estimate gas on a copy so the caller's UserOperation is never mutated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- **Gas estimation no longer mutates the caller's UserOperation.** `baseEstimateUserOperationGas` on `SafeAccount` and `Simple7702Account` (and their public `estimateUserOperationGas` wrappers) overwrote the operation's `signature` with a dummy and zeroed `maxFeePerGas`/`maxPriorityFeePerGas` in place, restoring the fees only on success. A bundler error left the caller's operation corrupted (zeroed fees, dummy signature). Estimation now runs on an internal shallow copy and the passed operation is never touched. (#132)
 - **`SafeAccount.baseEstimateUserOperationGas` per-signer `verificationGasLimit` compensation now applies on every dummy-signature path.** The ~55k-per-signer margin (covering signature verification cost that bundler simulation skips with short-circuiting dummy signatures) was only added when `dummySignerSignaturePairs` was passed explicitly. Calls using `expectedSigners` or the default single-EOA dummy got the raw bundler estimate back, underpricing `verificationGasLimit` for multi-signer Safes. Operations that already carry a caller-supplied signature are still returned uncompensated, since the signer count is unknown. (#152)
 
 ## 0.4.0

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1362,11 +1362,14 @@ export class SafeAccount extends SmartAccount {
 	 * estimate gas limits for a useroperation
 	 *
 	 * The returned verificationGasLimit includes ~55k gas per dummy signer
-	 * this method places on the operation (from dummySignerSignaturePairs,
-	 * expectedSigners, or the single-EOA default), compensating for the
-	 * per-signature verification cost bundler simulation skips. If the
-	 * operation already carries a signature, no compensation is added and
-	 * the caller is responsible for it.
+	 * used for estimation (from dummySignerSignaturePairs, expectedSigners,
+	 * or the single-EOA default), compensating for the per-signature
+	 * verification cost bundler simulation skips. If the operation already
+	 * carries a signature, no compensation is added and the caller is
+	 * responsible for it.
+	 *
+	 * The passed userOperation is not mutated; estimation runs on an
+	 * internal copy carrying the dummy signature and zeroed gas fees.
 	 * @param userOperation - useroperation to estimate gas for
 	 * @param bundlerRpc - bundler rpc for gas estimation
 	 * @param overrides - overrides for the default values
@@ -1394,11 +1397,12 @@ export class SafeAccount extends SmartAccount {
 		const validAfter = 0xffffffffffffn;
 		const validUntil = 0xffffffffffffn;
 
-		// Number of dummy signatures this method placed on the operation.
-		// Zero when the caller supplied a ready-made signature, in which
-		// case the signer count is unknown here and per-signer gas
+		// Number of dummy signatures this method placed on the estimated
+		// operation. Zero when the caller supplied a ready-made signature,
+		// in which case the signer count is unknown here and per-signer gas
 		// compensation is left to the caller.
 		let dummySignersCount = 0;
+		let estimationSignature = userOperation.signature;
 		if (overrides.dummySignerSignaturePairs != null) {
 			if (overrides.expectedSigners != null) {
 				throw new RangeError(
@@ -1409,7 +1413,7 @@ export class SafeAccount extends SmartAccount {
 				throw new RangeError("Number of dummy signers signature pairs can't be less than 1");
 			}
 			dummySignersCount = overrides.dummySignerSignaturePairs.length;
-			userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+			estimationSignature = SafeAccount.formatSignaturesToUseroperationSignature(
 				overrides.dummySignerSignaturePairs,
 				{
 					validAfter,
@@ -1438,7 +1442,7 @@ export class SafeAccount extends SmartAccount {
 					webAuthnSignerProxyCreationCode: overrides.webAuthnSignerProxyCreationCode,
 				});
 			dummySignersCount = dummySignerSignaturePairs.length;
-			userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+			estimationSignature = SafeAccount.formatSignaturesToUseroperationSignature(
 				dummySignerSignaturePairs,
 				{
 					validAfter,
@@ -1448,7 +1452,7 @@ export class SafeAccount extends SmartAccount {
 			);
 		} else if (userOperation.signature.length < 3) {
 			dummySignersCount = 1;
-			userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+			estimationSignature = SafeAccount.formatSignaturesToUseroperationSignature(
 				[EOADummySignerSignaturePair],
 				{
 					validAfter,
@@ -1460,17 +1464,19 @@ export class SafeAccount extends SmartAccount {
 
 		const bundler = Bundler.from(bundlerRpc);
 
-		const inputMaxFeePerGas = userOperation.maxFeePerGas;
-		const inputMaxPriorityFeePerGas = userOperation.maxPriorityFeePerGas;
-		userOperation.maxFeePerGas = 0n;
-		userOperation.maxPriorityFeePerGas = 0n;
+		// Estimate on a shallow copy so the caller's operation is never
+		// mutated, even when estimation throws.
+		const userOperationToEstimate = {
+			...userOperation,
+			signature: estimationSignature,
+			maxFeePerGas: 0n,
+			maxPriorityFeePerGas: 0n,
+		};
 		const estimation = await bundler.estimateUserOperationGas(
-			userOperation,
+			userOperationToEstimate,
 			this.entrypointAddress,
 			overrides.stateOverrideSet,
 		);
-		userOperation.maxFeePerGas = inputMaxFeePerGas;
-		userOperation.maxPriorityFeePerGas = inputMaxPriorityFeePerGas;
 
 		const preVerificationGas = BigInt(estimation.preVerificationGas);
 

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -716,21 +716,21 @@ export class BaseSimple7702Account extends SmartAccount {
 			dummySignature?: string;
 		} = {},
 	): Promise<[bigint, bigint, bigint]> {
-		userOperation.signature = overrides.dummySignature ?? BaseSimple7702Account.dummySignature;
-
 		const bundler = Bundler.from(bundlerRpc);
 
-		const inputMaxFeePerGas = userOperation.maxFeePerGas;
-		const inputMaxPriorityFeePerGas = userOperation.maxPriorityFeePerGas;
-		userOperation.maxFeePerGas = 0n;
-		userOperation.maxPriorityFeePerGas = 0n;
+		// Estimate on a shallow copy so the caller's operation is never
+		// mutated, even when estimation throws.
+		const userOperationToEstimate = {
+			...userOperation,
+			signature: overrides.dummySignature ?? BaseSimple7702Account.dummySignature,
+			maxFeePerGas: 0n,
+			maxPriorityFeePerGas: 0n,
+		};
 		const estimation = await bundler.estimateUserOperationGas(
-			userOperation,
+			userOperationToEstimate,
 			this.entrypointAddress,
 			overrides.stateOverrideSet,
 		);
-		userOperation.maxFeePerGas = inputMaxFeePerGas;
-		userOperation.maxPriorityFeePerGas = inputMaxPriorityFeePerGas;
 
 		const preVerificationGas = BigInt(estimation.preVerificationGas);
 

--- a/test/safe/estimationDoesNotMutate.test.js
+++ b/test/safe/estimationDoesNotMutate.test.js
@@ -1,0 +1,94 @@
+// Unit tests for issue #132: baseEstimateUserOperationGas must not mutate
+// the caller's UserOperation (signature, maxFeePerGas, maxPriorityFeePerGas),
+// and must not leave it corrupted (zeroed fees, dummy signature) when the
+// bundler estimation throws. Covers Simple7702Account and SafeAccount.
+// Uses mock Transports so no network is required.
+
+const ak = require("../../dist/index.cjs");
+
+function mockEstimatingTransport() {
+	return {
+		request: async () => ({
+			callGasLimit: "0x100",
+			preVerificationGas: "0x200",
+			verificationGasLimit: "0x300",
+		}),
+	};
+}
+
+function mockThrowingTransport() {
+	return {
+		request: async () => {
+			const err = new Error("estimation reverted");
+			err.code = -32500;
+			err.name = "TransportRpcError";
+			throw err;
+		},
+	};
+}
+
+const SENDER = "0x1111111111111111111111111111111111111111";
+
+function makeUserOpV7() {
+	return {
+		sender: SENDER,
+		nonce: 0n,
+		factory: null,
+		factoryData: null,
+		callData: "0x",
+		callGasLimit: 0n,
+		verificationGasLimit: 0n,
+		preVerificationGas: 0n,
+		maxFeePerGas: 123n,
+		maxPriorityFeePerGas: 45n,
+		paymaster: null,
+		paymasterVerificationGasLimit: null,
+		paymasterPostOpGasLimit: null,
+		paymasterData: null,
+		signature: "0x",
+	};
+}
+
+function makeUserOpV8() {
+	return { ...makeUserOpV7(), eip7702Auth: null };
+}
+
+describe("Simple7702Account estimation does not mutate the caller's op (#132)", () => {
+	const account = new ak.Simple7702Account(SENDER);
+
+	test("success path: signature and fees are untouched", async () => {
+		const userOp = makeUserOpV8();
+		const snapshot = { ...userOp };
+		await account.estimateUserOperationGas(userOp, mockEstimatingTransport());
+		expect(userOp).toEqual(snapshot);
+	});
+
+	test("throw path: op is not left with zeroed fees and a dummy signature", async () => {
+		const userOp = makeUserOpV8();
+		const snapshot = { ...userOp };
+		await expect(
+			account.estimateUserOperationGas(userOp, mockThrowingTransport()),
+		).rejects.toThrow();
+		expect(userOp).toEqual(snapshot);
+	});
+});
+
+describe("SafeAccount estimation does not mutate the caller's op (#132)", () => {
+	const account = new ak.SafeAccountV0_3_0(SENDER);
+
+	test("success path: signature and fees are untouched", async () => {
+		const userOp = makeUserOpV7();
+		const snapshot = { ...userOp };
+		await account.estimateUserOperationGas(userOp, mockEstimatingTransport());
+		expect(userOp).toEqual(snapshot);
+	});
+
+	test("throw path: op is not left with zeroed fees and a dummy signature", async () => {
+		const userOp = makeUserOpV7();
+		const snapshot = { ...userOp };
+		await expect(
+			account.estimateUserOperationGas(userOp, mockThrowingTransport()),
+		).rejects.toThrow();
+		expect(userOp).toEqual(snapshot);
+	});
+});


### PR DESCRIPTION
Fixes #132

Stacked on #205 (edits the same function); GitHub will retarget this to `dev` when #205 merges.

Red/green verified: `test/safe/estimationDoesNotMutate.test.js` (mock transports, success and bundler-throw paths, Safe + Simple7702) fails 4/4 on pre-fix dev and passes 4/4 with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gas estimation for Safe and Simple7702 accounts no longer mutates caller's user operations, preventing corruption during bundler errors.
  * Per-signer verification gas limit compensation now applies to all dummy-signature paths, fixing underpricing for multi-signer Safe accounts.

* **Tests**
  * Added tests verifying gas estimation doesn't mutate user operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->