### PR TITLE
fix: poll immediately and honor the timeout in SendUseroperationResponse.included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- **`SendUseroperationResponse.included()` polls immediately and respects its timeout.** The receipt loop slept a full polling interval before the first lookup (adding a flat `requestIntervalInSeconds` of latency to every call, even when the operation was already included) and could overshoot `timeoutInSeconds` by up to one interval. It now polls first, sleeps between attempts, and caps the final sleep to the time remaining. (#130)
+- **`SendUseroperationResponse.included()` polls immediately and respects its timeout.** The receipt loop slept a full polling interval before the first lookup (adding a flat `requestIntervalInSeconds` of latency to every call, even when the operation was already included) and could overshoot `timeoutInSeconds` by up to one interval. It now polls first, sleeps between attempts, and caps the final sleep to the time remaining. Non-finite `timeoutInSeconds`/`requestIntervalInSeconds` (e.g. `NaN` from an unset env var) are now rejected with a `RangeError` up front; `NaN` previously slipped past the `<= 0` validation and degraded into a `setTimeout` 1ms timer, polling the bundler at high frequency. (#130)
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+### Bug Fixes
+
+- **`SendUseroperationResponse.included()` polls immediately and respects its timeout.** The receipt loop slept a full polling interval before the first lookup (adding a flat `requestIntervalInSeconds` of latency to every call, even when the operation was already included) and could overshoot `timeoutInSeconds` by up to one interval. It now polls first, sleeps between attempts, and caps the final sleep to the time remaining. (#130)
+
 ## 0.4.0
 
 ### New Features

--- a/src/account/SendUseroperationResponse.ts
+++ b/src/account/SendUseroperationResponse.ts
@@ -39,16 +39,24 @@ export class SendUseroperationResponse {
 	 * @param timeoutInSeconds - Maximum time to wait for inclusion (default: 180s)
 	 * @param requestIntervalInSeconds - Time between polling requests (default: 2s)
 	 * @returns The UserOperation receipt once included
-	 * @throws RangeError if timeout or interval are <= 0, or timeout < interval
+	 * @throws RangeError if timeout or interval are not finite, <= 0, or timeout < interval
 	 * @throws AbstractionKitError with code "TIMEOUT" if the operation is not found within the timeout
 	 */
 	async included(
 		timeoutInSeconds: number = 180,
 		requestIntervalInSeconds: number = 2,
 	): Promise<UserOperationReceiptResult> {
-		if (timeoutInSeconds <= 0 || requestIntervalInSeconds <= 0) {
+		// Reject non-finite values explicitly: NaN slips past <= comparisons
+		// (every NaN comparison is false) and would otherwise turn the sleep
+		// below into a ~1ms timer that polls the bundler indefinitely.
+		if (
+			!Number.isFinite(timeoutInSeconds) ||
+			!Number.isFinite(requestIntervalInSeconds) ||
+			timeoutInSeconds <= 0 ||
+			requestIntervalInSeconds <= 0
+		) {
 			throw new RangeError(
-				"timeoutInSeconds and requestIntervalInSeconds should be bigger than zero",
+				"timeoutInSeconds and requestIntervalInSeconds should be finite and bigger than zero",
 			);
 		}
 		if (timeoutInSeconds < requestIntervalInSeconds) {

--- a/src/account/SendUseroperationResponse.ts
+++ b/src/account/SendUseroperationResponse.ts
@@ -54,15 +54,20 @@ export class SendUseroperationResponse {
 		if (timeoutInSeconds < requestIntervalInSeconds) {
 			throw new RangeError("timeoutInSeconds can't be less than requestIntervalInSeconds");
 		}
-		let count = 0;
-		while (count <= timeoutInSeconds) {
-			await this.delay(requestIntervalInSeconds * 1000);
+		// Poll immediately, then wait between attempts; cap the last wait to
+		// the time remaining so the total never overshoots the timeout by a
+		// full interval.
+		const deadline = Date.now() + timeoutInSeconds * 1000;
+		for (;;) {
 			const res = await this.bundler.getUserOperationReceipt(this.userOperationHash);
-			if (res == null) {
-				count += requestIntervalInSeconds;
-			} else {
+			if (res != null) {
 				return res;
 			}
+			const remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) {
+				break;
+			}
+			await this.delay(Math.min(requestIntervalInSeconds * 1000, remainingMs));
 		}
 		throw new AbstractionKitError("TIMEOUT", "can't find useroperation", {
 			context: this.userOperationHash,

--- a/test/transport/includedPolling.test.js
+++ b/test/transport/includedPolling.test.js
@@ -78,4 +78,14 @@ describe("SendUseroperationResponse.included() polling (#130)", () => {
 		},
 		15000,
 	);
+
+	test("non-finite timeout or interval is rejected up front", async () => {
+		const response = makeResponse(() => null);
+		// NaN slips past <= comparisons (every NaN comparison is false) and
+		// previously turned the sleep into a ~1ms timer polling indefinitely.
+		await expect(response.included(NaN, 2)).rejects.toThrow(RangeError);
+		await expect(response.included(10, NaN)).rejects.toThrow(RangeError);
+		await expect(response.included(Infinity, 2)).rejects.toThrow(RangeError);
+		await expect(response.included(10, Infinity)).rejects.toThrow(RangeError);
+	});
 });

--- a/test/transport/includedPolling.test.js
+++ b/test/transport/includedPolling.test.js
@@ -1,0 +1,81 @@
+// Live timing tests for issue #130: SendUseroperationResponse.included()
+// must poll immediately (not sleep a full interval first) and must not
+// overshoot the timeout by a full polling interval. Uses a mock Transport
+// and real timers; no network required.
+
+const ak = require("../../dist/index.cjs");
+
+const HASH = "0x1111111111111111111111111111111111111111111111111111111111111111";
+const ENTRYPOINT = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+
+const RAW_RECEIPT = {
+	userOpHash: HASH,
+	sender: "0x2222222222222222222222222222222222222222",
+	nonce: "0x0",
+	actualGasCost: "0x1",
+	actualGasUsed: "0x1",
+	success: true,
+	logs: [],
+	receipt: {
+		blockNumber: "0x1",
+		cumulativeGasUsed: "0x1",
+		gasUsed: "0x1",
+		transactionIndex: "0x0",
+		transactionHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	},
+};
+
+function makeResponse(receiptByAttempt) {
+	let attempt = 0;
+	const transport = {
+		request: async ({ method }) => {
+			if (method !== "eth_getUserOperationReceipt") {
+				throw new Error(`unexpected method ${method}`);
+			}
+			const result = receiptByAttempt(attempt);
+			attempt += 1;
+			return result;
+		},
+	};
+	return new ak.SendUseroperationResponse(HASH, new ak.Bundler(transport), ENTRYPOINT);
+}
+
+describe("SendUseroperationResponse.included() polling (#130)", () => {
+	test(
+		"receipt available on the first poll resolves without sleeping an interval",
+		async () => {
+			const response = makeResponse(() => RAW_RECEIPT);
+			const start = Date.now();
+			const receipt = await response.included(10, 3);
+			const elapsed = Date.now() - start;
+			expect(receipt.userOpHash).toBe(HASH);
+			// Pre-fix this slept the full 3s interval before the first poll.
+			expect(elapsed).toBeLessThan(1500);
+		},
+		15000,
+	);
+
+	test(
+		"timeout does not overshoot by a full interval",
+		async () => {
+			const response = makeResponse(() => null);
+			const start = Date.now();
+			await expect(response.included(2, 2)).rejects.toMatchObject({ code: "TIMEOUT" });
+			const elapsed = Date.now() - start;
+			// Pre-fix included(2, 2) took ~4s (two full sleeps) before throwing.
+			expect(elapsed).toBeLessThan(3200);
+		},
+		15000,
+	);
+
+	test(
+		"receipt appearing on a later poll is returned",
+		async () => {
+			const response = makeResponse((attempt) => (attempt < 2 ? null : RAW_RECEIPT));
+			const receipt = await response.included(10, 1);
+			expect(receipt.userOpHash).toBe(HASH);
+			expect(receipt.receipt.blockNumber).toBe(1n);
+		},
+		15000,
+	);
+});


### PR DESCRIPTION
Fixes #130

Red/green verified with real timers (`test/transport/includedPolling.test.js`, mock transport): on pre-fix dev, an immediately-available receipt still took the full 3s interval and `included(2, 2)` threw after ~4s; with the fix the receipt returns in ~3ms and the timeout throws at ~2s.

Follow-up: non-finite `timeoutInSeconds`/`requestIntervalInSeconds` (e.g. `NaN` from `Number(unsetEnvVar)`) slipped past the `<= 0` checks and, with the deadline loop, degraded into a ~1ms `setTimeout` polling indefinitely (measured: 258 polls in 300ms, never settling). `included()` now rejects non-finite inputs with a `RangeError` up front; covered by a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed polling behavior to check for results immediately, then wait between attempts instead of delaying the initial lookup.
  * Fixed timeout handling to prevent exceeding the specified maximum duration.
  * Added validation to reject invalid timeout and polling interval values upfront, preventing unintended high-frequency polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->