### PR TITLE
fix: keep legacy transaction v computation in BigInt to avoid precision loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+### Bug Fixes
+
+- **Legacy transaction `v` precision for chain IDs above 2^53.** `createAndSignLegacyRawTransaction` computed the EIP-155 `v` field via `Number(chainId)`, silently rounding large chain IDs and producing a transaction whose signature recovers to the wrong sender. The computation now stays in `BigInt`. (#128)
+
 ## 0.4.0
 
 ### New Features

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -106,7 +106,7 @@ export function createAndSignLegacyRawTransaction(
 		destination,
 		bigintToBytes(value),
 		data,
-		bigintToBytes(BigInt(signature.yParity + Number(chainId) * 2 + 35)),
+		bigintToBytes(BigInt(signature.yParity) + chainId * 2n + 35n),
 		getBytes(signature.r),
 		getBytes(signature.s),
 	];

--- a/test/utils7702.test.js
+++ b/test/utils7702.test.js
@@ -1,0 +1,40 @@
+// Unit tests for issue #128: the legacy transaction v field was computed
+// with Number(chainId), losing precision for chain IDs above 2^53 and
+// producing an unrecoverable signature. Verified independently by parsing
+// the raw transaction with ethers and checking the recovered sender.
+
+const ak = require("../dist/index.cjs");
+const { Transaction, Wallet } = require("ethers");
+
+const DESTINATION = "0x1111111111111111111111111111111111111111";
+
+function signAndParse(chainId) {
+	const wallet = Wallet.createRandom();
+	const raw = ak.createAndSignLegacyRawTransaction(
+		chainId,
+		1n, // nonce
+		1000000000n, // gas price
+		21000n, // gas limit
+		DESTINATION,
+		0n, // value
+		"0x",
+		wallet.privateKey,
+	);
+	return { wallet, tx: Transaction.from(raw) };
+}
+
+describe("createAndSignLegacyRawTransaction v computation (#128)", () => {
+	test("chainId above 2^53 keeps exact EIP-155 v and recovers the sender", () => {
+		const chainId = 4337433743374337433n; // > 2^53, not float-representable
+		const { wallet, tx } = signAndParse(chainId);
+		expect(tx.chainId).toBe(chainId);
+		expect(tx.from.toLowerCase()).toBe(wallet.address.toLowerCase());
+	});
+
+	test("small chainId still signs and recovers correctly", () => {
+		const chainId = 11155111n; // Sepolia
+		const { wallet, tx } = signAndParse(chainId);
+		expect(tx.chainId).toBe(chainId);
+		expect(tx.from.toLowerCase()).toBe(wallet.address.toLowerCase());
+	});
+});


### PR DESCRIPTION
Fixes #128

Red/green verified: `test/utils7702.test.js` signs a legacy tx with chainId 4337433743374337433 (> 2^53) and parses it back with ethers; on pre-fix dev the recovered sender is wrong (1 failed), with the fix both chainId and sender recover exactly (2 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legacy transaction signing for very large chain IDs so transactions preserve correct chain ID and sender recovery.

* **Tests**
  * Added unit tests verifying signing and sender recovery for large and standard chain IDs.

* **Documentation**
  * Updated changelog with the bug fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->