### PR TITLE
docs: fix stale getDelegatedAddress README reference and AllowAllPaymaster JSDoc grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ const response = await account.sendUserOperation(userOp, bundlerRpc);
 const receipt = await response.included();
 ```
 
-After the first UserOp deploys the delegation, subsequent UserOps no longer need `eip7702Auth`. Use `getDelegatedAddress(eoaAddress, nodeRpc)` to check delegation status.
+After the first UserOp deploys the delegation, subsequent UserOps no longer need `eip7702Auth`. Use `JsonRpcNode.from(nodeRpc).getDelegatedAddress(eoaAddress)` (import `JsonRpcNode` from `"abstractionkit"`) to check delegation status; it returns the delegatee address, or `null` when the EOA has no delegation.
 
 ### Calibur 7702: register a WebAuthn passkey
 

--- a/src/paymaster/AllowAllPaymaster.ts
+++ b/src/paymaster/AllowAllPaymaster.ts
@@ -44,7 +44,7 @@ export class ExperimentalAllowAllParallelPaymaster extends Paymaster {
 	/**
 	 * getApprovedPaymasterData will return a valid paymasterData
 	 * This function is async to simulate a paymaster service
-	 * that require an http call to fetch approved data.
+	 * that requires an HTTP call to fetch approved data.
 	 * @param userOperation - User operation to be sponsored
 	 * @returns a promise of string
 	 */


### PR DESCRIPTION
Fixes #181
Fixes #127

Verified against the built package: top-level `getDelegatedAddress` is no longer exported, and `JsonRpcNode.from(nodeRpc).getDelegatedAddress(eoaAddress)` exists and is the documented replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Calibur 7702 delegation-status example in the README with the new method import and usage pattern for checking EOA delegation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->