### PR TITLE
ci: run the full offline test suite and auto-rebuild stale dist before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Signer unit tests
-        run: yarn test:signer
+      # Runs every suite outside test/integration/ (root jest config
+      # excludes it): transport, safe, calibur, paymaster, signer, and
+      # utility tests. All offline — mock transports or loopback servers.
+      - name: Offline unit tests
+        run: yarn test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   integration:
-    name: integration/chainId
+    name: integration
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,4 +2,6 @@ module.exports = {
 	testEnvironment: "node",
 	modulePathIgnorePatterns: ["/.worktrees/"],
 	testPathIgnorePatterns: ["/node_modules/", "/dist/", "/.worktrees/", "/test/integration/"],
+	// Tests import the built package from dist/; rebuild when src/ is newer.
+	globalSetup: "<rootDir>/test/_ensureFreshDist.cjs",
 };

--- a/test/_ensureFreshDist.cjs
+++ b/test/_ensureFreshDist.cjs
@@ -1,0 +1,34 @@
+// Jest globalSetup: tests import the built package from dist/, so a stale
+// build silently tests old code. Rebuild automatically when any file under
+// src/ (or the build inputs) is newer than dist/index.cjs. Costs nothing
+// when dist is fresh; one tsdown run (~3s) when it is not.
+
+const { execSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.join(__dirname, "..");
+
+function newestMtimeMs(entry) {
+	const stat = fs.statSync(entry);
+	if (!stat.isDirectory()) {
+		return stat.mtimeMs;
+	}
+	let newest = 0;
+	for (const name of fs.readdirSync(entry)) {
+		newest = Math.max(newest, newestMtimeMs(path.join(entry, name)));
+	}
+	return newest;
+}
+
+module.exports = async () => {
+	const distEntry = path.join(ROOT, "dist", "index.cjs");
+	const inputs = ["src", "package.json", "tsconfig.json", "tsdown.config.ts"]
+		.map((p) => path.join(ROOT, p))
+		.filter((p) => fs.existsSync(p));
+	const newestInput = Math.max(...inputs.map(newestMtimeMs));
+	if (!fs.existsSync(distEntry) || fs.statSync(distEntry).mtimeMs < newestInput) {
+		console.log("\ndist/ is stale relative to src/ — rebuilding before tests...");
+		execSync("npm run build", { stdio: "inherit", cwd: ROOT });
+	}
+};


### PR DESCRIPTION
- CI now runs `yarn test` (all suites outside `test/integration/` — transport, safe, calibur, paymaster, signer, utilities; 468 tests, ~5s, all offline) instead of only `test:signer`.
- New jest `globalSetup` rebuilds `dist/` automatically when `src/` (or build inputs) is newer, so any jest invocation — including `npx jest <path>` — tests current code instead of a stale build. No-op when fresh.
- Renamed the integration job label `integration/chainId` → `integration` (it runs the whole suite, not just chainId). If branch protection lists `integration/chainId` as a required check, update it to `integration`.

Verified: full suite passes locally (468/468); guard rebuilds exactly once on stale dist and skips when fresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow test organization, renaming steps to better reflect their scope and improving overall test categorization for developers.
  * Modified integration workflow job naming convention for improved clarity and consistency in the Actions UI.

* **Tests**
  * Implemented automatic build freshness validation to ensure the distribution package is rebuilt whenever source files change before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->