### PR TITLE
fix: preserve bigint gas scaling

### DIFF
--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -465,19 +465,12 @@ export class Calibur7702Account
 
 		maxFeePerGas =
 			overrides.maxFeePerGas ??
-			BigInt(
-				Math.floor(
-					Number(maxFeePerGas) * (((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(maxFeePerGas * BigInt((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100)) / 100n;
 		maxPriorityFeePerGas =
 			overrides.maxPriorityFeePerGas ??
-			BigInt(
-				Math.floor(
-					Number(maxPriorityFeePerGas) *
-						(((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(maxPriorityFeePerGas *
+				BigInt((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100)) /
+				100n;
 
 		if (nonce == null) {
 			throw new RangeError("failed to determine nonce");
@@ -620,29 +613,18 @@ export class Calibur7702Account
 
 		userOperation.preVerificationGas =
 			overrides.preVerificationGas ??
-			BigInt(
-				Math.floor(
-					Number(preVerificationGas) *
-						(((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(preVerificationGas * BigInt((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100)) /
+				100n;
 
 		userOperation.verificationGasLimit =
 			overrides.verificationGasLimit ??
-			BigInt(
-				Math.floor(
-					Number(verificationGasLimit) *
-						(((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(verificationGasLimit *
+				BigInt((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100)) /
+				100n;
 
 		userOperation.callGasLimit =
 			overrides.callGasLimit ??
-			BigInt(
-				Math.floor(
-					Number(callGasLimit) * (((overrides.callGasLimitPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(callGasLimit * BigInt((overrides.callGasLimitPercentageMultiplier ?? 0) + 100)) / 100n;
 
 		// Set the dummy signature so paymaster sponsorship calls can simulate
 		// validateUserOp (Calibur's signature decoder rejects empty signatures).

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -48,6 +48,16 @@ import {
 	type WebAuthnSignatureData,
 } from "./types";
 
+
+function percentageMultiplierToBigInt(value: number | undefined, name: string): bigint {
+	const percentage = value ?? 0;
+	if (!Number.isFinite(percentage) || !Number.isInteger(percentage)) {
+		throw new RangeError(`${name} must be a finite integer`);
+	}
+
+	return BigInt(percentage + 100);
+}
+
 const DEFAULT_SINGLETON_ADDRESS = CALIBUR_UNISWAP_V1_0_0_SINGLETON_ADDRESS;
 
 /** Root key hash (bytes32 zero) — used for the EOA's own secp256k1 key */
@@ -465,11 +475,11 @@ export class Calibur7702Account
 
 		maxFeePerGas =
 			overrides.maxFeePerGas ??
-			(maxFeePerGas * BigInt((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100)) / 100n;
+			(maxFeePerGas * percentageMultiplierToBigInt(overrides.maxFeePerGasPercentageMultiplier, "maxFeePerGasPercentageMultiplier")) / 100n;
 		maxPriorityFeePerGas =
 			overrides.maxPriorityFeePerGas ??
 			(maxPriorityFeePerGas *
-				BigInt((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100)) /
+				percentageMultiplierToBigInt(overrides.maxPriorityFeePerGasPercentageMultiplier, "maxPriorityFeePerGasPercentageMultiplier")) /
 				100n;
 
 		if (nonce == null) {
@@ -613,18 +623,18 @@ export class Calibur7702Account
 
 		userOperation.preVerificationGas =
 			overrides.preVerificationGas ??
-			(preVerificationGas * BigInt((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100)) /
+			(preVerificationGas * percentageMultiplierToBigInt(overrides.preVerificationGasPercentageMultiplier, "preVerificationGasPercentageMultiplier")) /
 				100n;
 
 		userOperation.verificationGasLimit =
 			overrides.verificationGasLimit ??
 			(verificationGasLimit *
-				BigInt((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100)) /
+				percentageMultiplierToBigInt(overrides.verificationGasLimitPercentageMultiplier, "verificationGasLimitPercentageMultiplier")) /
 				100n;
 
 		userOperation.callGasLimit =
 			overrides.callGasLimit ??
-			(callGasLimit * BigInt((overrides.callGasLimitPercentageMultiplier ?? 0) + 100)) / 100n;
+			(callGasLimit * percentageMultiplierToBigInt(overrides.callGasLimitPercentageMultiplier, "callGasLimitPercentageMultiplier")) / 100n;
 
 		// Set the dummy signature so paymaster sponsorship calls can simulate
 		// validateUserOp (Calibur's signature decoder rejects empty signatures).

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -90,6 +90,16 @@ import {
  * static `initializeNewAccount` to produce a counterfactual account + factory
  * data for first-time deployment.
  */
+
+function percentageMultiplierToBigInt(value: number | undefined, name: string): bigint {
+	const percentage = value ?? 0;
+	if (!Number.isFinite(percentage) || !Number.isInteger(percentage)) {
+		throw new RangeError(`${name} must be a finite integer`);
+	}
+
+	return BigInt(percentage + 100);
+}
+
 export class SafeAccount extends SmartAccount {
 	static readonly DEFAULT_WEB_AUTHN_SHARED_SIGNER: string =
 		"0xfD90FAd33ee8b58f32c00aceEad1358e4AFC23f9";
@@ -1550,11 +1560,11 @@ export class SafeAccount extends SmartAccount {
 
 		maxFeePerGas =
 			overrides.maxFeePerGas ??
-			(maxFeePerGas * BigInt((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100)) / 100n;
+			(maxFeePerGas * percentageMultiplierToBigInt(overrides.maxFeePerGasPercentageMultiplier, "maxFeePerGasPercentageMultiplier")) / 100n;
 		maxPriorityFeePerGas =
 			overrides.maxPriorityFeePerGas ??
 			(maxPriorityFeePerGas *
-				BigInt((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100)) /
+				percentageMultiplierToBigInt(overrides.maxPriorityFeePerGasPercentageMultiplier, "maxPriorityFeePerGasPercentageMultiplier")) /
 				100n;
 
 		const eip7212WebAuthnPrecompileVerifier =
@@ -1828,18 +1838,18 @@ export class SafeAccount extends SmartAccount {
 
 		userOperation.preVerificationGas =
 			overrides.preVerificationGas ??
-			(preVerificationGas * BigInt((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100)) /
+			(preVerificationGas * percentageMultiplierToBigInt(overrides.preVerificationGasPercentageMultiplier, "preVerificationGasPercentageMultiplier")) /
 				100n;
 
 		userOperation.verificationGasLimit =
 			overrides.verificationGasLimit ??
 			(verificationGasLimit *
-				BigInt((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100)) /
+				percentageMultiplierToBigInt(overrides.verificationGasLimitPercentageMultiplier, "verificationGasLimitPercentageMultiplier")) /
 				100n;
 
 		userOperation.callGasLimit =
 			overrides.callGasLimit ??
-			(callGasLimit * BigInt((overrides.callGasLimitPercentageMultiplier ?? 0) + 100)) / 100n;
+			(callGasLimit * percentageMultiplierToBigInt(overrides.callGasLimitPercentageMultiplier, "callGasLimitPercentageMultiplier")) / 100n;
 
 		return [userOperation, factoryAddress, factoryData];
 	}

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -32,6 +32,16 @@ import {
 import {SendUseroperationResponse} from "../SendUseroperationResponse";
 import {SmartAccount} from "../SmartAccount";
 
+
+function percentageMultiplierToBigInt(value: number | undefined, name: string): bigint {
+	const percentage = value ?? 0;
+	if (!Number.isFinite(percentage) || !Number.isInteger(percentage)) {
+		throw new RangeError(`${name} must be a finite integer`);
+	}
+
+	return BigInt(percentage + 100);
+}
+
 /**
  * A minimal transaction object for EIP-7702 simple accounts.
  * Represents a single call with a target address, ETH value, and calldata.
@@ -507,11 +517,11 @@ export class BaseSimple7702Account extends SmartAccount {
 		}
 		maxFeePerGas =
 			overrides.maxFeePerGas ??
-			(maxFeePerGas * BigInt((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100)) / 100n;
+			(maxFeePerGas * percentageMultiplierToBigInt(overrides.maxFeePerGasPercentageMultiplier, "maxFeePerGasPercentageMultiplier")) / 100n;
 		maxPriorityFeePerGas =
 			overrides.maxPriorityFeePerGas ??
 			(maxPriorityFeePerGas *
-				BigInt((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100)) /
+				percentageMultiplierToBigInt(overrides.maxPriorityFeePerGasPercentageMultiplier, "maxPriorityFeePerGasPercentageMultiplier")) /
 				100n;
 		if (nonce == null) {
 			throw new RangeError("failed to determine nonce");
@@ -665,18 +675,18 @@ export class BaseSimple7702Account extends SmartAccount {
 
 		userOperation.preVerificationGas =
 			overrides.preVerificationGas ??
-			(preVerificationGas * BigInt((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100)) /
+			(preVerificationGas * percentageMultiplierToBigInt(overrides.preVerificationGasPercentageMultiplier, "preVerificationGasPercentageMultiplier")) /
 				100n;
 
 		userOperation.verificationGasLimit =
 			overrides.verificationGasLimit ??
 			(verificationGasLimit *
-				BigInt((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100)) /
+				percentageMultiplierToBigInt(overrides.verificationGasLimitPercentageMultiplier, "verificationGasLimitPercentageMultiplier")) /
 				100n;
 
 		userOperation.callGasLimit =
 			overrides.callGasLimit ??
-			(callGasLimit * BigInt((overrides.callGasLimitPercentageMultiplier ?? 0) + 100)) / 100n;
+			(callGasLimit * percentageMultiplierToBigInt(overrides.callGasLimitPercentageMultiplier, "callGasLimitPercentageMultiplier")) / 100n;
 
 		return userOperation;
 	}

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -507,19 +507,12 @@ export class BaseSimple7702Account extends SmartAccount {
 		}
 		maxFeePerGas =
 			overrides.maxFeePerGas ??
-			BigInt(
-				Math.floor(
-					Number(maxFeePerGas) * (((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(maxFeePerGas * BigInt((overrides.maxFeePerGasPercentageMultiplier ?? 0) + 100)) / 100n;
 		maxPriorityFeePerGas =
 			overrides.maxPriorityFeePerGas ??
-			BigInt(
-				Math.floor(
-					Number(maxPriorityFeePerGas) *
-						(((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(maxPriorityFeePerGas *
+				BigInt((overrides.maxPriorityFeePerGasPercentageMultiplier ?? 0) + 100)) /
+				100n;
 		if (nonce == null) {
 			throw new RangeError("failed to determine nonce");
 		} else if (nonce < 0n) {
@@ -672,29 +665,18 @@ export class BaseSimple7702Account extends SmartAccount {
 
 		userOperation.preVerificationGas =
 			overrides.preVerificationGas ??
-			BigInt(
-				Math.floor(
-					Number(preVerificationGas) *
-						(((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(preVerificationGas * BigInt((overrides.preVerificationGasPercentageMultiplier ?? 0) + 100)) /
+				100n;
 
 		userOperation.verificationGasLimit =
 			overrides.verificationGasLimit ??
-			BigInt(
-				Math.floor(
-					Number(verificationGasLimit) *
-						(((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(verificationGasLimit *
+				BigInt((overrides.verificationGasLimitPercentageMultiplier ?? 0) + 100)) /
+				100n;
 
 		userOperation.callGasLimit =
 			overrides.callGasLimit ??
-			BigInt(
-				Math.floor(
-					Number(callGasLimit) * (((overrides.callGasLimitPercentageMultiplier ?? 0) + 100) / 100),
-				),
-			);
+			(callGasLimit * BigInt((overrides.callGasLimitPercentageMultiplier ?? 0) + 100)) / 100n;
 
 		return userOperation;
 	}


### PR DESCRIPTION
The 7702 account gas and fee multiplier paths converted bigint values through Number before scaling them.

This can lose precision for large bigint gas or fee values. The patch keeps the scaling in bigint arithmetic, matching the existing Safe account implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved precision and consistent integer-based handling for percentage adjustments to gas fees and gas limits, reducing rounding inconsistencies.
  * Added stricter validation for percentage overrides to prevent invalid multiplier inputs, leading to more predictable transaction fee calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->