### PR TITLE
fix: Safe WebAuthn owner matching, init-signature sorting, and estimation-path input handling

### DIFF
--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -2186,6 +2186,12 @@ export class SafeAccount extends SmartAccount {
 	): string {
 		if (typeof signer === "string") {
 			return signer.toLowerCase();
+		} else if (overrides.isInit) {
+			// on init the encoded owner is the WebAuthn shared signer, not the
+			// per-owner verifier proxy — sort by the same address that gets encoded
+			const webAuthnSharedSigner =
+				overrides.webAuthnSharedSigner ?? SafeAccount.DEFAULT_WEB_AUTHN_SHARED_SIGNER;
+			return webAuthnSharedSigner.toLowerCase();
 		} else {
 			const eip7212WebAuthnPrecompileVerifier =
 				overrides.eip7212WebAuthnPrecompileVerifier ?? SafeAccount.DEFAULT_WEB_AUTHN_PRECOMPILE;

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -2105,7 +2105,7 @@ export class SafeAccount extends SmartAccount {
 			],
 		).slice(-40);
 
-		return `0x${proxyAdd}`;
+		return getAddress(`0x${proxyAdd}`); //to checksummed
 	}
 
 	/**
@@ -2405,7 +2405,9 @@ export class SafeAccount extends SmartAccount {
 		let prevOwnerT = overrides.prevOwner;
 		if (prevOwnerT == null) {
 			const owners = await this.getOwners(nodeRpcUrl);
-			const oldOwnerIndex = owners.indexOf(oldOwnerT);
+			const oldOwnerIndex = owners.findIndex(
+				(owner) => owner.toLowerCase() === oldOwnerT.toLowerCase(),
+			);
 			if (oldOwnerIndex === -1) {
 				throw new RangeError("oldOwner is not a current owner.");
 			} else if (oldOwnerIndex === 0) {
@@ -2476,7 +2478,9 @@ export class SafeAccount extends SmartAccount {
 		let prevOwnerT = overrides.prevOwner;
 		if (prevOwnerT == null) {
 			const owners = await this.getOwners(nodeRpcUrl);
-			const ownerToDeleteIndex = owners.indexOf(ownerToDeleteT);
+			const ownerToDeleteIndex = owners.findIndex(
+				(owner) => owner.toLowerCase() === ownerToDeleteT.toLowerCase(),
+			);
 			if (ownerToDeleteIndex === -1) {
 				throw new RangeError("ownerToDelete is not a current owner.");
 			} else if (ownerToDeleteIndex === 0) {

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1397,6 +1397,26 @@ export class SafeAccount extends SmartAccount {
 		const validAfter = 0xffffffffffffn;
 		const validUntil = 0xffffffffffffn;
 
+		// Derived from the operation's own init fields; the signature encoder
+		// needs the init flag and verifier config whenever a dummy pair
+		// carries a raw WebauthnPublicKey signer.
+		let initCode: string | null;
+		if ("initCode" in userOperation) {
+			initCode = userOperation.initCode;
+		} else {
+			initCode = userOperation.factory;
+		}
+		const isInit = initCode != null && initCode !== "0x";
+		const webAuthnSignatureOverrides = {
+			isInit,
+			webAuthnSharedSigner: overrides.webAuthnSharedSigner,
+			eip7212WebAuthnPrecompileVerifier: overrides.eip7212WebAuthnPrecompileVerifier,
+			eip7212WebAuthnContractVerifier: overrides.eip7212WebAuthnContractVerifier,
+			webAuthnSignerFactory: overrides.webAuthnSignerFactory,
+			webAuthnSignerSingleton: overrides.webAuthnSignerSingleton,
+			webAuthnSignerProxyCreationCode: overrides.webAuthnSignerProxyCreationCode,
+		};
+
 		// Number of dummy signatures this method placed on the estimated
 		// operation. Zero when the caller supplied a ready-made signature,
 		// in which case the signer count is unknown here and per-signer gas
@@ -1419,28 +1439,15 @@ export class SafeAccount extends SmartAccount {
 					validAfter,
 					validUntil,
 					isMultiChainSignature: overrides.isMultiChainSignature,
+					...webAuthnSignatureOverrides,
 				},
 			);
 		} else if (overrides.expectedSigners != null) {
-			let initCode: string | null;
-
-			if ("initCode" in userOperation) {
-				initCode = userOperation.initCode;
-			} else {
-				initCode = userOperation.factory;
-			}
-			const isInit = initCode != null && initCode !== "0x";
-
 			const dummySignerSignaturePairs =
-				SafeAccount.createDummySignerSignaturePairForExpectedSigners(overrides.expectedSigners, {
-					isInit,
-					webAuthnSharedSigner: overrides.webAuthnSharedSigner,
-					eip7212WebAuthnPrecompileVerifier: overrides.eip7212WebAuthnPrecompileVerifier,
-					eip7212WebAuthnContractVerifier: overrides.eip7212WebAuthnContractVerifier,
-					webAuthnSignerFactory: overrides.webAuthnSignerFactory,
-					webAuthnSignerSingleton: overrides.webAuthnSignerSingleton,
-					webAuthnSignerProxyCreationCode: overrides.webAuthnSignerProxyCreationCode,
-				});
+				SafeAccount.createDummySignerSignaturePairForExpectedSigners(
+					overrides.expectedSigners,
+					webAuthnSignatureOverrides,
+				);
 			dummySignersCount = dummySignerSignaturePairs.length;
 			estimationSignature = SafeAccount.formatSignaturesToUseroperationSignature(
 				dummySignerSignaturePairs,
@@ -1448,6 +1455,7 @@ export class SafeAccount extends SmartAccount {
 					validAfter,
 					validUntil,
 					isMultiChainSignature: overrides.isMultiChainSignature,
+					...webAuthnSignatureOverrides,
 				},
 			);
 		} else if (userOperation.signature.length < 3) {
@@ -1742,10 +1750,17 @@ export class SafeAccount extends SmartAccount {
 				validAfter,
 				validUntil,
 				isMultiChainSignature: overrides.isMultiChainSignature,
-				webAuthnSharedSigner,
 				// needed when user-supplied dummySignerSignaturePairs contain raw
-				// WebauthnPublicKey signers — the encoder requires the init flag
+				// WebauthnPublicKey signers — the encoder requires the init flag,
+				// and for deployed accounts derives the per-owner verifier
+				// address from the verifier config
 				isInit,
+				webAuthnSharedSigner,
+				eip7212WebAuthnPrecompileVerifier,
+				eip7212WebAuthnContractVerifier,
+				webAuthnSignerFactory,
+				webAuthnSignerSingleton,
+				webAuthnSignerProxyCreationCode,
 			},
 		);
 

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1706,6 +1706,7 @@ export class SafeAccount extends SmartAccount {
 		const validAfter = 0xffffffffffffn;
 		const validUntil = 0xffffffffffffn;
 
+		const isInit = factoryAddress != null && factoryAddress !== "0x";
 		let dummySignerSignaturePairs: SignerSignaturePair[];
 		if (overrides.dummySignerSignaturePairs != null) {
 			if (overrides.expectedSigners != null) {
@@ -1721,7 +1722,6 @@ export class SafeAccount extends SmartAccount {
 			if (overrides.expectedSigners == null) {
 				dummySignerSignaturePairs = [EOADummySignerSignaturePair];
 			} else {
-				const isInit = factoryAddress != null && factoryAddress !== "0x";
 				dummySignerSignaturePairs = SafeAccount.createDummySignerSignaturePairForExpectedSigners(
 					overrides.expectedSigners,
 					{
@@ -1743,6 +1743,9 @@ export class SafeAccount extends SmartAccount {
 				validUntil,
 				isMultiChainSignature: overrides.isMultiChainSignature,
 				webAuthnSharedSigner,
+				// needed when user-supplied dummySignerSignaturePairs contain raw
+				// WebauthnPublicKey signers — the encoder requires the init flag
+				isInit,
 			},
 		);
 
@@ -1791,12 +1794,18 @@ export class SafeAccount extends SmartAccount {
 
 					const parallelPaymasterInitValues = overrides.parallelPaymasterInitValues;
 					if (parallelPaymasterInitValues != null) {
-						if (!parallelPaymasterInitValues.paymasterData.endsWith("22e325a297439656")) {
+						// lowercase like the EIP-712 trimmer and the MultiChain
+						// subclass — uppercase hex is valid input
+						if (
+							!parallelPaymasterInitValues.paymasterData
+								.toLowerCase()
+								.endsWith("22e325a297439656")
+						) {
 							throw new RangeError(
 								"Invalid paymasterData override, it must end with the PAYMASTER_SIG_MAGIC '22e325a297439656'.",
 							);
 						}
-						if (this.entrypointAddress !== ENTRYPOINT_V9) {
+						if (this.entrypointAddress.toLowerCase() !== ENTRYPOINT_V9.toLowerCase()) {
 							throw new RangeError("parallelPaymasterInitValues only works with ep v0.9");
 						}
 						userOperationToEstimate.paymaster = parallelPaymasterInitValues.paymaster;

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -2184,10 +2184,23 @@ export class SafeAccount extends SmartAccount {
 	}
 
 	/**
-	 * calculate a signer public address lowercase
-	 * @param signer - a signer to compute address for
-	 * @param overrides - overrides for the default values
-	 * @returns signer address
+	 * Resolve a {@link Signer} to the lowercase address the Safe contract
+	 * sees as the owner — not merely a case conversion:
+	 *
+	 * - string signer: returned lowercased as-is.
+	 * - WebAuthn public key with `overrides.isInit` set: resolves to the
+	 *   WebAuthn **shared signer** address, since during account init the
+	 *   shared signer is the enabled owner rather than a per-owner verifier.
+	 * - WebAuthn public key otherwise: **derives** the deterministic CREATE2
+	 *   address of the per-owner WebAuthn verifier proxy from the key's x/y
+	 *   coordinates and the verifier/factory configuration.
+	 *
+	 * Used as the sort key in {@link sortSignatures}, so it must always match
+	 * the owner address that signature encoding will emit for the same
+	 * overrides — pass the same overrides bag to both.
+	 * @param signer - a signer to compute the owner address for
+	 * @param overrides - WebAuthn verifier configuration and the init flag
+	 * @returns the owner address, lowercased
 	 */
 	public static getSignerLowerCaseAddress(
 		signer: Signer,

--- a/test/safe/webauthnDummyPairsEstimation.test.js
+++ b/test/safe/webauthnDummyPairsEstimation.test.js
@@ -1,0 +1,105 @@
+// Regression tests: baseEstimateUserOperationGas must accept user-supplied
+// dummySignerSignaturePairs containing raw WebauthnPublicKey signers —
+// deriving isInit from the operation's own init fields — and must forward
+// the WebAuthn verifier-config overrides so deployed accounts with custom
+// verifier setups encode the correct owner address. Offline.
+
+const ak = require('../../dist/index.cjs');
+
+const WEBAUTHN_KEY = {
+    x: 0x7a2fa39b3c61b3cbab8e44abeac8c9c7a4c1f76d42ae6f47b3b2a96d5c4f1a2bn,
+    y: 0x2e8c5f6d4b7a9c1e3f5a8d7b6c4e2f1a9d8c7b6a5e4f3d2c1b0a9f8e7d6c5b4an,
+};
+const WEBAUTHN_SIG = '0x' + 'ab'.repeat(320);
+const ACCOUNT = '0x' + '42'.repeat(20);
+const CUSTOM_SIGNER_FACTORY = '0x' + '77'.repeat(20);
+
+const GAS_RESULT = {
+    callGasLimit: '0x10000',
+    verificationGasLimit: '0x10000',
+    preVerificationGas: '0x10000',
+};
+
+function estimateWithDummyPairs({ factory, overrides = {} }) {
+    const captured = [];
+    const bundler = new ak.Bundler({
+        request: async ({ method, params }) => {
+            captured.push({ method, params });
+            return GAS_RESULT;
+        },
+    });
+    const account = new ak.SafeAccountV0_3_0(ACCOUNT);
+    const userOperation = {
+        sender: ACCOUNT,
+        nonce: 0n,
+        factory,
+        factoryData: null,
+        callData: '0x',
+        callGasLimit: 0n,
+        verificationGasLimit: 0n,
+        preVerificationGas: 0n,
+        maxFeePerGas: 0n,
+        maxPriorityFeePerGas: 0n,
+        paymaster: null,
+        paymasterVerificationGasLimit: null,
+        paymasterPostOpGasLimit: null,
+        paymasterData: null,
+        signature: '0x',
+    };
+    const estimation = account.baseEstimateUserOperationGas(userOperation, bundler, {
+        dummySignerSignaturePairs: [{ signer: WEBAUTHN_KEY, signature: WEBAUTHN_SIG }],
+        ...overrides,
+    });
+    return { estimation, captured };
+}
+
+// signature layout: 0x + validAfter (6 bytes) + validUntil (6 bytes) + static
+// segments (65 bytes per signer: r = padded owner address, s = offset, v).
+// The encoded owner address sits in bytes 12..32 of the first segment's r.
+function encodedOwner(signature) {
+    return signature.slice(2 + 24).slice(24, 64);
+}
+
+describe('WebAuthn dummySignerSignaturePairs in baseEstimateUserOperationGas', () => {
+    test('init op: derives isInit from the factory field and encodes the shared signer', async () => {
+        const { estimation, captured } = estimateWithDummyPairs({
+            factory: '0x' + '11'.repeat(20),
+        });
+        await expect(estimation).resolves.toBeDefined();
+        const sentOp = captured[0].params[0];
+        expect(encodedOwner(sentOp.signature)).toBe(
+            ak.SafeAccountV0_3_0.DEFAULT_WEB_AUTHN_SHARED_SIGNER.slice(2).toLowerCase(),
+        );
+    });
+
+    test('deployed op: encodes the per-owner verifier-proxy address', async () => {
+        const { estimation, captured } = estimateWithDummyPairs({ factory: null });
+        await expect(estimation).resolves.toBeDefined();
+        const sentOp = captured[0].params[0];
+        const verifierProxy = ak.SafeAccountV0_3_0.createWebAuthnSignerVerifierAddress(
+            WEBAUTHN_KEY.x,
+            WEBAUTHN_KEY.y,
+        );
+        expect(encodedOwner(sentOp.signature)).toBe(verifierProxy.slice(2).toLowerCase());
+    });
+
+    test('deployed op: forwards custom verifier-config overrides to the encoder', async () => {
+        const { estimation, captured } = estimateWithDummyPairs({
+            factory: null,
+            overrides: { webAuthnSignerFactory: CUSTOM_SIGNER_FACTORY },
+        });
+        await expect(estimation).resolves.toBeDefined();
+        const sentOp = captured[0].params[0];
+        const customVerifierProxy = ak.SafeAccountV0_3_0.createWebAuthnSignerVerifierAddress(
+            WEBAUTHN_KEY.x,
+            WEBAUTHN_KEY.y,
+            { webAuthnSignerFactory: CUSTOM_SIGNER_FACTORY },
+        );
+        const defaultVerifierProxy = ak.SafeAccountV0_3_0.createWebAuthnSignerVerifierAddress(
+            WEBAUTHN_KEY.x,
+            WEBAUTHN_KEY.y,
+        );
+        expect(customVerifierProxy).not.toBe(defaultVerifierProxy);
+        expect(encodedOwner(sentOp.signature)).toBe(customVerifierProxy.slice(2).toLowerCase());
+    });
+});

--- a/test/safe/webauthnInitSignatureSort.test.js
+++ b/test/safe/webauthnInitSignatureSort.test.js
@@ -1,0 +1,60 @@
+// Regression test: during account init the encoded owner for a WebAuthn
+// signer is the shared signer, so sorting must use the shared-signer
+// address too — not the per-owner verifier-proxy address. Offline.
+
+const ak = require('../../dist/index.cjs');
+
+const WEBAUTHN_KEY = {
+    x: 0x7a2fa39b3c61b3cbab8e44abeac8c9c7a4c1f76d42ae6f47b3b2a96d5c4f1a2bn,
+    y: 0x2e8c5f6d4b7a9c1e3f5a8d7b6c4e2f1a9d8c7b6a5e4f3d2c1b0a9f8e7d6c5b4an,
+};
+
+const SHARED_SIGNER = ak.SafeAccountV0_3_0.DEFAULT_WEB_AUTHN_SHARED_SIGNER;
+// one below the shared signer, so: verifierProxy < EOA < sharedSigner
+const EOA = '0x' + (BigInt(SHARED_SIGNER) - 1n).toString(16).padStart(40, '0');
+
+const WEBAUTHN_SIG = '0x' + 'ab'.repeat(320);
+const EOA_SIG = '0x' + '22'.repeat(32) + '33'.repeat(32) + '1c';
+
+describe('WebAuthn init signature sorting', () => {
+    const verifierProxy = ak.SafeAccountV0_3_0.createWebAuthnSignerVerifierAddress(
+        WEBAUTHN_KEY.x,
+        WEBAUTHN_KEY.y,
+    );
+
+    test('fixture precondition: verifierProxy < EOA < sharedSigner', () => {
+        expect(verifierProxy.toLowerCase() < EOA.toLowerCase()).toBe(true);
+        expect(EOA.toLowerCase() < SHARED_SIGNER.toLowerCase()).toBe(true);
+    });
+
+    test('isInit: true sorts by the shared-signer address that gets encoded', () => {
+        const sig = ak.SafeAccountV0_3_0.buildSignaturesFromSingerSignaturePairs(
+            [
+                { signer: WEBAUTHN_KEY, signature: WEBAUTHN_SIG },
+                { signer: EOA, signature: EOA_SIG },
+            ],
+            { isInit: true },
+        );
+        const seg1 = sig.slice(2, 132);
+        const seg2 = sig.slice(132, 262);
+        // EOA (lower address) must come first: its segment ends with v=0x1c
+        expect(seg1.endsWith('1c')).toBe(true);
+        // contract-signature segment second: owner = shared signer, v=0
+        expect(seg2.slice(24, 64)).toBe(SHARED_SIGNER.slice(2).toLowerCase());
+        expect(seg2.slice(128, 130)).toBe('00');
+    });
+
+    test('isInit: false still sorts by the verifier-proxy address', () => {
+        const sig = ak.SafeAccountV0_3_0.buildSignaturesFromSingerSignaturePairs(
+            [
+                { signer: EOA, signature: EOA_SIG },
+                { signer: WEBAUTHN_KEY, signature: WEBAUTHN_SIG },
+            ],
+            { isInit: false },
+        );
+        const seg1 = sig.slice(2, 132);
+        // verifier proxy (lower address) comes first as the contract signature
+        expect(seg1.slice(24, 64)).toBe(verifierProxy.slice(2).toLowerCase());
+        expect(seg1.slice(128, 130)).toBe('00');
+    });
+});


### PR DESCRIPTION
Fixes for WebAuthn owner handling in `SafeAccount`.

  - **Init UserOperations failed with GS026 for ~50% of WebAuthn key pairs**: during account init the signature encoder substitutes the WebAuthn shared-signer address for a `WebauthnPublicKey` owner, but `sortSignatures` keyed on the per-owner verifier-proxy address. Whenever the two sorted differently relative to the other owners, the encoded signatures were out of ascending owner order and the Safe rejected the op — after gas estimation had already succeeded. Sorting now keys on the address that actually gets encoded.
  - **WebAuthn owners could never be swapped/removed**: `createWebAuthnSignerVerifierAddress` returned a lowercase address while `getOwners()` returns checksummed ones, so the lookups in `createSwapOwnerMetaTransactions`/`createRemoveOwnerMetaTransaction` always threw "not a current owner". The derived address is now checksummed and owner lookups are case-insensitive (lowercase EOA inputs work too).
  - **Estimation-path overrides**: user-supplied `dummySignerSignaturePairs` containing raw `WebauthnPublicKey` signers threw "Must define isInit parameter" with no way to supply the flag through the overrides API — in both `createUserOperation` and the public `baseEstimateUserOperationGas`. The init flag is now derived from the operation’s own init fields at both call sites, and the WebAuthn verifier-config overrides are forwarded to the signature encoder so deployed accounts with custom verifier setups encode the correct owner address instead of one derived from the defaults. The `PAYMASTER_SIG_MAGIC` check and its entrypoint-v0.9 gate also compared case-sensitively, spuriously rejecting uppercase hex `paymasterData` and lowercase entrypoint addresses.
  - **Docs**: clarify that `getSignerLowerCaseAddress` derives owner addresses (WebAuthn → verifier address), not just lowercases input.

  Tests added in `test/safe/webauthnInitSignatureSort.test.js` and `test/safe/webauthnDummyPairsEstimation.test.js`; full offline suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAuthn dummy-signature handling for user operation gas estimation, including correct “init” vs “deployed” owner resolution.
  * Fixed WebAuthn signer/verifier address formatting and ensured consistent sorting behavior across initialization and regular flows.
  * Improved compatibility for paymaster signature validation and EntryPoint checks with case-insensitive address handling.
  * Made Safe owner swap/remove operations reliable regardless of address capitalization.
* **Tests**
  * Added regression coverage for WebAuthn signature sorting during initialization.
  * Added regression coverage for gas estimation with user-supplied dummy signer signature pairs containing raw WebAuthn signers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->