### PR TITLE
fix: AllowanceModule start-delay semantics and Safe module diagnostics

### DIFF
--- a/src/account/Safe/modules/AllowanceModule.ts
+++ b/src/account/Safe/modules/AllowanceModule.ts
@@ -41,36 +41,37 @@ export class AllowanceModule extends SafeModule {
 
 	/**
 	 * Creates a MetaTransaction that sets a one-time (non-recurring) token allowance
-	 * for a delegate. The allowance is consumed once and never resets.
+	 * for a delegate. The allowance is consumed once and never resets, and it is
+	 * active as soon as the Safe executes the transaction.
+	 *
+	 * Note: the deployed AllowanceModule cannot delay activation of a one-time
+	 * allowance — `setAllowance` with `resetTimeMin == 0` reverts for any nonzero
+	 * `resetBaseMin` (division by zero in the period alignment).
 	 * @param delegate - Address of the delegate to grant the allowance to.
 	 * @param token - ERC-20 token contract address (use zero address for native token).
 	 * @param allowanceAmount - Maximum amount the delegate can spend, in the token's smallest unit.
-	 * @param startAfterInMinutes - Delay in minutes before the allowance becomes active.
 	 * @returns A MetaTransaction to be executed by the Safe.
 	 */
 	public createOneTimeAllowanceMetaTransaction(
 		delegate: string,
 		token: string,
 		allowanceAmount: bigint,
-		startAfterInMinutes: bigint,
 	): MetaTransaction {
-		return this.createBaseSetAllowanceMetaTransaction(
-			delegate,
-			token,
-			allowanceAmount,
-			0n,
-			startAfterInMinutes,
-		);
+		return this.createBaseSetAllowanceMetaTransaction(delegate, token, allowanceAmount, 0n, 0n);
 	}
 
 	/**
 	 * Creates a MetaTransaction that sets a recurring token allowance for a delegate.
-	 * The allowance resets to the full amount after each validity period elapses.
+	 * The allowance resets to the full amount after each validity period elapses,
+	 * and is spendable immediately once the Safe executes the transaction.
 	 * @param delegate - Address of the delegate to grant the allowance to.
 	 * @param token - ERC-20 token contract address (use zero address for native token).
 	 * @param allowanceAmount - Maximum amount per period, in the token's smallest unit.
 	 * @param recurringAllowanceValidityPeriodInMinutes - Duration of each allowance period in minutes.
-	 * @param startAfterInMinutes - Delay in minutes before the first allowance period begins.
+	 * @param periodStartBaseInMinutes - Optional absolute baseline that period
+	 * boundaries are aligned to, in minutes since the unix epoch (not a relative
+	 * delay — the module has no delayed-activation concept and requires this
+	 * baseline to be in the past). Defaults to 0n, aligning periods to the epoch.
 	 * @returns A MetaTransaction to be executed by the Safe.
 	 */
 	public createRecurringAllowanceMetaTransaction(
@@ -78,14 +79,23 @@ export class AllowanceModule extends SafeModule {
 		token: string,
 		allowanceAmount: bigint,
 		recurringAllowanceValidityPeriodInMinutes: bigint,
-		startAfterInMinutes: bigint,
+		periodStartBaseInMinutes: bigint = 0n,
 	): MetaTransaction {
+		const nowInMinutes = BigInt(Math.floor(Date.now() / 60_000));
+		if (periodStartBaseInMinutes > nowInMinutes) {
+			throw new RangeError(
+				"periodStartBaseInMinutes is an absolute baseline in minutes since " +
+					"the unix epoch and must be in the past — the AllowanceModule " +
+					"contract reverts on a future baseline and has no " +
+					"delayed-activation concept.",
+			);
+		}
 		return this.createBaseSetAllowanceMetaTransaction(
 			delegate,
 			token,
 			allowanceAmount,
 			recurringAllowanceValidityPeriodInMinutes,
-			startAfterInMinutes,
+			periodStartBaseInMinutes,
 		);
 	}
 

--- a/src/account/Safe/modules/AllowanceModule.ts
+++ b/src/account/Safe/modules/AllowanceModule.ts
@@ -396,10 +396,10 @@ export class AllowanceModule extends SafeModule {
 		let start = overrides.start ?? 0n;
 		if (overrides.maxNumberOfResults != null) {
 			// the module's page-size parameter is a uint8
-			if (overrides.maxNumberOfResults > 255n) {
+			if (overrides.maxNumberOfResults < 0n || overrides.maxNumberOfResults > 255n) {
 				throw new RangeError(
-					"maxNumberOfResults can't exceed 255 (the module's page size is a " +
-						"uint8) — omit it to fetch all delegates via pagination.",
+					"maxNumberOfResults must be between 0 and 255 (the module's page " +
+						"size is a uint8) — omit it to fetch all delegates via pagination.",
 				);
 			}
 			return (

--- a/src/account/Safe/modules/AllowanceModule.ts
+++ b/src/account/Safe/modules/AllowanceModule.ts
@@ -388,6 +388,13 @@ export class AllowanceModule extends SafeModule {
 	): Promise<string[]> {
 		let start = overrides.start ?? 0n;
 		if (overrides.maxNumberOfResults != null) {
+			// the module's page-size parameter is a uint8
+			if (overrides.maxNumberOfResults > 255n) {
+				throw new RangeError(
+					"maxNumberOfResults can't exceed 255 (the module's page size is a " +
+						"uint8) — omit it to fetch all delegates via pagination.",
+				);
+			}
 			return (
 				await this.baseGetDelegates(nodeRpcUrl, safeAddress, start, overrides.maxNumberOfResults)
 			).results;

--- a/src/account/Safe/modules/AllowanceModule.ts
+++ b/src/account/Safe/modules/AllowanceModule.ts
@@ -45,8 +45,8 @@ export class AllowanceModule extends SafeModule {
 	 * active as soon as the Safe executes the transaction.
 	 *
 	 * Note: the deployed AllowanceModule cannot delay activation of a one-time
-	 * allowance — `setAllowance` with `resetTimeMin == 0` reverts for any nonzero
-	 * `resetBaseMin` (division by zero in the period alignment).
+	 * allowance — `setAllowance` explicitly requires `resetTimeMin > 0` whenever
+	 * `resetBaseMin` is nonzero and reverts otherwise.
 	 * @param delegate - Address of the delegate to grant the allowance to.
 	 * @param token - ERC-20 token contract address (use zero address for native token).
 	 * @param allowanceAmount - Maximum amount the delegate can spend, in the token's smallest unit.
@@ -68,10 +68,16 @@ export class AllowanceModule extends SafeModule {
 	 * @param token - ERC-20 token contract address (use zero address for native token).
 	 * @param allowanceAmount - Maximum amount per period, in the token's smallest unit.
 	 * @param recurringAllowanceValidityPeriodInMinutes - Duration of each allowance period in minutes.
-	 * @param periodStartBaseInMinutes - Optional absolute baseline that period
-	 * boundaries are aligned to, in minutes since the unix epoch (not a relative
-	 * delay — the module has no delayed-activation concept and requires this
-	 * baseline to be in the past). Defaults to 0n, aligning periods to the epoch.
+	 * @param inThePastPeriodStartBaseTimeStamp - Optional unix
+	 * timestamp **in seconds** that must be in the past (less than the block timestamp).
+	 * It represents the start of the recurring allowance period accounting — it does
+	 * **not** delay activation: the allowance is active and spendable immediately once
+	 * the Safe executes the transaction; this value only sets when each period resets.
+	 * So if you want to start accounting from a Saturday 10am for example, calculate the
+	 * timestamp of any previous Saturday 10am and use it as the value for this param.
+	 * Defaults to 0n, which starts the period accounting at the moment the Safe
+	 * executes the transaction for a new allowance; when updating an existing
+	 * allowance, 0n keeps its current accounting anchor unchanged.
 	 * @returns A MetaTransaction to be executed by the Safe.
 	 */
 	public createRecurringAllowanceMetaTransaction(
@@ -79,15 +85,16 @@ export class AllowanceModule extends SafeModule {
 		token: string,
 		allowanceAmount: bigint,
 		recurringAllowanceValidityPeriodInMinutes: bigint,
-		periodStartBaseInMinutes: bigint = 0n,
+		inThePastPeriodStartBaseTimeStamp: bigint = 0n,
 	): MetaTransaction {
-		const nowInMinutes = BigInt(Math.floor(Date.now() / 60_000));
-		if (periodStartBaseInMinutes > nowInMinutes) {
+		const baseInMinutes = inThePastPeriodStartBaseTimeStamp / 60n;
+		// resetBaseMin is a uint32 of minutes since the epoch; a millisecond
+		// timestamp (Date.now()) still overflows this bound after conversion
+		if (inThePastPeriodStartBaseTimeStamp < 0n || baseInMinutes >= 2n ** 32n) {
 			throw new RangeError(
-				"periodStartBaseInMinutes is an absolute baseline in minutes since " +
-					"the unix epoch and must be in the past — the AllowanceModule " +
-					"contract reverts on a future baseline and has no " +
-					"delayed-activation concept.",
+				"inThePastPeriodStartBaseTimeStamp must be a unix timestamp in " +
+					"seconds — its minutes equivalent must fit the contract's " +
+					"uint32 resetBaseMin; a millisecond timestamp does not.",
 			);
 		}
 		return this.createBaseSetAllowanceMetaTransaction(
@@ -95,7 +102,7 @@ export class AllowanceModule extends SafeModule {
 			token,
 			allowanceAmount,
 			recurringAllowanceValidityPeriodInMinutes,
-			periodStartBaseInMinutes,
+			baseInMinutes,
 		);
 	}
 

--- a/src/account/Safe/modules/SocialRecoveryModule.ts
+++ b/src/account/Safe/modules/SocialRecoveryModule.ts
@@ -536,7 +536,7 @@ export class SocialRecoveryModule extends SafeModule {
 		};
 		const getGuardiansResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		this.checkForEmptyResultAndRevert(getGuardiansResult, "threshold");
+		this.checkForEmptyResultAndRevert(getGuardiansResult, "getGuardians");
 		const decodedCalldata = decodeAbiParameters<[string[]]>(["address[]"], getGuardiansResult);
 
 		return decodedCalldata[0];
@@ -562,7 +562,7 @@ export class SocialRecoveryModule extends SafeModule {
 		};
 		const nonceResult = await JsonRpcNode.from(nodeRpcUrl).call(ethCallParams, "latest");
 
-		this.checkForEmptyResultAndRevert(nonceResult, "threshold");
+		this.checkForEmptyResultAndRevert(nonceResult, "nonce");
 		const decodedCalldata = decodeAbiParameters<[bigint]>(["uint256"], nonceResult);
 
 		return BigInt(decodedCalldata[0]);
@@ -579,7 +579,7 @@ export class SocialRecoveryModule extends SafeModule {
 	 * object needed for hashing and signing
 	 */
 	async getRecoveryRequestEip712Data(
-		rpcNode: string,
+		rpcNode: string | Transport | JsonRpcNode,
 		chainId: bigint,
 		accountAddress: string,
 		newOwners: string[],

--- a/test/safe/allowanceModule.test.js
+++ b/test/safe/allowanceModule.test.js
@@ -29,24 +29,40 @@ describe('AllowanceModule setAllowance encoding', () => {
         expect(resetBaseMin).toBe(0n);
     });
 
-    test('recurring allowance encodes the validity period and past baseline', () => {
-        const baseline = BigInt(Math.floor(Date.now() / 60_000)) - 60n;
+    test('recurring allowance converts the seconds timestamp to epoch-minutes', () => {
+        const baselineSeconds = BigInt(Math.floor(Date.now() / 1000)) - 3600n;
         const tx = module.createRecurringAllowanceMetaTransaction(
             DELEGATE,
             TOKEN,
             100n,
             1440n,
-            baseline,
+            baselineSeconds,
         );
         const { resetTimeMin, resetBaseMin } = decodeSetAllowance(tx.data);
         expect(resetTimeMin).toBe(1440n);
-        expect(resetBaseMin).toBe(baseline);
+        expect(resetBaseMin).toBe(baselineSeconds / 60n);
     });
 
-    test('recurring allowance rejects a future baseline (reverts on-chain)', () => {
-        const future = BigInt(Math.floor(Date.now() / 60_000)) + 60n;
+    test('sub-minute precision is floored', () => {
+        const tx = module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, 1440n, 119n);
+        const { resetBaseMin } = decodeSetAllowance(tx.data);
+        expect(resetBaseMin).toBe(1n);
+    });
+
+    test('recurring allowance accepts a near-future baseline (contract enforces the past bound at execution)', () => {
+        const futureSeconds = BigInt(Math.floor(Date.now() / 1000)) + 3600n;
+        const tx = module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, 1440n, futureSeconds);
+        const { resetBaseMin } = decodeSetAllowance(tx.data);
+        expect(resetBaseMin).toBe(futureSeconds / 60n);
+    });
+
+    test.each([
+        ['negative', -1n],
+        ['uint32 overflow after conversion', 2n ** 32n * 60n],
+        ['millisecond timestamp', 1_770_000_000_000n],
+    ])('recurring allowance rejects a timestamp whose minutes cannot be a uint32 (%s)', (_label, bad) => {
         expect(() =>
-            module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, 1440n, future),
+            module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, 1440n, bad),
         ).toThrow(RangeError);
     });
 });

--- a/test/safe/allowanceModule.test.js
+++ b/test/safe/allowanceModule.test.js
@@ -1,0 +1,52 @@
+// Offline tests for AllowanceModule setAllowance encoding and the guards
+// around the on-chain semantics of resetTimeMin/resetBaseMin.
+
+const ak = require('../../dist/index.cjs');
+const { AbiCoder } = require('ethers');
+
+const DELEGATE = '0x1a02592A3484c2077d2E5D24482497F85e1980C6';
+const TOKEN = '0x084f4dB6bae8fBb7fb9709c0A25532E21C7A097E';
+const SET_ALLOWANCE_SELECTOR = '0xbeaeb388';
+
+function decodeSetAllowance(data) {
+    expect(data.slice(0, 10)).toBe(SET_ALLOWANCE_SELECTOR);
+    const [delegate, token, amount, resetTimeMin, resetBaseMin] =
+        AbiCoder.defaultAbiCoder().decode(
+            ['address', 'address', 'uint96', 'uint16', 'uint32'],
+            '0x' + data.slice(10),
+        );
+    return { delegate, token, amount, resetTimeMin, resetBaseMin };
+}
+
+describe('AllowanceModule setAllowance encoding', () => {
+    const module = new ak.AllowanceModule();
+
+    test('one-time allowance encodes resetTimeMin=0 and resetBaseMin=0', () => {
+        const tx = module.createOneTimeAllowanceMetaTransaction(DELEGATE, TOKEN, 100n);
+        const { amount, resetTimeMin, resetBaseMin } = decodeSetAllowance(tx.data);
+        expect(amount).toBe(100n);
+        expect(resetTimeMin).toBe(0n);
+        expect(resetBaseMin).toBe(0n);
+    });
+
+    test('recurring allowance encodes the validity period and past baseline', () => {
+        const baseline = BigInt(Math.floor(Date.now() / 60_000)) - 60n;
+        const tx = module.createRecurringAllowanceMetaTransaction(
+            DELEGATE,
+            TOKEN,
+            100n,
+            1440n,
+            baseline,
+        );
+        const { resetTimeMin, resetBaseMin } = decodeSetAllowance(tx.data);
+        expect(resetTimeMin).toBe(1440n);
+        expect(resetBaseMin).toBe(baseline);
+    });
+
+    test('recurring allowance rejects a future baseline (reverts on-chain)', () => {
+        const future = BigInt(Math.floor(Date.now() / 60_000)) + 60n;
+        expect(() =>
+            module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, 1440n, future),
+        ).toThrow(RangeError);
+    });
+});

--- a/test/safe/allowanceModule.test.js
+++ b/test/safe/allowanceModule.test.js
@@ -65,4 +65,13 @@ describe('AllowanceModule setAllowance encoding', () => {
             module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, 1440n, bad),
         ).toThrow(RangeError);
     });
+
+    test.each([
+        ['negative', -1n],
+        ['above 255', 256n],
+    ])('getDelegates rejects a maxNumberOfResults outside the uint8 range (%s)', async (_label, bad) => {
+        await expect(
+            module.getDelegates('http://localhost:1', DELEGATE, { maxNumberOfResults: bad }),
+        ).rejects.toThrow(RangeError);
+    });
 });


### PR DESCRIPTION
Fixes for the Safe AllowanceModule and SocialRecoveryModule helpers.

  - **Delayed one-time allowances never worked**: `createOneTimeAllowanceMetaTransaction` passed `startAfterInMinutes` as the contract's `resetBaseMin` with `resetTimeMin = 0`, which reverts on-chain for any nonzero value (`setAllowance` explicitly requires `resetTimeMin > 0` whenever `resetBaseMin` is nonzero). The parameter is removed.
  - **Recurring allowance "delay" was misleading and unsafe**: the last parameter of `createRecurringAllowanceMetaTransaction` was documented as a relative activation delay, but  on-chain `resetBaseMin` is an absolute epoch-minutes baseline that must be in the past and only aligns period boundaries — a relative value made funds spendable immediately. Renamed to `inThePastPeriodStartBaseTimeStamp`, now taking a unix timestamp **in seconds** (converted to the contract's epoch-minutes `resetBaseMin` internally, flooring sub-minute precision). The docs state explicitly that the allowance is active immediately — the value only anchors the period accounting, with a worked example. A deterministic uint32 range check on the converted minutes catches millisecond-timestamp mistakes; the contract's own `require(resetBaseMin <= currentMin)` enforces the past bound at execution time, so a meta-transaction can be prepared before its anchor passes.
  - **Diagnostics**: `SocialRecoveryModule.getGuardians`/`.nonce` reported empty-result errors under the name "threshold"; `getRecoveryRequestEip712Data` only accepted a URL string  while every sibling accepts `string | Transport | JsonRpcNode`; `AllowanceModule.getDelegates` with `maxNumberOfResults > 255` threw an opaque ABI out-of-bounds error (the module's  page size is a uint8) and now fails with a clear `RangeError` pointing at pagination.

  Note: removing/renaming the start-delay parameters is a breaking change to those two helper signatures.

  Tests added in `test/safe/allowanceModule.test.js`; full offline suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated allowance meta-transaction creation: one-time allowances removed start-delay input and always use immediate reset values; recurring allowances now take an absolute baseline timestamp in seconds (defaulting to immediate) instead of a relative delay.

- **Bug Fixes**
  - Improved Social Recovery JSON-RPC helpers to use correct operation names for empty-result/nonce handling.
  - Added stricter validation for recurring baseline inputs and delegate pagination limits, throwing `RangeError` for out-of-range values.

- **Tests**
  - Added offline calldata decoding tests for allowance `setAllowance`, including baseline conversion edge cases and invalid-input rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->