### PR TITLE
fix: 7702 authorization/legacy-tx signature encoding and Simple7702 revoke guard

### DIFF
--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -1,4 +1,4 @@
-import {decodeAbiParameters, hexlify, signHash} from "src/ethereUtils";
+import {decodeAbiParameters, hexlify, privateKeyToAddress, signHash} from "src/ethereUtils";
 import {Bundler} from "src/Bundler";
 import {BaseUserOperationDummyValues, ENTRYPOINT_V8, ENTRYPOINT_V9} from "src/constants";
 import {AbstractionKitError} from "src/errors";
@@ -208,6 +208,17 @@ export class BaseSimple7702Account extends SmartAccount {
 			chainId?: bigint;
 		} = {},
 	): Promise<string> {
+		// Verify the private key matches this account — otherwise the raw
+		// transaction's sender (recovered from the signature) would be a
+		// different EOA and the revoke would target the signer's delegation
+		const signerAddress = privateKeyToAddress(eoaPrivateKey);
+		if (signerAddress.toLowerCase() !== this.accountAddress.toLowerCase()) {
+			throw new AbstractionKitError(
+				"BAD_DATA",
+				`eoaPrivateKey does not match accountAddress (${this.accountAddress})`,
+			);
+		}
+
 		// Verify delegation state before revoking
 		const delegatedTo = await JsonRpcNode.from(providerRpc).getDelegatedAddress(this.accountAddress);
 		if (delegatedTo === null) {

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -454,24 +454,37 @@ function parseRawSignature(rawSig: string): { yParity: 0 | 1; r: bigint; s: bigi
 		);
 	}
 	const r = BigInt(`0x${sig.slice(0, 64)}`);
+	let yParity: 0 | 1;
+	let s: bigint;
 
 	if (sig.length === 128) {
 		// EIP-2098 compact signature (64 bytes): r (32) + yParity||s (32)
 		const yParityAndS = BigInt(`0x${sig.slice(64, 128)}`);
-		const yParity = Number((yParityAndS >> 255n) & 1n) as 0 | 1;
-		const s = yParityAndS & ((1n << 255n) - 1n);
-		return { yParity, r, s };
+		yParity = Number((yParityAndS >> 255n) & 1n) as 0 | 1;
+		s = yParityAndS & ((1n << 255n) - 1n);
+	} else {
+		// Standard 65-byte signature: r (32) + s (32) + v (1)
+		s = BigInt(`0x${sig.slice(64, 128)}`);
+		const v = parseInt(sig.slice(128, 130), 16);
+		if (v !== 0 && v !== 1 && v !== 27 && v !== 28) {
+			throw new RangeError(`invalid signature v value: ${v}`);
+		}
+		yParity = (v >= 27 ? v - 27 : v) as 0 | 1;
 	}
 
-	// Standard 65-byte signature: r (32) + s (32) + v (1)
-	const s = BigInt(`0x${sig.slice(64, 128)}`);
-	const v = parseInt(sig.slice(128, 130), 16);
-	if (v !== 0 && v !== 1 && v !== 27 && v !== 28) {
-		throw new RangeError(`invalid signature v value: ${v}`);
+	// EIP-7702 requires s <= n/2; nodes silently skip high-s authorization
+	// tuples. Normalize to the complementary low-s signature.
+	if (s > SECP256K1_HALF_N) {
+		s = SECP256K1_N - s;
+		yParity = (1 - yParity) as 0 | 1;
 	}
-	const yParity = (v >= 27 ? v - 27 : v) as 0 | 1;
 	return { yParity, r, s };
 }
+
+const SECP256K1_N = BigInt(
+	"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+);
+const SECP256K1_HALF_N = SECP256K1_N / 2n;
 
 /**
  * Converts a bigint to a 0x-prefixed hex string with even-length padding.

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -440,6 +440,11 @@ function bigintToBytes(bi: bigint) {
 	return getBytes(toBeArray(bi));
 }
 
+const SECP256K1_N = BigInt(
+	"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+);
+const SECP256K1_HALF_N = SECP256K1_N / 2n;
+
 /**
  * Parse a raw ECDSA signature into its components.
  * Supports standard 65-byte (r + s + v) and EIP-2098 64-byte compact formats.
@@ -480,11 +485,6 @@ function parseRawSignature(rawSig: string): { yParity: 0 | 1; r: bigint; s: bigi
 	}
 	return { yParity, r, s };
 }
-
-const SECP256K1_N = BigInt(
-	"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
-);
-const SECP256K1_HALF_N = SECP256K1_N / 2n;
 
 /**
  * Converts a bigint to a 0x-prefixed hex string with even-length padding.

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -448,8 +448,29 @@ const SECP256K1_HALF_N = SECP256K1_N / 2n;
 /**
  * Parse a raw ECDSA signature into its components.
  * Supports standard 65-byte (r + s + v) and EIP-2098 64-byte compact formats.
+ *
+ * High-s signatures are normalized to the complementary low-s form
+ * (s' = n - s, flipped yParity) rather than rejected. A high-s value is not
+ * a signer defect: plain ECDSA produces s uniformly across the range, so
+ * generic signers (AWS KMS, HSMs, WebCrypto) return high-s for ~half of all
+ * signatures — the low-s rule is an Ethereum canonicalization convention
+ * (EIP-2), not part of ECDSA. Per the EIP-2 rationale, the complementary
+ * signature is equally valid for the same signer and payload, so the
+ * conversion changes the encoding, not the authorization. Rejecting instead
+ * would fail nondeterministically on ~half of all signatures from such
+ * signers, and EIP-7702 makes the unnormalized failure mode silent: nodes
+ * validate s <= secp256k1n/2 per tuple and skip invalid tuples without
+ * error, so a high-s authorization would "succeed" without ever applying
+ * the delegation.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-2 - s-value bound and the
+ * malleability rationale (flipping s to secp256k1n - s with the v flip
+ * "would still be valid")
+ * @see https://eips.ethereum.org/EIPS/eip-7702 - Behavior steps: "Verify s
+ * is less than or equal to secp256k1n/2" and "If any step above fails,
+ * immediately stop processing the tuple and continue to the next tuple"
  * @param rawSig - Hex string: 128 chars (EIP-2098 compact), or 130/132 chars (standard with 0x prefix)
- * @returns An object with yParity (0 or 1), r, and s components
+ * @returns An object with yParity (0 or 1), r, and s components (low-s normalized)
  */
 function parseRawSignature(rawSig: string): { yParity: 0 | 1; r: bigint; s: bigint } {
 	const sig = rawSig.startsWith("0x") ? rawSig.slice(2) : rawSig;

--- a/src/utils7702.ts
+++ b/src/utils7702.ts
@@ -107,8 +107,10 @@ export function createAndSignLegacyRawTransaction(
 		bigintToBytes(value),
 		data,
 		bigintToBytes(BigInt(signature.yParity) + chainId * 2n + 35n),
-		getBytes(signature.r),
-		getBytes(signature.s),
+		// r and s must be minimal big-endian integers — nodes reject RLP
+		// scalars with leading zero bytes as non-canonical
+		bigintToBytes(BigInt(signature.r)),
+		bigintToBytes(BigInt(signature.s)),
 	];
 	const transactionPayload = encodeRlp(payload);
 	return transactionPayload;

--- a/test/utils7702.test.js
+++ b/test/utils7702.test.js
@@ -38,3 +38,33 @@ describe("createAndSignLegacyRawTransaction v computation (#128)", () => {
 		expect(tx.from.toLowerCase()).toBe(wallet.address.toLowerCase());
 	});
 });
+
+describe("createAndSignLegacyRawTransaction canonical RLP r/s", () => {
+	// These keys deterministically (RFC 6979) produce a signature whose r or s
+	// has a leading zero byte for this payload; the raw tx must still encode
+	// r/s as minimal integers or nodes reject it as non-canonical RLP.
+	test.each([38, 63])(
+		"key %i with a leading-zero r/s component encodes minimally and recovers",
+		(i) => {
+			const { decodeRlp, getBytes } = require("ethers");
+			const pk = "0x" + i.toString(16).padStart(64, "0");
+			const raw = ak.createAndSignLegacyRawTransaction(
+				1n,
+				0n,
+				1000000000n,
+				21000n,
+				"0x" + "aa".repeat(20),
+				0n,
+				"0x",
+				pk,
+			);
+			const fields = decodeRlp(raw);
+			const r = getBytes(fields[7]);
+			const s = getBytes(fields[8]);
+			expect(r.length === 0 || r[0] !== 0).toBe(true);
+			expect(s.length === 0 || s[0] !== 0).toBe(true);
+			const tx = Transaction.from(raw);
+			expect(tx.from.toLowerCase()).toBe(new Wallet(pk).address.toLowerCase());
+		},
+	);
+});

--- a/test/utils7702.test.js
+++ b/test/utils7702.test.js
@@ -68,3 +68,39 @@ describe("createAndSignLegacyRawTransaction canonical RLP r/s", () => {
 		},
 	);
 });
+
+describe("createAndSignEip7702DelegationAuthorization low-s normalization", () => {
+	const N = BigInt(
+		"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+	);
+
+	test("normalizes a high-s callback signature to the low-s complement", async () => {
+		const { SigningKey } = require("ethers");
+		const wallet = new Wallet("0x" + "11".repeat(32));
+		const chainId = 1n;
+		const delegatee = "0x" + "aa".repeat(20);
+		const nonce = 0n;
+
+		const authHash = ak.createEip7702DelegationAuthorizationHash(chainId, delegatee, nonce);
+		const lowSig = wallet.signingKey.sign(authHash); // ethers always low-s
+		// construct the complementary high-s signature with flipped parity
+		const highS = N - BigInt(lowSig.s);
+		const highV = lowSig.yParity === 0 ? 28 : 27;
+		const highSig =
+			"0x" +
+			lowSig.r.slice(2) +
+			highS.toString(16).padStart(64, "0") +
+			highV.toString(16).padStart(2, "0");
+
+		const auth = await ak.createAndSignEip7702DelegationAuthorization(
+			chainId,
+			delegatee,
+			nonce,
+			async () => highSig,
+		);
+		// must come back as the original low-s signature
+		expect(BigInt(auth.s)).toBe(BigInt(lowSig.s));
+		expect(Number(BigInt(auth.yParity))).toBe(lowSig.yParity);
+		expect(BigInt(auth.s) <= N / 2n).toBe(true);
+	});
+});


### PR DESCRIPTION
 Signature-encoding fixes on the EIP-7702 paths.

  - **Legacy transactions with leading-zero r/s were rejected by nodes**: `createAndSignLegacyRawTransaction` encoded r and s from the 32-byte zero-padded hex, so any signature whose
  r or s has a leading zero byte (~0.8% of transactions, deterministic per key/payload under RFC 6979) produced `rlp: non-canonical integer (leading zero bytes)`. Both are now encoded
  as minimal RLP integers via `bigintToBytes`, like the EIP-7702 path.
  - **High-s external signatures silently never applied delegation**: EIP-7702 requires `s <= n/2` in authorization tuples, and nodes silently skip high-s tuples during set-code processing — a signer callback returning a standard high-s signature failed with no error surfaced. `parseRawSignature` now normalizes to the complementary low-s form (`s' = n − s`,
  flipped parity), matching the private-key path.
  - **Simple7702 revoke could revoke the wrong account's delegation**: `createRevokeDelegationTransaction` fetched delegation status and the nonce for `accountAddress` but signed with
  `eoaPrivateKey` unconditionally — with a mismatched key, the broadcast transaction revoked the *signer's* delegation instead. The same up-front key/address check the Calibur revoke
  path has is now applied.

  Also moves the secp256k1 constants above `parseRawSignature` for read-before-use ordering (no behavior change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delegation revocation when the supplied private key does not match the account address.
  - Improved transaction signature encoding to use canonical, minimal formats.
  - Normalized high-`s` signatures for EIP-7702 authorizations, improving compatibility and validation.

- **Tests**
  - Added coverage for canonical signature encoding and low-`s` normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->