### PR TITLE
fix: paymaster gas-buffer casing, caller-op mutation, and token-flow errors

### DIFF
--- a/src/paymaster/CandidePaymaster.ts
+++ b/src/paymaster/CandidePaymaster.ts
@@ -485,7 +485,14 @@ export class CandidePaymaster extends Paymaster implements Transport {
 			overrides.callGasLimit ??
 			applyMultiplier(callGasLimit, overrides.callGasLimitPercentageMultiplier ?? 10);
 
-		if (entrypoint === ENTRYPOINT_V6) {
+		// Lowercase compare — the entrypoint comes from arbitrary user input
+		// and ENTRYPOINT_V6 is checksummed. Skip the buffer when the caller
+		// pinned verificationGasLimit explicitly: the override is documented
+		// to be used verbatim.
+		if (
+			overrides.verificationGasLimit == null &&
+			entrypoint.toLowerCase() === ENTRYPOINT_V6.toLowerCase()
+		) {
 			userOp.verificationGasLimit += PAYMASTER_V06_VERIFICATION_OVERHEAD;
 		}
 	}

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -65,7 +65,11 @@ function parsePositiveExchangeRate(raw: string | bigint | undefined | null): big
  * (Pimlico, Alchemy, …) have their own conventions. Refer to the
  * paymaster provider's documentation for the exact fields.
  *
- * ## Reserved fields consumed by this class (not forwarded to the RPC)
+ * ## Fields consumed by this class
+ *
+ * The whole context object — including the fields below — is forwarded to the
+ * RPC verbatim; providers ignore keys they don't recognize. The fields listed
+ * here are additionally interpreted by this class:
  *
  * - `exchangeRate` - token-to-ETH exchange rate as a bigint or hex/decimal
  *   string. Represents the count of token smallest-units equivalent to 1 ETH
@@ -74,6 +78,8 @@ function parsePositiveExchangeRate(raw: string | bigint | undefined | null): big
  *   provider is auto-detected (floored to a minimum of 1 token smallest-unit
  *   to handle cheap-gas chains). Not needed when `provider` is `"pimlico"` or
  *   `"candide"`; the class fetches the rate from the provider's RPC.
+ * - `paymasterAddress` - overrides the token-flow paymaster address when it
+ *   cannot be derived from the stub data or a provider RPC.
  */
 export type Erc7677Context = Record<string, unknown>;
 
@@ -133,9 +139,11 @@ export interface Erc7677StubDataResult extends Erc7677PaymasterFields {
  *
  * ## Token paymaster flows
  *
- * When `context.token` is set and the smart account implements
- * `prependTokenPaymasterApproveToCallData`, the class automatically runs the
- * token paymaster pipeline:
+ * When `context.token` is set the class runs the token paymaster pipeline.
+ * Once the pipeline engages (a provider is detected or an exchange rate is
+ * available) the smart account must implement
+ * `prependTokenPaymasterApproveToCallData`, otherwise a PAYMASTER_ERROR is
+ * thrown:
  *
  * - **Provider detected** (Candide, Pimlico): fetches exchange rate and
  *   paymaster address via provider-specific RPC, then handles approval
@@ -814,6 +822,15 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 		} else {
 			// Case C: no provider, no exchangeRate — fall through to regular flow.
 			return this.sponsoredFlow(userOp, bundlerRpc, entrypoint, chainIdHex, context, overrides);
+		}
+
+		if (typeof smartAccount.prependTokenPaymasterApproveToCallData !== "function") {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"context.token is set but this smart account does not implement " +
+					"prependTokenPaymasterApproveToCallData, which the token " +
+					"paymaster flow requires to prepend the ERC-20 approval.",
+			);
 		}
 
 		// Step 2 — stub paymaster data for gas estimation.

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -791,6 +791,22 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 		context: Erc7677Context,
 		overrides: GasPaymasterUserOperationOverrides,
 	): Promise<{ userOperation: SameUserOp<T>; tokenQuote?: TokenQuote }> {
+		// Case C: no provider, no exchangeRate — fall through to regular flow.
+		if (this.provider == null && context.exchangeRate == null) {
+			return this.sponsoredFlow(userOp, bundlerRpc, entrypoint, chainIdHex, context, overrides);
+		}
+
+		// The flow below always prepends an approval, so verify the account
+		// supports it before spending a provider round-trip on the quote.
+		if (typeof smartAccount.prependTokenPaymasterApproveToCallData !== "function") {
+			throw new AbstractionKitError(
+				"PAYMASTER_ERROR",
+				"context.token is set but this smart account does not implement " +
+					"prependTokenPaymasterApproveToCallData, which the token " +
+					"paymaster flow requires to prepend the ERC-20 approval.",
+			);
+		}
+
 		// Step 1 — resolve exchange rate + paymaster address.
 		let exchangeRate: bigint;
 		let paymasterAddress: string | null = null;
@@ -820,17 +836,9 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 				);
 			}
 		} else {
-			// Case C: no provider, no exchangeRate — fall through to regular flow.
+			// Unreachable: the Case C guard above already returned. Kept for
+			// definite assignment of exchangeRate.
 			return this.sponsoredFlow(userOp, bundlerRpc, entrypoint, chainIdHex, context, overrides);
-		}
-
-		if (typeof smartAccount.prependTokenPaymasterApproveToCallData !== "function") {
-			throw new AbstractionKitError(
-				"PAYMASTER_ERROR",
-				"context.token is set but this smart account does not implement " +
-					"prependTokenPaymasterApproveToCallData, which the token " +
-					"paymaster flow requires to prepend the ERC-20 approval.",
-			);
 		}
 
 		// Step 2 — stub paymaster data for gas estimation.

--- a/src/paymaster/Erc7677Paymaster.ts
+++ b/src/paymaster/Erc7677Paymaster.ts
@@ -568,7 +568,12 @@ export class Erc7677Paymaster extends Paymaster implements Transport {
 			overrides.callGasLimit ??
 			applyMultiplier(callGasLimit, overrides.callGasLimitPercentageMultiplier ?? 10);
 
-		if (entrypoint.toLowerCase() === ENTRYPOINT_V6.toLowerCase()) {
+		// Skip the buffer when the caller pinned verificationGasLimit
+		// explicitly: the override is documented to be used verbatim.
+		if (
+			overrides.verificationGasLimit == null &&
+			entrypoint.toLowerCase() === ENTRYPOINT_V6.toLowerCase()
+		) {
 			// Align with CandidePaymaster: add paymaster verification overhead for v0.6.
 			// Lowercase compare — overrides.entrypoint is arbitrary user input
 			// and ENTRYPOINT_V6 is checksummed.

--- a/src/paymaster/WorldIdPermissionlessPaymaster.ts
+++ b/src/paymaster/WorldIdPermissionlessPaymaster.ts
@@ -96,10 +96,13 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 			encodeAbiParameters(["uint256"], [nullifierHash]).slice(2) +
 			encodeAbiParameters(["uint256[8]"], [proofArr]).slice(2);
 
-		userOperation.paymaster = this.address;
-		userOperation.paymasterData = paymasterData;
-		userOperation.paymasterPostOpGasLimit = 45_000n;
-		userOperation.paymasterVerificationGasLimit = 350_000n;
+		// work on a shallow copy so the caller's userOperation is not mutated
+		// (and not left corrupted if estimation throws below)
+		const userOp: UserOperationV8 | UserOperationV7 = { ...userOperation };
+		userOp.paymaster = this.address;
+		userOp.paymasterData = paymasterData;
+		userOp.paymasterPostOpGasLimit = 45_000n;
+		userOp.paymasterVerificationGasLimit = 350_000n;
 
 		if (overrides == null) {
 			overrides = {};
@@ -107,23 +110,23 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 		let entrypointAddress = overrides.entrypoint;
 
 		if (entrypointAddress == null) {
-			if ("eip7702Auth" in userOperation) {
+			if ("eip7702Auth" in userOp) {
 				entrypointAddress = ENTRYPOINT_V8;
 			} else {
 				entrypointAddress = ENTRYPOINT_V7;
 			}
 		}
 
-		let preVerificationGas = userOperation.preVerificationGas;
-		let verificationGasLimit = userOperation.verificationGasLimit;
-		let callGasLimit = userOperation.callGasLimit;
+		let preVerificationGas = userOp.preVerificationGas;
+		let verificationGasLimit = userOp.verificationGasLimit;
+		let callGasLimit = userOp.callGasLimit;
 
 		// set preVerificationGas to zero to force re-estimation
-		userOperation.preVerificationGas = 0n;
+		userOp.preVerificationGas = 0n;
 
 		const bundler = Bundler.from(bundlerRpc);
 		const estimation = await bundler.estimateUserOperationGas(
-			userOperation,
+			userOp,
 			entrypointAddress as string,
 			overrides.state_override_set,
 		);
@@ -140,11 +143,11 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 			callGasLimit = estimation.callGasLimit;
 		}
 
-		userOperation.preVerificationGas = preVerificationGas;
-		userOperation.verificationGasLimit = verificationGasLimit;
-		userOperation.callGasLimit = callGasLimit;
+		userOp.preVerificationGas = preVerificationGas;
+		userOp.verificationGasLimit = verificationGasLimit;
+		userOp.callGasLimit = callGasLimit;
 
-		return userOperation;
+		return userOp;
 	}
 }
 


### PR DESCRIPTION
Three paymaster fixes.

  - **v0.6 verification-gas buffer silently skipped**: `CandidePaymaster` compared the entrypoint against the checksummed `ENTRYPOINT_V6` constant with strict equality, so a lowercase entrypoint (accepted everywhere else) skipped the 40k v0.6 paymaster verification buffer, under-provisioning `verificationGasLimit` once real `paymasterAndData` replaced the dummy.
  Both paymasters also added the buffer on top of an explicit `overrides.verificationGasLimit`, which is documented as used verbatim — making it impossible to pin the field (e.g. to reproduce a previously signed op). The buffer now only applies to estimated values.
  - **WorldId paymaster poisoned the caller's op on failure**: `createPaymasterUserOperation` wrote paymaster fields and a zeroed `preVerificationGas` directly onto the caller-owned object before calling the bundler; if estimation threw, the caller's op was left corrupted for any retry down another path. It now operates on a shallow copy like the other paymasters and returns the copy.
  - **Token flow crashed with a raw TypeError**: the token pipeline force-cast the smart account and failed with "is not a function" (wrapped as a generic `PAYMASTER_ERROR`) when the account doesn't implement `prependTokenPaymasterApproveToCallData`. It now checks up front and throws a descriptive error. Also corrects the `Erc7677Context` docs: the context object is forwarded to the RPC verbatim, and the consumed-but-undocumented `paymasterAddress` field is documented.

  Full offline suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Respect explicit `verificationGasLimit` overrides during EntryPoint v0.6 gas estimation.
  * Added clearer errors when token paymaster flows require unsupported smart account functionality.
  * Prevented paymaster gas estimation from mutating the original user operation.
  * Improved compatibility with case variations in EntryPoint addresses.

* **Documentation**
  * Clarified ERC-7677 context usage, `paymasterAddress` overrides, and token flow requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->