### PR TITLE
fix: range-check Calibur key settings so expiration cannot set the isAdmin bit

### DIFF
--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -868,6 +868,17 @@ export class Calibur7702Account
 		const hook = BigInt(settings.hook ?? ZeroAddress);
 		const expiration = BigInt(settings.expiration ?? 0);
 		const isAdmin = settings.isAdmin ? 1n : 0n;
+		if (expiration < 0n || expiration >= 1n << 40n) {
+			// the on-chain field is uint40; an oversized value (e.g. a millisecond
+			// timestamp) would bleed into the isAdmin bit at position 200
+			throw new RangeError(
+				"expiration must be a unix timestamp in seconds that fits in 40 bits, " +
+					`got ${expiration}. Did you pass milliseconds instead of seconds?`,
+			);
+		}
+		if (hook < 0n || hook >= 1n << 160n) {
+			throw new RangeError("hook must be a valid 20-byte address.");
+		}
 		return (isAdmin << 200n) | (expiration << 160n) | hook;
 	}
 

--- a/test/calibur/packKeySettings.test.js
+++ b/test/calibur/packKeySettings.test.js
@@ -1,0 +1,28 @@
+// Offline tests for Calibur key-settings packing: the on-chain layout is
+// (isAdmin << 200) | (uint40 expiration << 160) | (uint160 hook), so an
+// oversized expiration must be rejected rather than silently setting the
+// isAdmin bit.
+
+const ak = require('../../dist/index.cjs');
+
+const Calibur = ak.Calibur7702Account;
+
+describe('Calibur7702Account.packKeySettings', () => {
+    test('packs a valid seconds timestamp without touching the isAdmin bit', () => {
+        const expiration = 1786000000n; // seconds, fits in uint40
+        const packed = Calibur.packKeySettings({ expiration, isAdmin: false });
+        expect((packed >> 160n) & ((1n << 40n) - 1n)).toBe(expiration);
+        expect((packed >> 200n) & 1n).toBe(0n);
+    });
+
+    test('rejects a milliseconds timestamp instead of leaking into isAdmin', () => {
+        const ms = 1786000000000n; // >= 2^40: would set bit 200 (isAdmin)
+        expect(() => Calibur.packKeySettings({ expiration: ms })).toThrow(RangeError);
+    });
+
+    test('rejects an out-of-range hook value', () => {
+        expect(() => Calibur.packKeySettings({ hook: '0x' + 'ff'.repeat(21) })).toThrow(
+            RangeError,
+        );
+    });
+});


### PR DESCRIPTION
`packKeySettings` shifted `expiration` into bits 160+ without validating it fits the contract's uint40 field. A millisecond timestamp (≥ 2^40) overflowed exactly into bit 200 — the
  `isAdmin` flag — registering the key as admin and bypassing the explicit guardrail in `createRegisterKeyMetaTransactions`.

  Both `expiration` and `hook` are now range-checked, with an error hint about seconds vs milliseconds since a ms timestamp is the most likely way to hit this.

  Tests added in `test/calibur/packKeySettings.test.js`; full offline suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for key expiration values and hook addresses.
  * Prevented invalid values from corrupting packed account settings or administrative flags.
  * Added clearer errors when expiration values use milliseconds instead of seconds.

* **Tests**
  * Added coverage for valid packing and out-of-range input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->