### PR TITLE
fix: widen fetchAccountNonce key param to number | bigint

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -576,14 +576,17 @@ export function getFunctionSelector(functionSignature: string): string {
  * @param rpc - Ethereum JSON-RPC node URL, {@link Transport}, or {@link JsonRpcNode}
  * @param entryPoint - EntryPoint contract address
  * @param account - Smart account address to query
- * @param key - Nonce key (default 0). Different keys allow parallel nonce channels.
+ * @param key - Nonce key (default 0). Different keys allow parallel nonce
+ *   channels. Prefer a `bigint` — keys can be as large as `uint192`, beyond
+ *   what a JS `number` can represent; `number` is kept for backward
+ *   compatibility.
  * @returns The current nonce as a bigint
  */
 export async function fetchAccountNonce(
 	rpc: string | Transport | JsonRpcNode,
 	entryPoint: string,
 	account: string,
-	key: number = 0,
+	key: number | bigint = 0,
 ): Promise<bigint> {
 	return JsonRpcNode.from(rpc).getEntryPointNonce(entryPoint, account, BigInt(key));
 }


### PR DESCRIPTION
The nonce key is a uint192, which a JS number cannot represent beyond 2^53-1 (e.g. keccak-derived parallel-lane keys). The implementation already coerces via BigInt(key); this aligns the declared type with it. number stays accepted for backward compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account nonce retrieval now supports nonce keys provided as either numbers or bigints.
  * Enables reliable use of parallel nonce channels beyond JavaScript’s safe integer range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->