### PR TITLE
refactor(signer): rename capability Signer to ExternalSigner internally

### DIFF
--- a/src/abstractionkit.ts
+++ b/src/abstractionkit.ts
@@ -123,13 +123,13 @@ export {
 	fromViemWalletClient,
 } from "./signer/adapters";
 // ─── Signer interface design (capability-oriented) ──────────────────────
-// Exported as `ExternalSigner` because the old package-level `Signer` is
-// already taken by an owner-identifier union in Safe/types. An eventual
-// rename there would promote this to the unqualified `Signer`.
+// Named `ExternalSigner` (declaration and export alike) because the old
+// package-level `Signer` is already taken by an owner-identifier union in
+// Safe/types. An eventual rename there would free the unqualified `Signer`.
 export type {
+	ExternalSigner,
 	MultiOpSignContext,
 	SignContext,
-	Signer as ExternalSigner,
 	SignHashFn,
 	SigningScheme,
 	SignTypedDataFn,

--- a/src/account/Calibur/Calibur7702Account.ts
+++ b/src/account/Calibur/Calibur7702Account.ts
@@ -16,7 +16,7 @@ import {
 import {AbstractionKitError} from "src/errors";
 import type {PrependTokenPaymasterApproveAccount} from "src/paymaster/types";
 import {invokeSigner, pickScheme} from "src/signer/negotiate";
-import type {SignContext, Signer as AkSigner, SigningScheme, TypedData} from "src/signer/types";
+import type {SignContext, ExternalSigner, SigningScheme, TypedData} from "src/signer/types";
 import {JsonRpcNode, type Transport} from "src/transport";
 import type {JsonRpcResult, UserOperationV8, UserOperationV9} from "src/types";
 import {
@@ -706,7 +706,7 @@ export class Calibur7702Account
 	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["typedData", "hash"];
 
 	/**
-	 * Sign a UserOperation with an {@link AkSigner}. The signer can implement
+	 * Sign a UserOperation with an {@link ExternalSigner}. The signer can implement
 	 * either `signTypedData` (preferred — JSON-RPC wallets, viem `WalletClient`)
 	 * or `signHash` (local keys, hardware wallets). Both schemes produce
 	 * signatures that validate against the same `userOpHash` because the
@@ -718,7 +718,7 @@ export class Calibur7702Account
 	 */
 	public async signUserOperationWithSigner(
 		userOperation: UserOperationV8,
-		signer: AkSigner,
+		signer: ExternalSigner,
 		chainId: bigint,
 		overrides: CaliburSignatureOverrides = {},
 	): Promise<string> {

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -1946,7 +1946,7 @@ export class SafeAccount extends SmartAccount {
 	}
 
 	/**
-	 * Schemes Safe accepts from a {@link Signer}, in preference order.
+	 * Schemes Safe accepts from an {@link ExternalSigner}, in preference order.
 	 * `typedData` is preferred because wallets can display structured fields
 	 * rather than a hex blob; `hash` is accepted as a fallback for signers
 	 * that only support raw ECDSA.
@@ -1954,17 +1954,17 @@ export class SafeAccount extends SmartAccount {
 	public static readonly ACCEPTED_SIGNING_SCHEMES: readonly SigningScheme[] = ["typedData", "hash"];
 
 	/**
-	 * Sign a UserOperation using one or more {@link Signer}s. This is the
+	 * Sign a UserOperation using one or more {@link ExternalSigner}s. This is the
 	 * capability-oriented signing path: each signer declares what it can do
 	 * (`signHash`, `signTypedData`, both) and the account picks the best
 	 * match per signer. Incompatible signers fail offline with an actionable
 	 * error rather than a silent bundler rejection.
 	 *
 	 * Signers are invoked in parallel. For interactive wallets that share a
-	 * popup session, sequence the prompts inside your Signer implementation.
+	 * popup session, sequence the prompts inside your ExternalSigner implementation.
 	 *
 	 * @param useroperation - UserOperation to sign
-	 * @param signers - Signer instances (`fromViem(account)`, `fromEthersWallet(wallet)`, etc.)
+	 * @param signers - ExternalSigner instances (`fromViem(account)`, `fromEthersWallet(wallet)`, etc.)
 	 * @param chainId - target chain id
 	 * @param params - bag combining required wiring (`entrypointAddress`,
 	 *   `safe4337ModuleAddress`, `context`) with optional `options`

--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -17,7 +17,7 @@ import {Bundler} from "src/Bundler";
 import {AbstractionKitError, ensureError} from "src/errors";
 import {SafeAccountFactory} from "src/factory/SafeAccountFactory";
 import {invokeSigner, pickScheme} from "src/signer/negotiate";
-import type {Signer as AkSigner, SigningScheme, TypedData} from "src/signer/types";
+import type {ExternalSigner, SigningScheme, TypedData} from "src/signer/types";
 import {JsonRpcNode, type Transport} from "src/transport";
 import {
 	BaseUserOperationDummyValues,
@@ -1954,7 +1954,7 @@ export class SafeAccount extends SmartAccount {
 		C,
 	>(
 		useroperation: T,
-		signers: ReadonlyArray<AkSigner<C>>,
+		signers: ReadonlyArray<ExternalSigner<C>>,
 		chainId: bigint,
 		params: {
 			entrypointAddress: string;

--- a/src/account/Safe/SafeAccountV0_2_0.ts
+++ b/src/account/Safe/SafeAccountV0_2_0.ts
@@ -1,6 +1,6 @@
 import type {Bundler} from "src/Bundler";
 import {ENTRYPOINT_V6} from "src/constants";
-import type {SignContext, Signer as AkSigner} from "src/signer/types";
+import type {SignContext, ExternalSigner} from "src/signer/types";
 import type {JsonRpcNode, Transport} from "src/transport";
 import type {MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet, UserOperationV6,} from "../../types";
 import {SafeAccount} from "./SafeAccount";
@@ -452,7 +452,7 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 	}
 
 	/**
-	 * Sign a UserOperation using one or more {@link AkSigner} instances.
+	 * Sign a UserOperation using one or more {@link ExternalSigner} instances.
 	 * See {@link SafeAccountV0_3_0.signUserOperationWithSigners} for full
 	 * design rationale and examples.
 	 *
@@ -464,7 +464,7 @@ export class SafeAccountV0_2_0 extends SafeAccount {
 	 */
 	public signUserOperationWithSigners(
 		useroperation: UserOperationV6,
-		signers: ReadonlyArray<AkSigner>,
+		signers: ReadonlyArray<ExternalSigner>,
 		chainId: bigint,
 		options: SafeSignatureOptions = {},
 	): Promise<string> {

--- a/src/account/Safe/SafeAccountV0_3_0.ts
+++ b/src/account/Safe/SafeAccountV0_3_0.ts
@@ -1,6 +1,6 @@
 import type {Bundler} from "src/Bundler";
 import {ENTRYPOINT_V7} from "src/constants";
-import type {SignContext, Signer as AkSigner} from "src/signer/types";
+import type {SignContext, ExternalSigner} from "src/signer/types";
 import type {JsonRpcNode, Transport} from "src/transport";
 
 import type {MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet, UserOperationV7,} from "../../types";
@@ -408,7 +408,7 @@ export class SafeAccountV0_3_0 extends SafeAccount {
 	 */
 	public signUserOperationWithSigners(
 		useroperation: UserOperationV7,
-		signers: ReadonlyArray<AkSigner>,
+		signers: ReadonlyArray<ExternalSigner>,
 		chainId: bigint,
 		options: SafeSignatureOptions = {}
 	): Promise<string> {

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -11,7 +11,7 @@ import {
 	ENTRYPOINT_V9,
 } from "src/constants";
 import {invokeSigner, pickScheme} from "src/signer/negotiate";
-import type {MultiOpSignContext, SignContext, Signer as AkSigner, TypedData} from "src/signer/types";
+import type {MultiOpSignContext, SignContext, ExternalSigner, TypedData} from "src/signer/types";
 import type {JsonRpcNode, Transport} from "src/transport";
 import type {MetaTransaction, OnChainIdentifierParamsType, StateOverrideSet, UserOperationV9} from "../../types";
 import {
@@ -611,7 +611,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 
 	/**
 	 * Sign a single UserOperation for multi-chain using one or more
-	 * {@link AkSigner} instances. See
+	 * {@link ExternalSigner} instances. See
 	 * {@link SafeAccountV0_3_0.signUserOperationWithSigners} for the full
 	 * design rationale. Sets the multi-chain flag automatically.
 	 *
@@ -631,7 +631,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 */
 	public signUserOperationWithSigners(
 		userOperation: UserOperationV9,
-		signers: ReadonlyArray<AkSigner>,
+		signers: ReadonlyArray<ExternalSigner>,
 		chainId: bigint,
 		options: SafeSignatureOptions = {},
 	): Promise<string> {
@@ -767,7 +767,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 */
 	public async signUserOperationsWithSigners(
 		userOperationsToSign: UserOperationToSign[],
-		signers: ReadonlyArray<AkSigner<MultiOpSignContext<UserOperationV9>>>,
+		signers: ReadonlyArray<ExternalSigner<MultiOpSignContext<UserOperationV9>>>,
 	): Promise<string[]> {
 		if (userOperationsToSign.length < 1) {
 			throw new RangeError("There should be at least one userOperationsToSign");

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -749,8 +749,8 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * `fromPrivateKey`, `fromViem`, `fromEthersWallet`, and `fromViemWalletClient`
 	 * all work here without retyping (`fromViemWalletClient` will sign the
 	 * typed-data Merkle wrapper). User-defined single-op signers
-	 * (`Signer<SignContext>`) still don't work — they'd receive a context shape
-	 * they didn't declare.
+	 * (`ExternalSigner<SignContext>`) still don't work — they'd receive a
+	 * context shape they didn't declare.
 	 *
 	 * Note the chainId plumbing asymmetry vs the single-op variant:
 	 *   - **Plural** (this method): each `UserOperationToSign` carries its
@@ -762,7 +762,7 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	 * element rather than reaching for the singular variant.
 	 *
 	 * @param userOperationsToSign - UserOperations + chain IDs + validity windows
-	 * @param signers - one Signer per owner (any order; sorted by address on-chain)
+	 * @param signers - one ExternalSigner per owner (any order; sorted by address on-chain)
 	 * @returns one signature per input UserOperation, in the same order
 	 */
 	public async signUserOperationsWithSigners(

--- a/src/account/Safe/adapters.ts
+++ b/src/account/Safe/adapters.ts
@@ -1,5 +1,5 @@
 import { fromUtf8Bytes, getBytes, hexlify, toUtf8Bytes } from "../../ethereUtils";
-import type { Signer } from "src/signer/types";
+import type { ExternalSigner } from "src/signer/types";
 import { SafeAccount } from "./SafeAccount";
 import type { WebauthnPublicKey, WebauthnSignatureData } from "./types";
 
@@ -73,7 +73,7 @@ export interface FromSafeWebauthnParams {
 }
 
 /**
- * Adapt a WebAuthn credential to a Signer for `signUserOperationWithSigners`
+ * Adapt a WebAuthn credential to an ExternalSigner for `signUserOperationWithSigners`
  * on Safe accounts. Safe-specific (uses Safe's WebAuthn shared signer /
  * verifier proxy / signature encoding) — for non-Safe accounts, use the
  * account's own WebAuthn adapter.
@@ -136,7 +136,7 @@ export interface FromSafeWebauthnParams {
  *   userOperation, [signer], chainId,
  * );
  */
-export function fromSafeWebauthn(params: FromSafeWebauthnParams): Signer<unknown> {
+export function fromSafeWebauthn(params: FromSafeWebauthnParams): ExternalSigner<unknown> {
 	const {
 		publicKey,
 		isInit,

--- a/src/account/simple/Simple7702Account.ts
+++ b/src/account/simple/Simple7702Account.ts
@@ -3,7 +3,7 @@ import {Bundler} from "src/Bundler";
 import {BaseUserOperationDummyValues, ENTRYPOINT_V8, ENTRYPOINT_V9} from "src/constants";
 import {AbstractionKitError} from "src/errors";
 import {invokeSigner, pickScheme} from "src/signer/negotiate";
-import type {SignContext, Signer as AkSigner, SigningScheme, TypedData} from "src/signer/types";
+import type {SignContext, ExternalSigner, SigningScheme, TypedData} from "src/signer/types";
 import {JsonRpcNode, type Transport} from "src/transport";
 import type {
 	GasOption,
@@ -784,7 +784,7 @@ export class BaseSimple7702Account extends SmartAccount {
 	 * EntryPoint v0.8 / v0.9 domain. Lower-level escape hatch for integrators
 	 * driving `signTypedData` themselves with their own signing primitive
 	 * (HSM, MPC, custom wallet abstraction). Most callers should pass an
-	 * {@link AkSigner} to {@link signUserOperationWithSigner} instead, which
+	 * {@link ExternalSigner} to {@link signUserOperationWithSigner} instead, which
 	 * builds this internally.
 	 *
 	 * The digest of the returned payload equals the UserOperation hash from
@@ -837,7 +837,7 @@ export class BaseSimple7702Account extends SmartAccount {
 	}
 
 	/**
-	 * Sign a UserOperation with an {@link AkSigner}. The signer can implement
+	 * Sign a UserOperation with an {@link ExternalSigner}. The signer can implement
 	 * either `signTypedData` (preferred — JSON-RPC wallets, viem `WalletClient`)
 	 * or `signHash` (local keys, hardware wallets). Both schemes produce
 	 * signatures that validate against the same `userOpHash` because the
@@ -849,7 +849,7 @@ export class BaseSimple7702Account extends SmartAccount {
 	 */
 	protected async baseSignUserOperationWithSigner<T extends UserOperationV8 | UserOperationV9>(
 		useroperation: T,
-		signer: AkSigner,
+		signer: ExternalSigner,
 		chainId: bigint,
 	): Promise<string> {
 		const scheme = pickScheme(signer, BaseSimple7702Account.ACCEPTED_SIGNING_SCHEMES, {
@@ -1111,7 +1111,7 @@ export class Simple7702Account extends BaseSimple7702Account {
 	 */
 	public async signUserOperationWithSigner(
 		useroperation: UserOperationV8,
-		signer: AkSigner,
+		signer: ExternalSigner,
 		chainId: bigint,
 	): Promise<string> {
 		return this.baseSignUserOperationWithSigner(useroperation, signer, chainId);

--- a/src/account/simple/Simple7702AccountV09.ts
+++ b/src/account/simple/Simple7702AccountV09.ts
@@ -1,6 +1,6 @@
 import type {Bundler} from "src/Bundler";
 import {ENTRYPOINT_V9} from "src/constants";
-import type {Signer as AkSigner, TypedData} from "src/signer/types";
+import type {ExternalSigner, TypedData} from "src/signer/types";
 import type {JsonRpcNode, Transport} from "src/transport";
 import type {StateOverrideSet, UserOperationV9} from "src/types";
 import type {SendUseroperationResponse} from "../SendUseroperationResponse";
@@ -155,7 +155,7 @@ export class Simple7702AccountV09 extends BaseSimple7702Account {
 	 */
 	public async signUserOperationWithSigner(
 		useroperation: UserOperationV9,
-		signer: AkSigner,
+		signer: ExternalSigner,
 		chainId: bigint,
 	): Promise<string> {
 		return this.baseSignUserOperationWithSigner(useroperation, signer, chainId);

--- a/src/signer/adapters.ts
+++ b/src/signer/adapters.ts
@@ -1,5 +1,5 @@
 import { privateKeyToAddress, signHash, signTypedData } from "../ethereUtils";
-import type { Signer, TypedData } from "./types";
+import type { ExternalSigner, TypedData } from "./types";
 
 // Structural types for well-known signers. NO imports from viem / ethers
 // at the type level (beyond the already-present ethers runtime dep used by
@@ -79,7 +79,7 @@ export interface EthersWalletLike {
 }
 
 /**
- * Build a Signer from a raw private-key hex string. Supports both raw-hash
+ * Build an ExternalSigner from a raw private-key hex string. Supports both raw-hash
  * and typed-data signing, delegated to the internal `ethereUtils` helpers
  * ({@link signHash}, {@link signTypedData}) — no extra packages needed.
  * If you already hold a viem Account or ethers Wallet, use {@link fromViem}
@@ -90,7 +90,7 @@ export interface EthersWalletLike {
  * const signer = fromPrivateKey(process.env.PRIVATE_KEY!);
  * userOp.signature = await safe.signUserOperationWithSigners(userOp, [signer], chainId);
  */
-export function fromPrivateKey(privateKey: string): Signer<unknown> {
+export function fromPrivateKey(privateKey: string): ExternalSigner<unknown> {
 	return {
 		address: privateKeyToAddress(privateKey),
 		signHash: (hash) => signHash(privateKey, hash).serialized,
@@ -99,12 +99,12 @@ export function fromPrivateKey(privateKey: string): Signer<unknown> {
 }
 
 /**
- * Adapt a viem Local Account (e.g. `privateKeyToAccount(pk)`) to a Signer.
+ * Adapt a viem Local Account (e.g. `privateKeyToAccount(pk)`) to an ExternalSigner.
  * Supports both raw-hash and typed-data signing.
  *
  * @remarks Requires viem &gt;= 2.0.
  */
-export function fromViem(account: ViemLocalAccountLike): Signer<unknown> {
+export function fromViem(account: ViemLocalAccountLike): ExternalSigner<unknown> {
 	return {
 		address: account.address,
 		signHash: (hash) => account.sign({ hash }),
@@ -119,7 +119,7 @@ export function fromViem(account: ViemLocalAccountLike): Signer<unknown> {
 }
 
 /**
- * Adapt a viem `WalletClient` to a Signer. Only typed-data signing is
+ * Adapt a viem `WalletClient` to an ExternalSigner. Only typed-data signing is
  * exposed, because `WalletClient` drives browser/JSON-RPC wallets which
  * can't sign raw hashes. Requires the client to have been constructed with
  * an `account`; for local accounts, prefer `fromViem` so you also get
@@ -127,7 +127,7 @@ export function fromViem(account: ViemLocalAccountLike): Signer<unknown> {
  *
  * @remarks Requires viem &gt;= 2.0.
  */
-export function fromViemWalletClient(client: ViemWalletClientLike): Signer<unknown> {
+export function fromViemWalletClient(client: ViemWalletClientLike): ExternalSigner<unknown> {
 	if (!client.account) {
 		throw new Error(
 			"fromViemWalletClient: client has no `account` configured. " +
@@ -153,12 +153,12 @@ export function fromViemWalletClient(client: ViemWalletClientLike): Signer<unkno
 }
 
 /**
- * Adapt an ethers `Wallet` / `HDNodeWallet` to a Signer. Supports both
+ * Adapt an ethers `Wallet` / `HDNodeWallet` to an ExternalSigner. Supports both
  * raw-hash and typed-data signing.
  *
  * @remarks Requires ethers &gt;= 6.0.
  */
-export function fromEthersWallet(wallet: EthersWalletLike): Signer<unknown> {
+export function fromEthersWallet(wallet: EthersWalletLike): ExternalSigner<unknown> {
 	// ethers types `address` as plain `string`; at runtime it's always
 	// checksummed 0x-prefixed hex.
 	return {

--- a/src/signer/negotiate.ts
+++ b/src/signer/negotiate.ts
@@ -1,5 +1,5 @@
 import { AbstractionKitError } from "../errors";
-import type { Signer, SigningScheme, TypedData } from "./types";
+import type { ExternalSigner, SigningScheme, TypedData } from "./types";
 
 /**
  * Pick the best mutually-supported signing scheme for one signer against an
@@ -11,7 +11,7 @@ import type { Signer, SigningScheme, TypedData } from "./types";
  * signer can do.
  */
 export function pickScheme<C>(
-	signer: Signer<C>,
+	signer: ExternalSigner<C>,
 	accepted: readonly SigningScheme[],
 	context: { accountName: string; signerIndex: number },
 ): SigningScheme {
@@ -51,7 +51,7 @@ function buildMismatchMessage(params: {
 		`No compatible signing scheme for signer[${signerIndex}] ${signerAddress}. ` +
 		`${accountName} accepts: [${accepted.join(", ")}]; signer provides: [${canStr}]. ` +
 		(signerCan.length === 0
-			? "Signer must implement at least one of `signHash` or `signTypedData`. "
+			? "ExternalSigner must implement at least one of `signHash` or `signTypedData`. "
 			: "") +
 		"Hint: `fromViem` / `fromEthersWallet` give both; " +
 		"`fromViemWalletClient` gives only `typedData` (use Safe for JSON-RPC wallets)."
@@ -67,7 +67,7 @@ function buildMismatchMessage(params: {
  * can inspect the userOp.
  */
 export async function invokeSigner<C>(
-	signer: Signer<C>,
+	signer: ExternalSigner<C>,
 	scheme: SigningScheme,
 	payload: {
 		hash: `0x${string}`;

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -4,7 +4,7 @@ import type { BaseUserOperation } from "../types";
  * Narrow EIP-712 typed data payload. All hex fields are typed as
  * `` `0x${string}` `` so callers don't need casts when handing this straight
  * to viem / ethers. `EIP712Domain` is stripped from `types` before the payload
- * is handed to a Signer, so consumers don't need to filter it out.
+ * is handed to an ExternalSigner, so consumers don't need to filter it out.
  */
 export interface TypedData {
 	domain: {
@@ -26,7 +26,7 @@ export type SigningScheme = "hash" | "typedData";
  * Context the SDK passes to a signer on every account's
  * `signUserOperationWithSigner(s)` (the single-op path — 99% of usage).
  * All fields are required; IDE autocomplete shows them directly without a
- * type guard. Default for {@link Signer}, {@link SignHashFn},
+ * type guard. Default for {@link ExternalSigner}, {@link SignHashFn},
  * {@link SignTypedDataFn}.
  *
  * For the multi-op Merkle path
@@ -48,7 +48,7 @@ export interface SignContext<T extends BaseUserOperation = BaseUserOperation> {
  * Type your multi-op signer as `ExternalSigner<MultiOpSignContext>` for
  * full autocomplete on `userOperations`. Pre-built adapters
  * `fromPrivateKey`, `fromViem`, `fromEthersWallet`, and
- * `fromViemWalletClient` all return a universal `Signer<unknown>` and
+ * `fromViemWalletClient` all return a universal `ExternalSigner<unknown>` and
  * work on either single-op or multi-op paths without retyping — the
  * multi-op Merkle root is wrapped in an EIP-712 `MerkleTreeRoot`
  * message, so `signTypedData`-only signers are accepted.
@@ -61,8 +61,8 @@ export interface MultiOpSignContext<T extends BaseUserOperation = BaseUserOperat
 	readonly entryPoint: string;
 }
 
-/** Common fields every Signer exposes. */
-interface SignerBase {
+/** Common fields every ExternalSigner exposes. */
+interface ExternalSignerBase {
 	/** Address that will recover from signatures this signer produces. */
 	readonly address: `0x${string}`;
 	/**
@@ -71,7 +71,7 @@ interface SignerBase {
 	 * signature blob from a smart-contract owner; it gets encoded as a
 	 * dynamic-length contract-signature segment when the aggregate is built.
 	 *
-	 * Account-agnostic: `Signer` is shared with non-Safe accounts that ignore
+	 * Account-agnostic: `ExternalSigner` is shared with non-Safe accounts that ignore
 	 * this field. For Safe, this drives the per-pair `isContractSignature`
 	 * flag set on the {@link SignerSignaturePair} produced for this signer,
 	 * so different signers in the same batch can mix kinds correctly.
@@ -115,8 +115,10 @@ export type SignTypedDataFn<C = SignContext> = (
  * as a discriminated union so TypeScript rejects `{ address }` with neither
  * method at compile time.
  *
- * Re-exported at the package root as `ExternalSigner` (the unqualified
- * `Signer` name is already a Safe owner-identifier union).
+ * Named `ExternalSigner` (not `Signer`) because the unqualified `Signer`
+ * name is already taken by the legacy Safe owner-identifier union in
+ * `account/Safe/types`; if that union is ever renamed (e.g. to
+ * `SafeOwner`), this type could adopt the plain `Signer` name.
  *
  * `signMessage` (EIP-191) is intentionally omitted: the `v`-byte mismatch
  * between default tooling and Safe's on-chain validator makes it a footgun.
@@ -154,7 +156,7 @@ export type SignTypedDataFn<C = SignContext> = (
  * }
  * ```
  */
-export type Signer<C = SignContext> = SignerBase &
+export type ExternalSigner<C = SignContext> = ExternalSignerBase &
 	(
 		| { signHash: SignHashFn<C>; signTypedData?: SignTypedDataFn<C> }
 		| { signHash?: SignHashFn<C>; signTypedData: SignTypedDataFn<C> }


### PR DESCRIPTION
The capability signer type had three names: declared as Signer in signer/types.ts, imported as AkSigner inside the account classes (to dodge the collision with the legacy Safe owner-identifier union also named Signer), and exported to consumers as ExternalSigner.

Align on ExternalSigner everywhere: the declaration is renamed (SignerBase → ExternalSignerBase alongside), the AkSigner import aliases are deleted, and the package root re-exports the name directly instead of aliasing. The legacy Safe union keeps the unqualified Signer name; if it is ever renamed (e.g. SafeOwner), the plain name frees up.

Pure rename — no runtime or public-API change (consumers already knew this type only as ExternalSigner).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Renamed the exported signer type to **ExternalSigner** (replacing the previous **Signer** naming).
  * Updated account signing APIs (including single and multi-op flows) to accept **ExternalSigner** parameters.
  * Updated signer adapter factories and integrations (WebAuthn, private key, Viem, Ethers) to return **ExternalSigner**.
  * Kept the existing signing behavior and supported signing schemes unchanged.
  * Refreshed related documentation and validation/error messaging to use the new terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->