### PR TITLE
docs: clarify SafeMultiChainSigAccountV1 works as a single-chain account

### DIFF
--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -47,15 +47,23 @@ import type {
  * to sign UserOperations for several chains under one signature.
  *
  * API-compatible with {@link SafeAccountV0_3_0}: same {@link SafeAccount} base,
- * same method signatures, same {@link InitCodeOverrides} shape. Selecting this
- * class instead of `SafeAccountV0_3_0` targets EntryPoint v0.9 — it is not a
- * separate integration. The multi-op methods ({@link signUserOperations},
- * {@link signUserOperationsWithSigners}) and the Merkle-root EIP-712 helpers
- * are additive; ignore them and the account behaves as a single-chain Safe.
+ * same method signatures, same {@link InitCodeOverrides} shape, so building on
+ * EntryPoint v0.9 is not a separate integration. The multi-op methods
+ * ({@link signUserOperations}, {@link signUserOperationsWithSigners}) and the
+ * Merkle-root EIP-712 helpers are additive; ignore them and the account
+ * behaves as a single-chain Safe.
  *
- * Note that the derived account address differs from `SafeAccountV0_3_0` for
- * the same owners, since the module and EntryPoint addresses feed the
- * counterfactual address.
+ * Which account this class refers to, however, is not interchangeable with
+ * `SafeAccountV0_3_0`:
+ *
+ * - **New accounts** derive a different address for the same owners, since the
+ *   module and EntryPoint addresses feed the counterfactual address.
+ * - **Deployed accounts** must be migrated before this class can operate on
+ *   them. Attaching this class to a Safe deployed through `SafeAccountV0_3_0`
+ *   is not enough — the v0.9 module has to be enabled and installed as the
+ *   fallback handler first, and UserOperations sent before that will fail. Use
+ *   {@link SafeAccountV0_3_0.createMigrateToSafeMultiChainSigAccountV1MetaTransactions},
+ *   whose batch must be sent as a UserOperation from the v0.7 account itself.
  *
  * @example Single-chain use — the common case
  * ```ts
@@ -104,6 +112,11 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 
 	/**
 	 * Create a SafeMultiChainSigAccount instance for an existing or new account.
+	 *
+	 * An existing account must already have the v0.9 module enabled and set as
+	 * its fallback handler. A Safe deployed through {@link SafeAccountV0_3_0}
+	 * has neither until it is migrated — see the class documentation.
+	 *
 	 * @param accountAddress - the Safe account address
 	 * @param overrides - optional overrides for module, entrypoint, and singleton addresses
 	 */

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -56,12 +56,14 @@ import type {
  * Which account this class refers to, however, is not interchangeable with
  * `SafeAccountV0_3_0`:
  *
- * - **New accounts** derive a different address for the same owners, since the
- *   module and EntryPoint addresses feed the counterfactual address.
- * - **Deployed accounts** must be migrated before this class can operate on
- *   them. Attaching this class to a Safe deployed through `SafeAccountV0_3_0`
- *   is not enough — the v0.9 module has to be enabled and installed as the
- *   fallback handler first, and UserOperations sent before that will fail. Use
+ * - **New accounts** derive a different counterfactual address for the same
+ *   owners, since the module and EntryPoint addresses feed that derivation.
+ * - **Deployed accounts** keep the address they have, but must be migrated
+ *   before this class can operate on them. Attaching this class to a Safe
+ *   deployed through `SafeAccountV0_3_0` is not enough: two pieces of Safe
+ *   configuration have to change first — the v0.9 module must be enabled on
+ *   the Safe, and the Safe's fallback handler must be updated to point at it.
+ *   Until both land, UserOperations sent to the account will fail. Use
  *   {@link SafeAccountV0_3_0.createMigrateToSafeMultiChainSigAccountV1MetaTransactions},
  *   whose batch must be sent as a UserOperation from the v0.7 account itself.
  *
@@ -113,9 +115,10 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	/**
 	 * Create a SafeMultiChainSigAccount instance for an existing or new account.
 	 *
-	 * An existing account must already have the v0.9 module enabled and set as
-	 * its fallback handler. A Safe deployed through {@link SafeAccountV0_3_0}
-	 * has neither until it is migrated — see the class documentation.
+	 * An existing account must already have the v0.9 module enabled, and its
+	 * fallback handler pointing at that module. A Safe deployed through
+	 * {@link SafeAccountV0_3_0} has neither until it is migrated — see the
+	 * class documentation.
 	 *
 	 * @param accountAddress - the Safe account address
 	 * @param overrides - optional overrides for module, entrypoint, and singleton addresses

--- a/src/account/Safe/SafeMultiChainSigAccount.ts
+++ b/src/account/Safe/SafeMultiChainSigAccount.ts
@@ -42,8 +42,31 @@ import type {
 } from "./types";
 
 /**
- * Safe account variant that supports multi-chain signatures via Merkle trees:
- * sign UserOperations for multiple chains under one signature on EntryPoint v0.9.
+ * Safe account on EntryPoint v0.9. Use it as a regular single-chain Safe
+ * account, and opt into multi-chain signatures via Merkle trees when you want
+ * to sign UserOperations for several chains under one signature.
+ *
+ * API-compatible with {@link SafeAccountV0_3_0}: same {@link SafeAccount} base,
+ * same method signatures, same {@link InitCodeOverrides} shape. Selecting this
+ * class instead of `SafeAccountV0_3_0` targets EntryPoint v0.9 — it is not a
+ * separate integration. The multi-op methods ({@link signUserOperations},
+ * {@link signUserOperationsWithSigners}) and the Merkle-root EIP-712 helpers
+ * are additive; ignore them and the account behaves as a single-chain Safe.
+ *
+ * Note that the derived account address differs from `SafeAccountV0_3_0` for
+ * the same owners, since the module and EntryPoint addresses feed the
+ * counterfactual address.
+ *
+ * @example Single-chain use — the common case
+ * ```ts
+ * const account = SafeMultiChainSigAccountV1.initializeNewAccount([owner]);
+ * const userOp = await account.createUserOperation([tx], nodeRpc, bundlerRpc);
+ * userOp.signature = await account.signUserOperationWithSigners(
+ *   userOp,
+ *   [signer],
+ *   chainId,
+ * );
+ * ```
  *
  * Uses Safe Passkey module v0.2.1 WebAuthn verifiers by default (Daimo P256
  * verifier instead of the base class's FCL P256).
@@ -575,7 +598,16 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
-	 * create a useroperation signature
+	 * Create a signature for a single UserOperation. This is the regular
+	 * signing path — use it for ordinary single-chain transactions. To sign
+	 * several UserOperations under one signature, use
+	 * {@link signUserOperations}.
+	 *
+	 * The multi-chain flag is set automatically, which only affects how the
+	 * signature is encoded: this account's module validates single-chain
+	 * UserOperations through the same scheme, signing the leaf SafeOp hash
+	 * directly rather than a Merkle root.
+	 *
 	 * @param useroperation - useroperation to sign
 	 * @param privateKeys - for the signers
 	 * @param chainId - target chain id
@@ -610,10 +642,18 @@ export class SafeMultiChainSigAccountV1 extends SafeAccount {
 	}
 
 	/**
-	 * Sign a single UserOperation for multi-chain using one or more
-	 * {@link ExternalSigner} instances. See
+	 * Sign a single UserOperation using one or more {@link ExternalSigner}
+	 * instances. This is the regular signing path — use it for ordinary
+	 * single-chain transactions. See
 	 * {@link SafeAccountV0_3_0.signUserOperationWithSigners} for the full
-	 * design rationale. Sets the multi-chain flag automatically.
+	 * design rationale.
+	 *
+	 * The multi-chain flag is set automatically, which only affects how the
+	 * signature is encoded: this account's module validates single-chain
+	 * UserOperations through the same scheme, signing the leaf SafeOp hash
+	 * directly rather than a Merkle root. Signing several UserOperations under
+	 * one signature is a separate method,
+	 * {@link signUserOperationsWithSigners}.
 	 *
 	 * Note the chainId plumbing asymmetry vs the multi-op variant:
 	 *   - **Singular** (this method): `chainId` is a positional argument.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified single-chain and multi-chain signing behavior for EntryPoint v0.9.
  * Documented automatic multi-chain signature encoding and single-operation signing details.
  * Added guidance for bundling multiple operations.
  * Clarified derived addresses and deployment or migration requirements for existing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->