### PR TITLE
Review follow-ups: transport, Tenderly, Safe v0.6, paymaster, and allowance fixes

### DIFF
--- a/src/account/Safe/SafeAccount.ts
+++ b/src/account/Safe/SafeAccount.ts
@@ -59,6 +59,7 @@ import {
 import {
 	type BaseInitOverrides,
 	type CreateBaseUserOperationOverrides,
+	type CreateUserOperationV6Overrides,
 	EOADummySignerSignaturePair,
 	type SafeAccountSingleton,
 	SafeModuleExecutorFunctionSelector,
@@ -1714,7 +1715,28 @@ export class SafeAccount extends SmartAccount {
 		const validAfter = 0xffffffffffffn;
 		const validUntil = 0xffffffffffffn;
 
-		const isInit = factoryAddress != null && factoryAddress !== "0x";
+		// V0.6 callers can override the final initCode (applied by
+		// createUserOperation after this method returns). Resolve it up front
+		// so the dummy-signature encoding and the estimation op below see the
+		// same deployment state as the returned op — e.g. a caller-supplied
+		// "0x" must select the deployed-account WebAuthn owner encoding even
+		// when a factory address is set.
+		let resolvedV06InitCode: string | null = null;
+		if (isV06) {
+			resolvedV06InitCode = (overrides as CreateUserOperationV6Overrides).initCode ?? null;
+			if (resolvedV06InitCode == null) {
+				resolvedV06InitCode = "0x";
+				if (factoryAddress != null) {
+					resolvedV06InitCode = factoryAddress;
+					if (factoryData != null) {
+						resolvedV06InitCode += factoryData.slice(2);
+					}
+				}
+			}
+		}
+		const isInit = isV06
+			? resolvedV06InitCode !== "0x"
+			: factoryAddress != null && factoryAddress !== "0x";
 		let dummySignerSignaturePairs: SignerSignaturePair[];
 		if (overrides.dummySignerSignaturePairs != null) {
 			if (overrides.expectedSigners != null) {
@@ -1783,17 +1805,9 @@ export class SafeAccount extends SmartAccount {
 
 				let userOperationToEstimate: UserOperationV6 | UserOperationV7;
 				if (isV06) {
-					let initCode = "0x";
-					if (factoryAddress != null) {
-						initCode = factoryAddress;
-
-						if (factoryData != null) {
-							initCode += factoryData.slice(2);
-						}
-					}
 					userOperationToEstimate = {
 						...userOperation,
-						initCode: initCode,
+						initCode: resolvedV06InitCode as string,
 						paymasterAndData: "0x",
 					};
 				} else {

--- a/src/account/Safe/modules/AllowanceModule.ts
+++ b/src/account/Safe/modules/AllowanceModule.ts
@@ -87,6 +87,17 @@ export class AllowanceModule extends SafeModule {
 		recurringAllowanceValidityPeriodInMinutes: bigint,
 		inThePastPeriodStartBaseTimeStamp: bigint = 0n,
 	): MetaTransaction {
+		// resetTimeMin is a uint16 on-chain — reject values the ABI encoder
+		// would otherwise refuse with an unhelpful generic error
+		if (
+			recurringAllowanceValidityPeriodInMinutes < 0n ||
+			recurringAllowanceValidityPeriodInMinutes >= 2n ** 16n
+		) {
+			throw new RangeError(
+				"recurringAllowanceValidityPeriodInMinutes must fit the contract's " +
+					"uint16 resetTimeMin (0 to 65535 minutes).",
+			);
+		}
 		const baseInMinutes = inThePastPeriodStartBaseTimeStamp / 60n;
 		// resetBaseMin is a uint32 of minutes since the epoch; a millisecond
 		// timestamp (Date.now()) still overflows this bound after conversion

--- a/src/paymaster/WorldIdPermissionlessPaymaster.ts
+++ b/src/paymaster/WorldIdPermissionlessPaymaster.ts
@@ -25,7 +25,10 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 
 	/**
 	 * createPaymasterUserOperation will estimate gas and set the paymaster fields.
-	 * @param userOperation - User operation to be sponsored
+	 * @param userOperation - User operation to be sponsored. Its
+	 * verificationGasLimit and callGasLimit are trusted as prior estimates
+	 * (e.g. from createUserOperation) and reused during re-estimation;
+	 * only preVerificationGas is always re-estimated.
 	 * @param bundlerRpc - Bundler endpoint rpc url
 	 * @param nullifierHash - nullifier hash
 	 * @param root - Worldid Merkle tree root
@@ -121,12 +124,14 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 		let verificationGasLimit = userOp.verificationGasLimit;
 		let callGasLimit = userOp.callGasLimit;
 
-		// zero the gas limits to force clean re-estimation (same pattern as
-		// SafeAccount and Erc7677Paymaster) — caller-supplied limits are still
-		// honored below as minimums
+		// Zero only preVerificationGas: the paymaster fields added above grow
+		// the calldata, so pvg must be re-estimated. verificationGasLimit and
+		// callGasLimit are paymaster-independent on v0.7+ (paymaster
+		// validation has its own gas field), so the supplied values are
+		// trusted as prior estimates and passed through — bundlers that skip
+		// estimating supplied fields answer faster. This assumes the caller's
+		// op carries real estimates (e.g. from createUserOperation).
 		userOp.preVerificationGas = 0n;
-		userOp.verificationGasLimit = 0n;
-		userOp.callGasLimit = 0n;
 
 		const bundler = Bundler.from(bundlerRpc);
 		const estimation = await bundler.estimateUserOperationGas(

--- a/src/paymaster/WorldIdPermissionlessPaymaster.ts
+++ b/src/paymaster/WorldIdPermissionlessPaymaster.ts
@@ -121,8 +121,12 @@ export class WorldIdPermissionlessPaymaster extends Paymaster {
 		let verificationGasLimit = userOp.verificationGasLimit;
 		let callGasLimit = userOp.callGasLimit;
 
-		// set preVerificationGas to zero to force re-estimation
+		// zero the gas limits to force clean re-estimation (same pattern as
+		// SafeAccount and Erc7677Paymaster) — caller-supplied limits are still
+		// honored below as minimums
 		userOp.preVerificationGas = 0n;
+		userOp.verificationGasLimit = 0n;
+		userOp.callGasLimit = 0n;
 
 		const bundler = Bundler.from(bundlerRpc);
 		const estimation = await bundler.estimateUserOperationGas(

--- a/src/transport/HttpTransport.ts
+++ b/src/transport/HttpTransport.ts
@@ -80,11 +80,18 @@ export class HttpTransport extends BaseRpcTransport {
 				responseText.slice(0, 1000),
 			);
 		}
+		// Only a properly shaped JSON-RPC error object counts. A non-RPC JSON
+		// error body (e.g. `{"error": "rate limited"}` from a gateway) must not
+		// mask the HTTP status below.
+		const rpcError =
+			typeof parsed === "object" && parsed != null && "error" in parsed
+				? (parsed as {error: unknown}).error
+				: null;
 		const hasRpcError =
-			typeof parsed === "object" &&
-			parsed != null &&
-			"error" in parsed &&
-			(parsed as {error: unknown}).error != null;
+			typeof rpcError === "object" &&
+			rpcError != null &&
+			typeof (rpcError as {code: unknown}).code === "number" &&
+			typeof (rpcError as {message: unknown}).message === "string";
 		if (!response.ok && !hasRpcError) {
 			// On HTTP failure, only a JSON-RPC *error* envelope falls through
 			// (parseResponse reports the server's error, e.g. a 429 rate

--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -41,6 +41,9 @@ function isEip7702FactorySentinel(factory: string | null | undefined): boolean {
  * code merged in. Override keys are EVM addresses, so the sender entry is
  * matched case-insensitively — a caller entry keyed by a checksummed address
  * merges into one lowercase entry instead of duplicating the address.
+ * Multiple keys matching the sender (differing only in case) are rejected,
+ * matching callTenderlySimulateBundle's duplicate policy — collapsing them
+ * here would silently pick one entry's fields over the other's.
  */
 function withSenderCodeOverride(
 	stateOverrides: OverrideType | null | undefined,
@@ -49,15 +52,18 @@ function withSenderCodeOverride(
 ): OverrideType {
 	const senderLower = sender.toLowerCase();
 	const merged: OverrideType = {};
-	let senderEntry: Record<string, string | Record<string, string>> = {};
+	let senderEntry: Record<string, string | Record<string, string>> | null = null;
 	for (const [address, entry] of Object.entries(stateOverrides ?? {})) {
 		if (address.toLowerCase() === senderLower) {
-			senderEntry = { ...senderEntry, ...entry };
+			if (senderEntry != null) {
+				throw new RangeError(`Duplicate stateOverrides address (case-insensitive): ${address}.`);
+			}
+			senderEntry = entry;
 		} else {
 			merged[address] = entry;
 		}
 	}
-	merged[senderLower] = { ...senderEntry, code: delegationCode };
+	merged[senderLower] = { ...(senderEntry ?? {}), code: delegationCode };
 	return merged;
 }
 

--- a/src/utilsTenderly.ts
+++ b/src/utilsTenderly.ts
@@ -37,6 +37,31 @@ function isEip7702FactorySentinel(factory: string | null | undefined): boolean {
 }
 
 /**
+ * Return a copy of `stateOverrides` with the sender's EIP-7702 delegation
+ * code merged in. Override keys are EVM addresses, so the sender entry is
+ * matched case-insensitively — a caller entry keyed by a checksummed address
+ * merges into one lowercase entry instead of duplicating the address.
+ */
+function withSenderCodeOverride(
+	stateOverrides: OverrideType | null | undefined,
+	sender: string,
+	delegationCode: string,
+): OverrideType {
+	const senderLower = sender.toLowerCase();
+	const merged: OverrideType = {};
+	let senderEntry: Record<string, string | Record<string, string>> = {};
+	for (const [address, entry] of Object.entries(stateOverrides ?? {})) {
+		if (address.toLowerCase() === senderLower) {
+			senderEntry = { ...senderEntry, ...entry };
+		} else {
+			merged[address] = entry;
+		}
+	}
+	merged[senderLower] = { ...senderEntry, code: delegationCode };
+	return merged;
+}
+
+/**
  * Rebuild the packed `initCode` from split factory/factoryData fields,
  * normalizing the short "0x7702" sentinel to the 20-byte right-padded marker
  * so non-empty factoryData lands after a well-formed head.
@@ -283,12 +308,7 @@ export async function simulateUserOperationWithTenderly(
 		const eip7702Auth = (userOperation as UserOperationV8 | UserOperationV9).eip7702Auth;
 		if (eip7702Auth != null && eip7702Auth.address != null) {
 			const delegationCode = `0xef0100${eip7702Auth.address.toLowerCase().replace("0x", "")}`;
-			const senderLower = userOperation.sender.toLowerCase();
-			stateOverrides = stateOverrides ? { ...stateOverrides } : {};
-			stateOverrides[senderLower] = {
-				...(stateOverrides[senderLower] || {}),
-				code: delegationCode,
-			};
+			stateOverrides = withSenderCodeOverride(stateOverrides, userOperation.sender, delegationCode);
 		}
 	}
 
@@ -527,12 +547,11 @@ export async function simulateUserOperationCallDataWithTenderly(
 				.eip7702Auth;
 			if (eip7702Auth != null && eip7702Auth.address != null) {
 				const delegationCode = `0xef0100${eip7702Auth.address.toLowerCase().replace("0x", "")}`;
-				const senderLower = userOperation.sender.toLowerCase();
-				stateOverrides = stateOverrides ? { ...stateOverrides } : {};
-				stateOverrides[senderLower] = {
-					...(stateOverrides[senderLower] || {}),
-					code: delegationCode,
-				};
+				stateOverrides = withSenderCodeOverride(
+					stateOverrides,
+					userOperation.sender,
+					delegationCode,
+				);
 			}
 			if (factoryData != null && factoryData !== "0x") {
 				factory = userOperation.sender;
@@ -860,7 +879,10 @@ export async function callTenderlySimulateBundle(
 					: transaction.value;
 		}
 		if (transaction.stateOverrides != null) {
-			// build a copy instead of rewriting the caller-owned object in place
+			// build a copy instead of rewriting the caller-owned object in place.
+			// Keys are EVM addresses: lowercase them so the payload carries one
+			// canonical key per address, and reject same-address keys that differ
+			// only in case rather than silently letting one override the other.
 			const stateOverrides: OverrideType = {};
 			for (const address in transaction.stateOverrides) {
 				const entry = { ...transaction.stateOverrides[address] };
@@ -876,7 +898,13 @@ export async function callTenderlySimulateBundle(
 					entry.storage = entry.stateDiff;
 					delete entry.stateDiff;
 				}
-				stateOverrides[address] = entry;
+				const addressLower = address.toLowerCase();
+				if (addressLower in stateOverrides) {
+					throw new RangeError(
+						`Duplicate stateOverrides address (case-insensitive): ${address}.`,
+					);
+				}
+				stateOverrides[addressLower] = entry;
 			}
 			transactionObject.state_objects = stateOverrides;
 		}

--- a/test/_ensureFreshDist.cjs
+++ b/test/_ensureFreshDist.cjs
@@ -14,7 +14,9 @@ function newestMtimeMs(entry) {
 	if (!stat.isDirectory()) {
 		return stat.mtimeMs;
 	}
-	let newest = 0;
+	// include the directory's own mtime: deleting a file updates only the
+	// parent directory, so ignoring it would let a deletion skip the rebuild
+	let newest = stat.mtimeMs;
 	for (const name of fs.readdirSync(entry)) {
 		newest = Math.max(newest, newestMtimeMs(path.join(entry, name)));
 	}

--- a/test/paymaster/worldIdPermissionlessPaymaster.test.js
+++ b/test/paymaster/worldIdPermissionlessPaymaster.test.js
@@ -1,0 +1,89 @@
+// Offline tests for WorldIdPermissionlessPaymaster.createPaymasterUserOperation:
+// gas limits must be zeroed for a clean re-estimation, with caller-supplied
+// values honored as minimums afterward, and the caller's op left unmutated.
+
+const ak = require('../../dist/index.cjs');
+
+const PAYMASTER = '0x' + 'aa'.repeat(20);
+const SENDER = '0x' + '42'.repeat(20);
+const PROOF = '0x' + '11'.repeat(256);
+
+function makeV7UserOperation(overrides = {}) {
+    return {
+        sender: SENDER,
+        nonce: 0n,
+        factory: null,
+        factoryData: null,
+        callData: '0x',
+        callGasLimit: 50n,
+        verificationGasLimit: 1_000_000n,
+        preVerificationGas: 1n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        paymaster: null,
+        paymasterVerificationGasLimit: null,
+        paymasterPostOpGasLimit: null,
+        paymasterData: null,
+        signature: '0x',
+        ...overrides,
+    };
+}
+
+describe('WorldIdPermissionlessPaymaster gas estimation', () => {
+    let captured;
+    let bundler;
+
+    beforeEach(() => {
+        captured = [];
+        bundler = new ak.Bundler({
+            request: async ({ method, params }) => {
+                captured.push({ method, params });
+                return {
+                    callGasLimit: '0x10000',
+                    verificationGasLimit: '0x10000',
+                    preVerificationGas: '0x10000',
+                };
+            },
+        });
+    });
+
+    test('zeroes all gas limits in the op sent for estimation', async () => {
+        const paymaster = new ak.WorldIdPermissionlessPaymaster(PAYMASTER);
+        await paymaster.createPaymasterUserOperation(
+            makeV7UserOperation(),
+            bundler,
+            1n,
+            2n,
+            PROOF,
+        );
+        expect(captured).toHaveLength(1);
+        const sentOp = captured[0].params[0];
+        // the op is hex-serialized before hitting the wire
+        expect(BigInt(sentOp.preVerificationGas)).toBe(0n);
+        expect(BigInt(sentOp.verificationGasLimit)).toBe(0n);
+        expect(BigInt(sentOp.callGasLimit)).toBe(0n);
+    });
+
+    test('keeps caller-supplied limits as minimums over the estimation', async () => {
+        const paymaster = new ak.WorldIdPermissionlessPaymaster(PAYMASTER);
+        const original = makeV7UserOperation();
+        const sponsored = await paymaster.createPaymasterUserOperation(
+            original,
+            bundler,
+            1n,
+            2n,
+            PROOF,
+        );
+        // estimated 0x10000 (65536) beats the supplied pvg/cgl; the supplied
+        // verificationGasLimit (1,000,000) beats the estimate and is kept
+        expect(sponsored.preVerificationGas).toBe(0x10000n);
+        expect(sponsored.callGasLimit).toBe(0x10000n);
+        expect(sponsored.verificationGasLimit).toBe(1_000_000n);
+        expect(sponsored.paymaster).toBe(PAYMASTER);
+        // the caller's op is untouched
+        expect(original.preVerificationGas).toBe(1n);
+        expect(original.verificationGasLimit).toBe(1_000_000n);
+        expect(original.callGasLimit).toBe(50n);
+        expect(original.paymaster).toBeNull();
+    });
+});

--- a/test/paymaster/worldIdPermissionlessPaymaster.test.js
+++ b/test/paymaster/worldIdPermissionlessPaymaster.test.js
@@ -47,7 +47,7 @@ describe('WorldIdPermissionlessPaymaster gas estimation', () => {
         });
     });
 
-    test('zeroes all gas limits in the op sent for estimation', async () => {
+    test('zeroes only preVerificationGas for estimation, passing supplied vgl/cgl through', async () => {
         const paymaster = new ak.WorldIdPermissionlessPaymaster(PAYMASTER);
         await paymaster.createPaymasterUserOperation(
             makeV7UserOperation(),
@@ -58,10 +58,13 @@ describe('WorldIdPermissionlessPaymaster gas estimation', () => {
         );
         expect(captured).toHaveLength(1);
         const sentOp = captured[0].params[0];
-        // the op is hex-serialized before hitting the wire
+        // pvg must be re-estimated (paymaster calldata grows it); vgl/cgl are
+        // paymaster-independent prior estimates and are passed through so
+        // bundlers that skip estimating supplied fields answer faster
+        // (the op is hex-serialized before hitting the wire)
         expect(BigInt(sentOp.preVerificationGas)).toBe(0n);
-        expect(BigInt(sentOp.verificationGasLimit)).toBe(0n);
-        expect(BigInt(sentOp.callGasLimit)).toBe(0n);
+        expect(BigInt(sentOp.verificationGasLimit)).toBe(1_000_000n);
+        expect(BigInt(sentOp.callGasLimit)).toBe(50n);
     });
 
     test('keeps caller-supplied limits as minimums over the estimation', async () => {

--- a/test/safe/allowanceModule.test.js
+++ b/test/safe/allowanceModule.test.js
@@ -68,6 +68,15 @@ describe('AllowanceModule setAllowance encoding', () => {
 
     test.each([
         ['negative', -1n],
+        ['uint16 overflow', 2n ** 16n],
+    ])('recurring allowance rejects a validity period outside the uint16 range (%s)', (_label, bad) => {
+        expect(() =>
+            module.createRecurringAllowanceMetaTransaction(DELEGATE, TOKEN, 100n, bad),
+        ).toThrow(RangeError);
+    });
+
+    test.each([
+        ['negative', -1n],
         ['above 255', 256n],
     ])('getDelegates rejects a maxNumberOfResults outside the uint8 range (%s)', async (_label, bad) => {
         await expect(

--- a/test/safe/initCodeOverrideIsInit.test.js
+++ b/test/safe/initCodeOverrideIsInit.test.js
@@ -1,0 +1,92 @@
+// Regression tests: a V0.6 overrides.initCode must be resolved before the
+// dummy signature and gas estimation are built — isInit derives from the
+// final initCode, not from the account's factory fields, so a caller-supplied
+// "0x" selects the deployed-account WebAuthn owner encoding and the
+// estimation op carries the same initCode as the returned op. Offline.
+
+const ak = require('../../dist/index.cjs');
+
+const WEBAUTHN_KEY = {
+    x: 0x7a2fa39b3c61b3cbab8e44abeac8c9c7a4c1f76d42ae6f47b3b2a96d5c4f1a2bn,
+    y: 0x2e8c5f6d4b7a9c1e3f5a8d7b6c4e2f1a9d8c7b6a5e4f3d2c1b0a9f8e7d6c5b4an,
+};
+const EOA_OWNER = '0x' + '42'.repeat(20);
+
+const GAS_RESULT = {
+    callGasLimit: '0x10000',
+    verificationGasLimit: '0x10000',
+    preVerificationGas: '0x10000',
+};
+
+// signature layout: 0x + validAfter (6 bytes) + validUntil (6 bytes) + static
+// segments (65 bytes per signer: r = padded owner address, s = offset, v).
+// The encoded owner address sits in bytes 12..32 of the first segment's r.
+function encodedOwner(signature) {
+    return signature.slice(2 + 24).slice(24, 64);
+}
+
+async function createV6UserOperation(overrides = {}) {
+    const captured = [];
+    const bundler = new ak.Bundler({
+        request: async ({ method, params }) => {
+            captured.push({ method, params });
+            return GAS_RESULT;
+        },
+    });
+    const account = ak.SafeAccountV0_2_0.initializeNewAccount([EOA_OWNER]);
+    const userOperation = await account.createUserOperation(
+        [{ to: EOA_OWNER, value: 0n, data: '0x' }],
+        undefined,
+        bundler,
+        {
+            nonce: 0n,
+            maxFeePerGas: 1n,
+            maxPriorityFeePerGas: 1n,
+            expectedSigners: [WEBAUTHN_KEY],
+            ...overrides,
+        },
+    );
+    const estimatedOp = captured.find(
+        (c) => c.method === 'eth_estimateUserOperationGas',
+    ).params[0];
+    return { userOperation, estimatedOp };
+}
+
+describe('V0.6 overrides.initCode and isInit resolution', () => {
+    test('without an override the estimation op carries the factory initCode and the init-mode shared signer', async () => {
+        const { userOperation, estimatedOp } = await createV6UserOperation();
+        expect(userOperation.initCode).not.toBe('0x');
+        expect(estimatedOp.initCode).toBe(userOperation.initCode);
+        expect(encodedOwner(estimatedOp.signature)).toBe(
+            ak.SafeAccountV0_2_0.DEFAULT_WEB_AUTHN_SHARED_SIGNER.slice(2).toLowerCase(),
+        );
+    });
+
+    test('overriding initCode to "0x" selects the deployed-account owner encoding and estimation initCode', async () => {
+        const { userOperation, estimatedOp } = await createV6UserOperation({
+            initCode: '0x',
+        });
+        expect(userOperation.initCode).toBe('0x');
+        expect(estimatedOp.initCode).toBe('0x');
+        const verifierProxy = ak.SafeAccountV0_2_0.createWebAuthnSignerVerifierAddress(
+            WEBAUTHN_KEY.x,
+            WEBAUTHN_KEY.y,
+        );
+        expect(encodedOwner(estimatedOp.signature)).toBe(
+            verifierProxy.slice(2).toLowerCase(),
+        );
+    });
+
+    test('a custom initCode override reaches the estimation op verbatim', async () => {
+        const customInitCode = '0x' + '11'.repeat(20) + 'deadbeef';
+        const { userOperation, estimatedOp } = await createV6UserOperation({
+            initCode: customInitCode,
+        });
+        expect(userOperation.initCode).toBe(customInitCode);
+        expect(estimatedOp.initCode).toBe(customInitCode);
+        // still init mode: the shared signer is the encoded owner
+        expect(encodedOwner(estimatedOp.signature)).toBe(
+            ak.SafeAccountV0_2_0.DEFAULT_WEB_AUTHN_SHARED_SIGNER.slice(2).toLowerCase(),
+        );
+    });
+});

--- a/test/transport/httpErrorHandling.test.js
+++ b/test/transport/httpErrorHandling.test.js
@@ -62,6 +62,22 @@ describe("HttpTransport error handling", () => {
 		});
 	});
 
+	test("surfaces the HTTP status for a bare-string error body on an HTTP failure", async () => {
+		const t = transportWith(429, { error: "rate limited" }, "Too Many Requests");
+		await expect(t.request({ method: "eth_chainId", params: [] })).rejects.toMatchObject({
+			name: "TransportRpcError",
+			message: expect.stringContaining("429"),
+		});
+	});
+
+	test("surfaces the HTTP status for a non-RPC-shaped error object on an HTTP failure", async () => {
+		const t = transportWith(503, { error: {} }, "Service Unavailable");
+		await expect(t.request({ method: "eth_chainId", params: [] })).rejects.toMatchObject({
+			name: "TransportRpcError",
+			message: expect.stringContaining("503"),
+		});
+	});
+
 	test("surfaces the HTTP status for an error:null envelope on an HTTP failure", async () => {
 		const t = transportWith(401, { jsonrpc: "2.0", id: 1, error: null }, "Unauthorized");
 		await expect(t.request({ method: "eth_chainId", params: [] })).rejects.toMatchObject({

--- a/test/utilsTenderly7702.test.js
+++ b/test/utilsTenderly7702.test.js
@@ -180,6 +180,17 @@ describe("Tenderly EIP-7702 simulation handling", () => {
 			});
 			expect(callerOverrides).toEqual({ [SENDER_MIXED_CASE]: { balance: "0x1" } });
 		});
+
+		test("rejects duplicate sender override keys differing only in case", async () => {
+			const callerOverrides = {
+				[SENDER]: { balance: "0x1" },
+				[SENDER_MIXED_CASE]: { balance: "0x2" },
+			};
+			await expect(
+				runCallDataSimulation(makeV8UserOperation(), callerOverrides),
+			).rejects.toThrow(/Duplicate stateOverrides address/);
+			expect(requests).toHaveLength(0);
+		});
 	});
 
 	describe("state override key normalization (callTenderlySimulateBundle)", () => {

--- a/test/utilsTenderly7702.test.js
+++ b/test/utilsTenderly7702.test.js
@@ -11,6 +11,7 @@ const PADDED_MARKER = "0x7702000000000000000000000000000000000000";
 const SENDER = "0x1f9090aae28b8a3dceadf281b0f12828e676c326";
 const DELEGATEE = "0xe6cae83bde06e4c305530e199d7217f42808555b";
 const DELEGATION_CODE = `0xef0100${DELEGATEE.slice(2)}`;
+const SENDER_MIXED_CASE = `0x${SENDER.slice(2).toUpperCase()}`;
 
 function makeV8UserOperation(overrides = {}) {
 	return {
@@ -97,6 +98,23 @@ describe("Tenderly EIP-7702 simulation handling", () => {
 			const sim = await runFullSimulation(makeV8UserOperation());
 			expect(sim.state_objects[SENDER].code).toBe(DELEGATION_CODE);
 		});
+
+		test("merges a caller override keyed by a checksummed sender address", async () => {
+			await ak.simulateUserOperationWithTenderly(
+				"account",
+				"project",
+				"key",
+				1n,
+				ENTRYPOINT_V8,
+				makeV8UserOperation(),
+				null,
+				{ [SENDER_MIXED_CASE]: { balance: "0x1" } },
+			);
+			const sim = requests[0].body.simulations[0];
+			expect(sim.state_objects).toEqual({
+				[SENDER]: { balance: "0x1", code: DELEGATION_CODE },
+			});
+		});
 	});
 
 	describe("direct call-data simulation (simulateUserOperationCallDataWithTenderly)", () => {
@@ -152,6 +170,50 @@ describe("Tenderly EIP-7702 simulation handling", () => {
 				code: DELEGATION_CODE,
 			});
 			expect(callerOverrides).toEqual({ [SENDER]: { balance: "0x1" } });
+		});
+
+		test("merges a caller override keyed by a checksummed sender address", async () => {
+			const callerOverrides = { [SENDER_MIXED_CASE]: { balance: "0x1" } };
+			const sims = await runCallDataSimulation(makeV8UserOperation(), callerOverrides);
+			expect(sims[0].state_objects).toEqual({
+				[SENDER]: { balance: "0x1", code: DELEGATION_CODE },
+			});
+			expect(callerOverrides).toEqual({ [SENDER_MIXED_CASE]: { balance: "0x1" } });
+		});
+	});
+
+	describe("state override key normalization (callTenderlySimulateBundle)", () => {
+		test("lowercases override addresses in the payload", async () => {
+			await ak.callTenderlySimulateBundle("account", "project", "key", [
+				{
+					chainId: 1n,
+					from: SENDER,
+					to: DELEGATEE,
+					data: "0x",
+					stateOverrides: { [SENDER_MIXED_CASE]: { balance: "0x1" } },
+				},
+			]);
+			expect(requests[0].body.simulations[0].state_objects).toEqual({
+				[SENDER]: { balance: "0x1" },
+			});
+		});
+
+		test("rejects override addresses that differ only in case", async () => {
+			await expect(
+				ak.callTenderlySimulateBundle("account", "project", "key", [
+					{
+						chainId: 1n,
+						from: SENDER,
+						to: DELEGATEE,
+						data: "0x",
+						stateOverrides: {
+							[SENDER]: { balance: "0x1" },
+							[SENDER_MIXED_CASE]: { code: "0x00" },
+						},
+					},
+				]),
+			).rejects.toThrow(/Duplicate stateOverrides address/);
+			expect(requests).toHaveLength(0);
 		});
 	});
 });


### PR DESCRIPTION
Fixes a batch of issues surfaced by bot review findings, each independently verified against the code before applying. Every fix ships with regression tests; the full suite (548
  tests, 26 suites) and type tests pass.

  Transport

  - Don't let non-RPC JSON error bodies mask the HTTP status (b90a12c) — HttpTransport.send treated any non-null error field as a JSON-RPC error envelope, so an HTTP failure with a
  body like {"error": "rate limited"} bypassed the HTTP-status branch and surfaced only a generic "malformed JSON-RPC response", losing the status code (e.g. 429). Only a properly
  shaped JSON-RPC error object (numeric code, string message) now falls through to response parsing.

  Tenderly simulation

  - Merge state overrides case-insensitively by address (089f602) — the EIP-7702 delegation-code injection looked up the sender in caller stateOverrides by lowercase key only; a
  checksummed caller entry was missed, producing two state_objects keys for the same EVM address and undefined server-side resolution. Both injection sites now merge via a shared
  withSenderCodeOverride helper, and callTenderlySimulateBundle normalizes all override keys to lowercase, rejecting same-address keys that differ only in case.

  Safe accounts

  - Resolve V0.6 initCode override before dummy signature and estimation (b5a41e4) — overrides.initCode was applied only after the base builder had derived isInit from factoryAddress
  and estimated gas with a factory-derived initCode. A caller-supplied "0x" or custom initCode therefore produced a mismatched WebAuthn dummy-signature encoding and estimation op. The
  final initCode is now resolved first and isInit derives from it.
  - Validate recurring allowance validity period against uint16 (13734b7) — an out-of-range recurringAllowanceValidityPeriodInMinutes previously surfaced as the ABI encoder's generic
  "value out-of-bounds for uint16" error; it's now rejected up front with a RangeError that names the parameter.

  WorldId paymaster

  - Gas estimation inputs (6f7156b, refined by 39c4c3a) — final behavior: only preVerificationGas is zeroed before eth_estimateUserOperationGas, since the paymaster's proof calldata
  is what invalidates it. Supplied verificationGasLimit/callGasLimit are paymaster-independent on v0.7+ and pass through as trusted prior estimates — bundlers that skip estimating
  supplied fields answer faster — with the existing max(supplied, estimated) clamp as a guard. The precondition is documented on the method.

  Test infrastructure

  - Detect src deletions in the dist freshness check (e58084e) — _ensureFreshDist ignored directory mtimes, so deleting a src file never triggered a rebuild and tests kept running
  against stale dist code.

  Review findings intentionally skipped

  - Extracting the duplicated Erc7677/Candide estimation logic into a shared helper: a ~200-line behavior-preserving refactor with provider-specific exceptions; deferred to its own
  change.
  - Further Tenderly helper extraction: already covered by withSenderCodeOverride; the remaining duplication is a two-line null check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Safe v0.6 initialization code handling so gas estimation reflects the final init mode when overrides are provided.
  * Added stricter validation for recurring allowance validity periods to prevent out-of-range values.
  * Enhanced HTTP transport error reporting for malformed/non-standard JSON-RPC error payloads.
  * Strengthened Tenderly simulations by canonicalizing state override addresses and rejecting case-duplicate overrides.
  * Preserved expected gas estimate behavior during paymaster user operation creation and re-estimation.

* **Tests**
  * Added regression and behavior tests for Safe init code, allowance validation, HTTP errors, paymaster gas handling, and Tenderly override merging/duplication.

* **Chores**
  * Improved Jest rebuild detection reliability for directory trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->